### PR TITLE
Expose config values in root URL

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "jira-bugzilla-integration"
-version = "0.1.0"
+version = "2.0.1"
 description = "jira-bugzilla-integration"
 authors = ["@mozilla/jbi-core"]
 license = "MPL"

--- a/src/app/api.py
+++ b/src/app/api.py
@@ -8,7 +8,6 @@ from datetime import datetime
 import sentry_sdk
 import uvicorn  # type: ignore
 from fastapi import FastAPI, Request
-from fastapi.responses import RedirectResponse
 from fastapi.staticfiles import StaticFiles
 from sentry_sdk.integrations.asgi import SentryAsgiMiddleware
 
@@ -39,8 +38,17 @@ app.add_middleware(SentryAsgiMiddleware)
 
 @app.get("/", include_in_schema=False)
 def root(request: Request):
-    """GET via root redirects to /docs."""
-    return RedirectResponse(url="./docs")
+    """Expose key configuration"""
+    return {
+        "title": app.title,
+        "description": app.description,
+        "version": app.version,
+        "documentation": app.docs_url,
+        "configuration": {
+            "jira_base_url": settings.jira_base_url,
+            "bugzilla_base_url": settings.bugzilla_base_url,
+        },
+    }
 
 
 @app.middleware("http")

--- a/src/app/api.py
+++ b/src/app/api.py
@@ -24,7 +24,7 @@ configure_logging()
 app = FastAPI(
     title="Jira Bugzilla Integration (JBI)",
     description="JBI v2 Platform",
-    version="0.1.0",
+    version="2.0.1",
 )
 
 app.include_router(monitor_router)

--- a/tests/unit/app/test_api.py
+++ b/tests/unit/app/test_api.py
@@ -9,13 +9,11 @@ from src.app.api import app
 
 
 def test_read_root(anon_client):
-    """The site root redirects to the Swagger docs"""
+    """The root URL provides information"""
     resp = anon_client.get("/")
-    assert resp.status_code == 200
-    assert len(resp.history) == 1
-    prev_resp = resp.history[0]
-    assert prev_resp.status_code == 307  # Temporary Redirect
-    assert prev_resp.headers["location"] == "./docs"
+    infos = resp.json()
+
+    assert "atlassian.net" in infos["configuration"]["jira_base_url"]
 
 
 def test_request_summary_is_logged(caplog):


### PR DESCRIPTION
Providing config information in the root URL endpoint would help us troubleshoot the instance