### PR TITLE
Allow actions to specify if they support private bugs.

### DIFF
--- a/src/jbi/bugzilla.py
+++ b/src/jbi/bugzilla.py
@@ -91,6 +91,7 @@ class BugzillaBug(BaseModel):
     whiteboard: Optional[str]
     keywords: Optional[List]
     flags: Optional[List]
+    groups: Optional[List]
     status: Optional[str]
     resolution: Optional[str]
     see_also: Optional[List]

--- a/src/jbi/models.py
+++ b/src/jbi/models.py
@@ -16,6 +16,7 @@ class Action(YamlModel, extra=Extra.allow):
 
     action: str = "src.jbi.whiteboard_actions.default"
     enabled: bool = False
+    allow_private: bool = False
     parameters: dict = {}
 
     @root_validator

--- a/src/jbi/router.py
+++ b/src/jbi/router.py
@@ -44,15 +44,17 @@ def execute_action(request: BugzillaWebhookRequest, action_map, settings):
         if not request.bug:
             raise IgnoreInvalidRequestError("no bug data received")
 
-        is_private_bug = request.bug.is_private
-        if is_private_bug:
-            raise IgnoreInvalidRequestError("private bugs are not valid")
-
         bug_obj = getbug_as_bugzilla_object(request=request)
         current_action = extract_current_action(bug_obj, action_map)  # type: ignore
+
         if not current_action:
             raise IgnoreInvalidRequestError(
                 "whiteboard tag not found in configured actions"
+            )
+
+        if bug_obj.is_private and not current_action["allow_private"]:
+            raise IgnoreInvalidRequestError(
+                "private bugs are not valid for this action"
             )
 
         jbi_logger.info("\nrequest: %s, \naction: %s", request.json(), current_action)

--- a/tests/unit/jbi/noop_action.py
+++ b/tests/unit/jbi/noop_action.py
@@ -8,18 +8,5 @@ A no-op action for testing.
 from src.jbi.bugzilla import BugzillaWebhookRequest
 
 
-def init(**kwargs):
-    """Function that takes required and optional params and returns a callable object"""
-    return NoopExecutor(**kwargs)
-
-
-class NoopExecutor:
-    """Callable class that encapsulates the no-op action."""
-
-    def __init__(self, **kwargs):
-        """Initialize DefaultExecutor Object"""
-        self.parameters = kwargs
-
-    def __call__(self, payload: BugzillaWebhookRequest):
-        """Called from BZ webhook when no-op action is used. Does nothing."""
-        pass
+def init(**parameters):
+    return lambda payload: {"parameters": parameters, "payload": payload}

