### PR TITLE
Always use the bug retrieved through the bugzilla API for field changes

### DIFF
--- a/src/jbi/whiteboard_actions/default.py
+++ b/src/jbi/whiteboard_actions/default.py
@@ -64,9 +64,9 @@ class DefaultExecutor:
         linked_issue_key = bug_obj.extract_from_see_also()  # type: ignore
         if linked_issue_key:
             # update
-            fields, comments = payload.map_as_tuple_of_field_dict_and_comments()
+            comments = payload.map_as_comments()
             jira_response_update = self.jira_client.update_issue_field(
-                key=linked_issue_key, fields=fields
+                key=linked_issue_key, fields=bug_obj.map_as_jira_issue()
             )
             # comment
             jira_response_comments = []
@@ -88,6 +88,7 @@ class DefaultExecutor:
         comment_list = self.bugzilla_client.get_comments(idlist=[bug_obj.id])
         fields = {
             **bug_obj.map_as_jira_issue(),  # type: ignore
+            "issuetype": {"name": bug_obj.issue_type()},
             "description": comment_list["bugs"][str(bug_obj.id)]["comments"][0]["text"],
             "project": {"key": self.jira_project_key},
         }

--- a/tests/unit/jbi/whiteboard_actions/test_default.py
+++ b/tests/unit/jbi/whiteboard_actions/test_default.py
@@ -6,6 +6,7 @@ from unittest import mock
 from unittest.mock import MagicMock
 
 import pytest
+from src.jbi.bugzilla import BugzillaBug, BugzillaWebhookRequest
 
 from src.jbi.whiteboard_actions import default
 
@@ -35,3 +36,273 @@ def test_default_returns_callable_with_data(webhook_request_example):
                 value = callable_object(payload=webhook_request_example)
 
     assert value["status"] == "create"
