### PR TITLE
Lint config files

### DIFF
--- a/.github/workflows/lint-build.yaml
+++ b/.github/workflows/lint-build.yaml
@@ -1,0 +1,28 @@
+name: Run lint
+
+on: pull_request
+
+jobs:
+  run_test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Build lint image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: infra/Dockerfile
+          push: false
+          target: "lint"
+          tags: ghcr.io/${{ github.repository }}-lint:${{ github.sha }}
+
+      - name: Run lint
+        run: |-
+          docker run --rm \
+          -e JIRA_USERNAME \
+          -e JIRA_API_KEY \
+          -e BUGZILLA_API_KEY \
+          ghcr.io/${{ github.repository }}-lint:${{ github.sha }}

--- a/config/config.prod.yaml
+++ b/config/config.prod.yaml
@@ -25,10 +25,10 @@ actions:
       jira_project_key: FIDEFE
       whiteboard_tag: fidefe
   flowstate:
+    allow_private: true
     contact: dtownsend@mozilla.com
     description: Flowstate whiteboard tag
     enabled: true
-    allow_private: true
     parameters:
       jira_project_key: MR2
       whiteboard_tag: flowstate

--- a/src/jbi/models.py
+++ b/src/jbi/models.py
@@ -6,7 +6,7 @@ from inspect import signature
 from types import ModuleType
 from typing import Any, Dict, Optional
 
-from pydantic import Extra, ValidationError, root_validator, validator
+from pydantic import Extra, root_validator, validator
 from pydantic_yaml import YamlModel
 
 
@@ -35,9 +35,9 @@ class Action(YamlModel, extra=Extra.allow):
 
             signature(action_module.init).bind(**action_parameters)  # type: ignore
         except ImportError as exception:
-            raise ValidationError(f"unknown action `{action}`.") from exception
+            raise ValueError(f"unknown action `{action}`.") from exception
         except (TypeError, AttributeError) as exception:
-            raise ValidationError("action is not properly setup.") from exception
+            raise ValueError("action is not properly setup.") from exception
         return values
 
 
@@ -56,9 +56,9 @@ class Actions(YamlModel):
         Validate that the inner actions are named as expected
         """
         if not actions:
-            raise ValidationError("no actions configured")
+            raise ValueError("no actions configured")
         for name, action in actions.items():
             if name != action.parameters["whiteboard_tag"]:
-                raise ValidationError("action name must match whiteboard tag")
+                raise ValueError("action name must match whiteboard tag")
 
         return actions


### PR DESCRIPTION
In #65, a YAML lint error was introduced. 

We could detect it only at the step of building the container, once merged.

This PR adds a Github action that will run linting on each pull-request. It also fixes the issues reported by yamllint and pylint on current master