### PR TITLE
Pr31 update

### DIFF
--- a/src/app/log.py
+++ b/src/app/log.py
@@ -31,6 +31,7 @@ def configure_logging():
         "loggers": {
             "request.summary": {"handlers": ["console"], "level": "INFO"},
             "src.jbi": {"handlers": ["console"], "level": "INFO"},
+            "ignored-requests": {"handlers": ["console"], "level": "DEBUG"},
         },
     }
 

--- a/src/jbi/router.py
+++ b/src/jbi/router.py
@@ -66,6 +66,12 @@ def execute_action(request: BugzillaWebhookRequest, action_map, settings):
     except IgnoreInvalidRequestError as exception:
         invalid_logger.debug("ignore-invalid-request: %s", exception)
         return JSONResponse(content={"error": str(exception)}, status_code=202)
+    except Exception as exception:  # pylint: disable=broad-except
+        # TODO: Remove when sentry is enabled # pylint: disable=fixme
+        jbi_logger.debug(
+            "unknown-exception (%s): %s", type(exception), exception, exc_info=True
+        )
+        raise exception
 
 
 @api_router.post("/bugzilla_webhook")

--- a/tests/unit/jbi/test_router.py
+++ b/tests/unit/jbi/test_router.py
@@ -28,7 +28,7 @@ def test_request_is_ignored_because_private(
         assert response.json()["error"] == "private bugs are not valid"
 
         invalid_request_logs = caplog.records[0]
-        assert invalid_request_logs.name == "src.jbi.router"
+        assert invalid_request_logs.name == "ignored-requests"
 
         assert invalid_request_logs.msg == "ignore-invalid-request: %s"
         assert invalid_request_logs.args
@@ -53,7 +53,7 @@ def test_request_is_ignored_because_no_bug(
         assert response.json()["error"] == "no bug data received"
 
         invalid_request_logs = caplog.records[0]
-        assert invalid_request_logs.name == "src.jbi.router"
+        assert invalid_request_logs.name == "ignored-requests"
 
         assert invalid_request_logs.msg == "ignore-invalid-request: %s"
         assert invalid_request_logs.args
@@ -85,7 +85,7 @@ def test_request_is_ignored_because_no_action(
                 )
 
                 invalid_request_logs = caplog.records[0]
-                assert invalid_request_logs.name == "src.jbi.router"
+                assert invalid_request_logs.name == "ignored-requests"
 
                 assert invalid_request_logs.msg == "ignore-invalid-request: %s"
                 assert invalid_request_logs.args


### PR DESCRIPTION
Add additional logging to request before calling action; modify logging when IgnoreInvalidRequestError happens (to debug and no longer exc_info). 

[from suggestions on #31 here.](https://github.com/mozilla/jira-bugzilla-integration/pull/31#discussion_r840425596)