+
+
+def test_created_public():
+    public_bug = BugzillaBug.parse_obj(
+        {
+            "assigned_to": "nobody@mozilla.org",
+            "comment": None,
+            "component": "General",
+            "creator": "nobody@mozilla.org",
+            "flags": [],
+            "id": 654321,
+            "is_private": False,
+            "keywords": [],
+            "priority": "",
+            "product": "JBI",
+            "resolution": "",
+            "see_also": [],
+            "severity": "--",
+            "status": "NEW",
+            "summary": "JBI Test",
+            "type": "defect",
+            "whiteboard": "[foo]",
+        }
+    )
+
+    public_webhook = BugzillaWebhookRequest.parse_obj(
+        {
+            "bug": public_bug,
+            "event": {
+                "action": "create",
+                "routing_key": "bug.create",
+                "target": "bug",
+                "time": "2022-06-30T14:03:02",
+                "user": {
+                    "id": 123456,
+                    "login": "nobody@mozilla.org",
+                    "real_name": "Nobody [ :nobody ]",
+                },
+            },
+            "webhook_id": 34,
+            "webhook_name": "local-test",
+        }
+    )
+
+    mock_jira_client = MagicMock()
+    mock_bugzilla_client = MagicMock()
+    mock_bugzilla_client.get_comments.return_value = {
+        "bugs": {"654321": {"comments": [{"text": "Initial comment"}]}}
+    }
+
+    with mock.patch("src.jbi.whiteboard_actions.default.get_jira") as mocked_jira:
+        mocked_jira.return_value = mock_jira_client
+        with mock.patch("src.jbi.whiteboard_actions.default.get_bugzilla") as mocked_bz:
+            mocked_bz.return_value = mock_bugzilla_client
+            with mock.patch(
+                "src.jbi.whiteboard_actions.default.getbug_as_bugzilla_object"
+            ) as mocked_bz_func:
+                mocked_bz_func.return_value = public_bug
+                callable_object = default.init(
+                    whiteboard_tag="", jira_project_key="JBI"
+                )
+                assert callable_object
+                value = callable_object(payload=public_webhook)
+
+    mock_jira_client.create_issue.assert_called_once_with(
+        fields={
+            "summary": "JBI Test",
+            "labels": ["bugzilla", "foo", "[foo]"],
+            "issuetype": {"name": "Bug"},
+            "description": "Initial comment",
+            "project": {"key": "JBI"},
+        },
+    )
+    assert value["status"] == "create"
+
+
+def test_created_private():
+    private_bug = BugzillaBug.parse_obj(
+        {
+            "assigned_to": "nobody@mozilla.org",
+            "comment": None,
+            "component": "General",
+            "creator": "nobody@mozilla.org",
+            "flags": [],
+            "id": 654321,
+            "is_private": True,
+            "keywords": [],
+            "priority": "",
+            "product": "JBI",
+            "resolution": "",
+            "see_also": [],
+            "severity": "--",
+            "status": "NEW",
+            "summary": "JBI Test",
+            "type": "defect",
+            "whiteboard": "[foo]",
+        }
+    )
+
+    private_webhook = BugzillaWebhookRequest.parse_obj(
+        {
+            "bug": {"id": 654321, "is_private": True},
+            "event": {
+                "action": "create",
+                "routing_key": "bug.create",
+                "target": "bug",
+                "time": "2022-06-30T14:03:02",
+                "user": {
+                    "id": 123456,
+                    "login": "nobody@mozilla.org",
+                    "real_name": "Nobody [ :nobody ]",
+                },
+            },
+            "webhook_id": 34,
+            "webhook_name": "local-test",
+        }
+    )
+
+    mock_jira_client = MagicMock()
+    mock_bugzilla_client = MagicMock()
+    mock_bugzilla_client.get_comments.return_value = {
+        "bugs": {"654321": {"comments": [{"text": "Initial comment"}]}}
+    }
+
+    with mock.patch("src.jbi.whiteboard_actions.default.get_jira") as mocked_jira:
+        mocked_jira.return_value = mock_jira_client
+        with mock.patch("src.jbi.whiteboard_actions.default.get_bugzilla") as mocked_bz:
+            mocked_bz.return_value = mock_bugzilla_client
+            with mock.patch(
+                "src.jbi.whiteboard_actions.default.getbug_as_bugzilla_object"
+            ) as mocked_bz_func:
+                mocked_bz_func.return_value = private_bug
+                callable_object = default.init(
+                    whiteboard_tag="", jira_project_key="JBI"
+                )
+                assert callable_object
+                value = callable_object(payload=private_webhook)
+
+    mock_jira_client.create_issue.assert_called_once_with(
+        fields={
+            "summary": "JBI Test",
+            "labels": ["bugzilla", "foo", "[foo]"],
+            "issuetype": {"name": "Bug"},
+            "description": "Initial comment",
+            "project": {"key": "JBI"},
+        },
+    )
+    assert value["status"] == "create"
+
+
+def test_modified_public():
+    public_bug = BugzillaBug.parse_obj(
+        {
+            "assigned_to": "nobody@mozilla.org",
+            "comment": None,
+            "component": "General",
+            "creator": "nobody@mozilla.org",
+            "flags": [],
+            "id": 654321,
+            "is_private": False,
+            "keywords": [],
+            "priority": "",
+            "product": "JBI",
+            "resolution": "",
+            "see_also": ["https://mozilla.atlassian.net/browse/JBI-234"],
+            "severity": "--",
+            "status": "NEW",
+            "summary": "JBI Test",
+            "type": "defect",
+            "whiteboard": "[foo]",
+        }
+    )
+
+    public_webhook = BugzillaWebhookRequest.parse_obj(
+        {
+            "bug": public_bug,
+            "event": {
+                "action": "modify",
+                "routing_key": "bug.modify:status",
+                "target": "bug",
+                "time": "2022-06-30T14:03:02",
+                "user": {
+                    "id": 123456,
+                    "login": "nobody@mozilla.org",
+                    "real_name": "Nobody [ :nobody ]",
+                },
+            },
+            "webhook_id": 34,
+            "webhook_name": "local-test",
+        }
+    )
+
+    mock_jira_client = MagicMock()
+    with mock.patch("src.jbi.whiteboard_actions.default.get_jira") as mocked_jira:
+        mocked_jira.return_value = mock_jira_client
+        with mock.patch("src.jbi.whiteboard_actions.default.get_bugzilla") as mocked_bz:
+            with mock.patch(
+                "src.jbi.whiteboard_actions.default.getbug_as_bugzilla_object"
+            ) as mocked_bz_func:
+                mocked_bz_func.return_value = public_bug
+                callable_object = default.init(whiteboard_tag="", jira_project_key="")
+                assert callable_object
+                value = callable_object(payload=public_webhook)
+
+    mock_jira_client.update_issue_field.assert_called_once_with(
+        key="JBI-234",
+        fields={"summary": "JBI Test", "labels": ["bugzilla", "foo", "[foo]"]},
+    )
+    assert value["status"] == "update"
+
+
+def test_modified_private():
+    private_bug = BugzillaBug.parse_obj(
+        {
+            "assigned_to": "nobody@mozilla.org",
+            "comment": None,
+            "component": "General",
+            "creator": "nobody@mozilla.org",
+            "flags": [],
+            "id": 654321,
+            "is_private": True,
+            "keywords": [],
+            "priority": "",
+            "product": "JBI",
+            "resolution": "",
+            "see_also": ["https://mozilla.atlassian.net/browse/JBI-234"],
+            "severity": "--",
+            "status": "NEW",
+            "summary": "JBI Test",
+            "type": "defect",
+            "whiteboard": "[foo]",
+        }
+    )
+
+    private_webhook = BugzillaWebhookRequest.parse_obj(
+        {
+            "bug": {"id": 654321, "is_private": True},
+            "event": {
+                "action": "modify",
+                "routing_key": "bug.modify:status",
+                "target": "bug",
+                "time": "2022-06-30T14:03:02",
+                "user": {
+                    "id": 123456,
+                    "login": "nobody@mozilla.org",
+                    "real_name": "Nobody [ :nobody ]",
+                },
+            },
+            "webhook_id": 34,
+            "webhook_name": "local-test",
+        }
+    )
+
+    mock_jira_client = MagicMock()
+    with mock.patch("src.jbi.whiteboard_actions.default.get_jira") as mocked_jira:
+        mocked_jira.return_value = mock_jira_client
+        with mock.patch("src.jbi.whiteboard_actions.default.get_bugzilla") as mocked_bz:
+            with mock.patch(
+                "src.jbi.whiteboard_actions.default.getbug_as_bugzilla_object"
+            ) as mocked_bz_func:
+                mocked_bz_func.return_value = private_bug
+                callable_object = default.init(whiteboard_tag="", jira_project_key="")
+                assert callable_object
+                value = callable_object(payload=private_webhook)
+
+    mock_jira_client.update_issue_field.assert_called_once_with(
+        key="JBI-234",
+        fields={"summary": "JBI Test", "labels": ["bugzilla", "foo", "[foo]"]},
+    )
+    assert value["status"] == "update"


### PR DESCRIPTION
Webhook requests for private bug creation and modification do not include the normal set of bug fields (for some reason requests for new comments do). So to make sure you have the full bug info you must retrieve the bug through the API and then use that to generate the correct field changes to make in Jira.

This does drop one behaviour, it looks like JBI attempts to modify the reporter when the reporter changes for a bug. But to my knowledge it isn't possible to change the reporter for a bug. Also the way JBI is attempting to update the reporter field is incorrect and throws an error anyway.