### PR TITLE
Remove useless /actions/ endpoint

### DIFF
--- a/src/jbi/router.py
+++ b/src/jbi/router.py
@@ -93,17 +93,6 @@ def get_whiteboard_tag(
     return actions
 
 
-@api_router.get("/actions/")
-def get_actions_by_type(action_type: Optional[str] = None):
-    """API for viewing actions within the config; `action_type` matched on end of action identifier"""
-    actions = configuration.get_actions_dict()
-    if action_type:
-        return [
-            a["action"] for a in actions.values() if a["action"].endswith(action_type)
-        ]
-    return [a["action"] for a in actions.values()]
-
-
 @api_router.get("/powered_by_jbi", response_class=HTMLResponse)
 def powered_by_jbi(request: Request, enabled: Optional[bool] = None):
     """API for `Powered By` endpoint"""


### PR DESCRIPTION
I don't think this endpoint brings any value TBH. The less the better IMO

```
$ http https://jbi.services.mozilla.com/actions/

HTTP/1.1 200 OK
Alt-Svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
Content-Length: 519
Content-Type: application/json
Date: Wed, 29 Jun 2022 12:22:48 GMT
Server: nginx
Strict-Transport-Security: max-age=31536000
Via: 1.1 google

[
    "src.jbi.whiteboard_actions.default",
    "src.jbi.whiteboard_actions.default",
    "src.jbi.whiteboard_actions.default",
    "src.jbi.whiteboard_actions.default",
    "src.jbi.whiteboard_actions.default",
    "src.jbi.whiteboard_actions.default",
    "src.jbi.whiteboard_actions.default",
    "src.jbi.whiteboard_actions.default",
    "src.jbi.whiteboard_actions.default",
    "src.jbi.whiteboard_actions.default",
    "src.jbi.whiteboard_actions.default",
    "src.jbi.whiteboard_actions.default",
    "src.jbi.whiteboard_actions.default",
    "src.jbi.whiteboard_actions.default"
]
```