### PR TITLE
Add flowstate to nonprod

### DIFF
--- a/config/config.nonprod.yaml
+++ b/config/config.nonprod.yaml
@@ -9,3 +9,11 @@ actions:
     parameters:
       jira_project_key: JST
       whiteboard_tag: devtest
+  flowstate:
+    allow_private: true
+    contact: dtownsend@mozilla.com
+    description: Flowstate whiteboard tag
+    enabled: true
+    parameters:
+      jira_project_key: MR2
+      whiteboard_tag: flowstate


### PR DESCRIPTION
If we want to test the `flowstate` use-case (private bugs) in DEV/STAGE, it has to be defined in the nonprod config.