--- a/tests/unit/jbi/noop_action.py
+++ b/tests/unit/jbi/noop_action.py
@@ -5,8 +5,6 @@ A no-op action for testing.
 `init` should return a __call__able
 """
 
-from src.jbi.bugzilla import BugzillaWebhookRequest
-
 
 def init(**parameters):
-    return lambda payload: {"parameters": parameters, "payload": payload}
+    return lambda payload: {"parameters": parameters, "payload": payload.json()}

--- a/tests/unit/jbi/noop_action.py
+++ b/tests/unit/jbi/noop_action.py
@@ -1,0 +1,25 @@
+"""
+A no-op action for testing.
+`init` is required.
+
+`init` should return a __call__able
+"""
+
+from src.jbi.bugzilla import BugzillaWebhookRequest
+
+
+def init(**kwargs):
+    """Function that takes required and optional params and returns a callable object"""
+    return NoopExecutor(**kwargs)
+
+
+class NoopExecutor:
+    """Callable class that encapsulates the no-op action."""
+
+    def __init__(self, **kwargs):
+        """Initialize DefaultExecutor Object"""
+        self.parameters = kwargs
+
+    def __call__(self, payload: BugzillaWebhookRequest):
+        """Called from BZ webhook when no-op action is used. Does nothing."""
+        pass

--- a/tests/unit/jbi/test_router.py
+++ b/tests/unit/jbi/test_router.py
@@ -61,9 +61,11 @@ def test_private_request_is_allowed(
         with mock.patch("src.jbi.router.getbug_as_bugzilla_object") as mocked_bz_func:
             mocked_bz_func.return_value = private_webhook_request_example.bug
             with mock.patch(
-                "tests.unit.jbi.noop_action.NoopExecutor.__call__"
-            ) as mocked_action:
+                "tests.unit.jbi.noop_action.init"
+            ) as mocked_action_init:
+                mocked_action = MagicMock()
                 mocked_action.return_value = dict()
+                mocked_action_init.return_value = mocked_action
                 with TestClient(app) as anon_client:
                     # https://fastapi.tiangolo.com/advanced/testing-events/
 

--- a/tests/unit/jbi/test_router.py
+++ b/tests/unit/jbi/test_router.py
@@ -60,9 +60,7 @@ def test_private_request_is_allowed(
         mocked_extract_action.return_value = test_action
         with mock.patch("src.jbi.router.getbug_as_bugzilla_object") as mocked_bz_func:
             mocked_bz_func.return_value = private_webhook_request_example.bug
-            with mock.patch(
-                "tests.unit.jbi.noop_action.init"
-            ) as mocked_action_init:
+            with mock.patch("tests.unit.jbi.noop_action.init") as mocked_action_init:
                 mocked_action = MagicMock()
                 mocked_action.return_value = dict()
                 mocked_action_init.return_value = mocked_action

--- a/tests/unit/jbi/test_router.py
+++ b/tests/unit/jbi/test_router.py
@@ -60,21 +60,17 @@ def test_private_request_is_allowed(
         mocked_extract_action.return_value = test_action
         with mock.patch("src.jbi.router.getbug_as_bugzilla_object") as mocked_bz_func:
             mocked_bz_func.return_value = private_webhook_request_example.bug
-            with mock.patch("tests.unit.jbi.noop_action.init") as mocked_action_init:
-                mocked_action = MagicMock()
-                mocked_action.return_value = dict()
-                mocked_action_init.return_value = mocked_action
-                with TestClient(app) as anon_client:
-                    # https://fastapi.tiangolo.com/advanced/testing-events/
+            with TestClient(app) as anon_client:
+                # https://fastapi.tiangolo.com/advanced/testing-events/
 
-                    response = anon_client.post(
-                        "/bugzilla_webhook", data=private_webhook_request_example.json()
-                    )
-                    assert response
-                    assert response.status_code == 200
+                response = anon_client.post(
+                    "/bugzilla_webhook", data=private_webhook_request_example.json()
+                )
+                assert response
+                assert response.status_code == 200
 
-                    assert mocked_action.call_count == 1
-                    assert mocked_action.call_args.kwargs["payload"].bug.id == 654321
+                payload = BugzillaWebhookRequest.parse_raw(response.json()["payload"])
+                assert payload.bug.id == 654321
 
 
 def test_request_is_ignored_because_no_bug(

--- a/tests/unit/jbi/test_router.py
+++ b/tests/unit/jbi/test_router.py
@@ -10,31 +10,71 @@ from fastapi.testclient import TestClient
 from src.app.api import app
 from src.jbi.bugzilla import BugzillaWebhookRequest
 from src.jbi.errors import IgnoreInvalidRequestError
+from src.jbi.models import Action
 
 
 def test_request_is_ignored_because_private(
     caplog, webhook_request_example: BugzillaWebhookRequest
 ):
-    with TestClient(app) as anon_client:
-        # https://fastapi.tiangolo.com/advanced/testing-events/
-        invalid_webhook_request_example = webhook_request_example
-        invalid_webhook_request_example.bug.is_private = True  # type: ignore
+    private_webhook_request_example = webhook_request_example
+    private_webhook_request_example.bug.is_private = True  # type: ignore
+    test_action = Action.parse_obj({"action": "tests.unit.jbi.noop_action"}).dict()
 
-        response = anon_client.post(
-            "/bugzilla_webhook", data=invalid_webhook_request_example.json()
-        )
-        assert response
-        assert response.status_code == 200
-        assert response.json()["error"] == "private bugs are not valid"
+    with mock.patch("src.jbi.router.extract_current_action") as mocked_extract_action:
+        mocked_extract_action.return_value = test_action
+        with mock.patch("src.jbi.router.getbug_as_bugzilla_object") as mocked_bz_func:
+            mocked_bz_func.return_value = private_webhook_request_example.bug
+            with TestClient(app) as anon_client:
+                # https://fastapi.tiangolo.com/advanced/testing-events/
 
-        invalid_request_logs = caplog.records[1]
-        assert invalid_request_logs.name == "ignored-requests"
+                response = anon_client.post(
+                    "/bugzilla_webhook", data=private_webhook_request_example.json()
+                )
+                assert response
+                assert response.status_code == 200
+                assert (
+                    response.json()["error"]
+                    == "private bugs are not valid for this action"
+                )
 
-        assert invalid_request_logs.msg == "ignore-invalid-request: %s"
-        assert invalid_request_logs.args
-        for arg in invalid_request_logs.args:
-            assert isinstance(arg, IgnoreInvalidRequestError)
-            assert str(arg) == "private bugs are not valid"
+                invalid_request_logs = caplog.records[1]
+                assert invalid_request_logs.name == "ignored-requests"
+
+                assert invalid_request_logs.msg == "ignore-invalid-request: %s"
+                assert invalid_request_logs.args
+                for arg in invalid_request_logs.args:
+                    assert isinstance(arg, IgnoreInvalidRequestError)
+                    assert str(arg) == "private bugs are not valid for this action"
+
+
+def test_private_request_is_allowed(
+    caplog, webhook_request_example: BugzillaWebhookRequest
+):
+    private_webhook_request_example = webhook_request_example
+    private_webhook_request_example.bug.is_private = True  # type: ignore
+    test_action = Action.parse_obj(
+        {"action": "tests.unit.jbi.noop_action", "allow_private": True}
+    ).dict()
+
+    with mock.patch("src.jbi.router.extract_current_action") as mocked_extract_action:
+        mocked_extract_action.return_value = test_action
+        with mock.patch("src.jbi.router.getbug_as_bugzilla_object") as mocked_bz_func:
+            mocked_bz_func.return_value = private_webhook_request_example.bug
+            with mock.patch(
+                "tests.unit.jbi.noop_action.NoopExecutor.__call__"
+            ) as mocked_action:
+                mocked_action.return_value = dict()
+                with TestClient(app) as anon_client:
+                    # https://fastapi.tiangolo.com/advanced/testing-events/
+
+                    response = anon_client.post(
+                        "/bugzilla_webhook", data=private_webhook_request_example.json()
+                    )
+                    assert response
+                    assert response.status_code == 200
+
+                    assert mocked_action.call_count == 1
+                    assert mocked_action.call_args.kwargs["payload"].bug.id == 654321
 
 
 def test_request_is_ignored_because_no_bug(


### PR DESCRIPTION
* Adds an `allow_private` settings to actions, defaults to False.
* Adds parsing of bugzilla groups for actions to use.

By default this doesn't change existing actions but it allows actions to
opt in to syncing private bugs. A custom action my be written to only
sync depending on the groups a bug is a member of. This will only
support bugs in groups that the JBI bugzilla account is a member of.

Strictly speaking the changes to the default action are unnecessary but since any project wanting to support this would need them and we have to change internal code anyway it made sense to me to make them. If you want those removed let me know.

The only thing I've been unable to verify myself is the behaviour for a private bug that is member of a group that the JBI bugzilla API key is not a member of. It isn't clear if the webhook will just not deliver those to JBI in which case I would expect everything to be fine or if it will deliver something in which case JBI's bug lookup request would fail and throw an error. Not being able to create custom groups and additional users on the test bugzilla instance mean I couldn't check that.

I found it a little odd that Bugzilla's `bug.create` webhook for private bugs includes almost no information about the bug while the `comment.create` webhook for the same bug would include the full details!