### PR TITLE
Gunicorn settings class

### DIFF
--- a/infra/gunicorn_conf.py
+++ b/infra/gunicorn_conf.py
@@ -8,6 +8,15 @@ import multiprocessing
 import os
 
 from prometheus_client import multiprocess
+from pydantic import BaseSettings
+
+
+class GunicornSettings(BaseSettings):
+    keep_alive: int = 5
+    timeout: int = 120
+    graceful_timeout: int = 120
+    log_level: str = "info"
+
 
 workers_per_core_str = os.getenv("WORKERS_PER_CORE", "1")
 max_workers_str = os.getenv("MAX_WORKERS")
@@ -19,7 +28,6 @@ web_concurrency_str = os.getenv("WEB_CONCURRENCY", None)
 host = os.getenv("HOST", "0.0.0.0")
 port = os.getenv("PORT", "8000")
 bind_env = os.getenv("BIND", None)
-use_loglevel = os.getenv("LOG_LEVEL", "info")
 if bind_env:
     use_bind = bind_env
 else:
@@ -39,20 +47,20 @@ accesslog_var = os.getenv("ACCESS_LOG", "-")
 use_accesslog = accesslog_var or None
 errorlog_var = os.getenv("ERROR_LOG", "-")
 use_errorlog = errorlog_var or None
-graceful_timeout_str = os.getenv("GRACEFUL_TIMEOUT", "120")
-timeout_str = os.getenv("TIMEOUT", "120")
-keepalive_str = os.getenv("KEEP_ALIVE", "5")
+
+
+gunicorn_settings = GunicornSettings()
 
 # Gunicorn config variables
-loglevel = use_loglevel
+loglevel = gunicorn_settings.log_level
 workers = web_concurrency
 bind = use_bind
 errorlog = use_errorlog
 worker_tmp_dir = "/dev/shm"
 accesslog = use_accesslog
-graceful_timeout = int(graceful_timeout_str)
-timeout = int(timeout_str)
-keepalive = int(keepalive_str)
+graceful_timeout = gunicorn_settings.graceful_timeout
+timeout = gunicorn_settings.timeout
+keepalive = gunicorn_settings.keep_alive
 
 
 # For debugging and testing

--- a/infra/gunicorn_conf.py
+++ b/infra/gunicorn_conf.py
@@ -1,8 +1,7 @@
 """
-Conf file extracted from:
+Conf file adapted from:
 https://github.com/tiangolo/uvicorn-gunicorn-docker/blob/2daa3e3873c837d5781feb4ff6a40a89f791f81b/docker-images/gunicorn_conf.py
 """
-# pylint: disable=invalid-name
 
 import multiprocessing
 from typing import Optional
@@ -49,6 +48,7 @@ class GunicornSettings(BaseSettings):
 gunicorn_settings = GunicornSettings()
 
 # Gunicorn config variables
+# https://docs.gunicorn.org/en/stable/settings.html#settings
 loglevel = gunicorn_settings.log_level
 workers = gunicorn_settings.workers
 bind = gunicorn_settings.bind

--- a/infra/gunicorn_conf.py
+++ b/infra/gunicorn_conf.py
@@ -5,7 +5,6 @@ https://github.com/tiangolo/uvicorn-gunicorn-docker/blob/2daa3e3873c837d5781feb4
 # pylint: disable=invalid-name
 
 import multiprocessing
-import os
 from typing import Optional
 
 from prometheus_client import multiprocess
@@ -20,6 +19,8 @@ class GunicornSettings(BaseSettings):
     host: str = "0.0.0.0"
     port: str = "8000"
     bind: Optional[str]
+    access_log: str = "-"
+    error_log: str = "-"
 
     @validator("bind")
     def set_bind(cls, bind, values):
@@ -43,10 +44,6 @@ else:
     web_concurrency = max(int(default_web_concurrency), 2)
     if use_max_workers:
         web_concurrency = min(web_concurrency, use_max_workers)
-accesslog_var = os.getenv("ACCESS_LOG", "-")
-use_accesslog = accesslog_var or None
-errorlog_var = os.getenv("ERROR_LOG", "-")
-use_errorlog = errorlog_var or None
 
 
 gunicorn_settings = GunicornSettings()
@@ -55,9 +52,9 @@ gunicorn_settings = GunicornSettings()
 loglevel = gunicorn_settings.log_level
 workers = web_concurrency
 bind = gunicorn_settings.bind
-errorlog = use_errorlog
+errorlog = gunicorn_settings.error_log
 worker_tmp_dir = "/dev/shm"
-accesslog = use_accesslog
+accesslog = gunicorn_settings.access_log
 graceful_timeout = gunicorn_settings.graceful_timeout
 timeout = gunicorn_settings.timeout
 keepalive = gunicorn_settings.keep_alive

--- a/tests/unit/test_gunicorn_conf.py
+++ b/tests/unit/test_gunicorn_conf.py
@@ -1,0 +1,43 @@
+from pydantic import ValidationError
+import pytest
+from infra.gunicorn_conf import GunicornSettings
+
+
+def test_set_bind(monkeypatch):
+    expected = "1.2.3.4:5678"
+    monkeypatch.setenv("BIND", expected)
+    settings = GunicornSettings()
+    assert settings.bind == expected
+
+
+class TestSetWorkers:
+    def test_workers_env_var(self, monkeypatch):
+        expected = 3
+        monkeypatch.setenv("WORKERS", str(expected))
+        settings = GunicornSettings()
+        assert settings.workers == expected
+
+    def test_web_concurency_env_var(self, monkeypatch):
+        expected = 3
+        monkeypatch.setenv("WEB_CONCURRENCY", str(expected))
+        settings = GunicornSettings()
+        assert settings.workers == expected
+
+    def test_web_concurency_env_var_out_of_range(self, monkeypatch):
+        expected = 0
+        monkeypatch.setenv("WEB_CONCURRENCY", str(expected))
+        with pytest.raises(ValidationError):
+            GunicornSettings()
+
+    def test_default_workers(self, monkeypatch):
+        expected = 2
+        monkeypatch.setattr("multiprocessing.cpu_count", lambda: 2)
+        settings = GunicornSettings()
+        assert settings.workers == expected
+
+    def test_max_workers(self, monkeypatch):
+        expected = 1
+        monkeypatch.setattr("multiprocessing.cpu_count", lambda: 2)
+        monkeypatch.setenv("MAX_WORKERS", str(expected))
+        settings = GunicornSettings()
+        assert settings.workers == expected


### PR DESCRIPTION
Closes #13 

This PR packages Gunicorn settings in a Pydantic BaseSettings class in order to:
- handle environment variable coercion and validation
- encapsulate logic to combine environment variables when needed (`bind`, `workers`)