### PR TITLE
Remove top-level `actions` config key

### DIFF
--- a/config/config.nonprod.yaml
+++ b/config/config.nonprod.yaml
@@ -1,19 +1,17 @@
 ---
-
 # Action Config
-actions:
-  devtest:
-    contact: tbd
-    description: DevTest whiteboard tag
-    enabled: true
-    parameters:
-      jira_project_key: JST
-      whiteboard_tag: devtest
-  flowstate:
-    allow_private: true
-    contact: dtownsend@mozilla.com
-    description: Flowstate whiteboard tag
-    enabled: true
-    parameters:
-      jira_project_key: MR2
-      whiteboard_tag: flowstate
+devtest:
+  contact: tbd
+  description: DevTest whiteboard tag
+  enabled: true
+  parameters:
+    jira_project_key: JST
+    whiteboard_tag: devtest
+flowstate:
+  allow_private: true
+  contact: dtownsend@mozilla.com
+  description: Flowstate whiteboard tag
+  enabled: true
+  parameters:
+    jira_project_key: MR2
+    whiteboard_tag: flowstate

--- a/config/config.prod.yaml
+++ b/config/config.prod.yaml
@@ -1,104 +1,102 @@
 ---
-
 # Action Config
-actions:
-  addons:
-    #  action: src.jbi.whiteboard_actions.default
-    contact: tbd
-    description: Addons whiteboard tag for AMO Team
-    enabled: true
-    parameters:
-      jira_project_key: WEBEXT
-      whiteboard_tag: addons
-  fidedi:
-    contact: tbd
-    description: Firefox Desktop Integration whiteboard tag
-    enabled: true
-    parameters:
-      jira_project_key: FIDEDI
-      whiteboard_tag: fidedi
-  fidefe:
-    contact: tbd
-    description: Firefox Front End whiteboard tag
-    enabled: true
-    parameters:
-      jira_project_key: FIDEFE
-      whiteboard_tag: fidefe
-  flowstate:
-    allow_private: true
-    contact: dtownsend@mozilla.com
-    description: Flowstate whiteboard tag
-    enabled: true
-    parameters:
-      jira_project_key: MR2
-      whiteboard_tag: flowstate
-  fxatps:
-    contact: tbd
-    description: Privacy & Security and Anti-Tracking Team whiteboard tag
-    enabled: true
-    parameters:
-      jira_project_key: FXATPS
-      whiteboard_tag: fxatps
-  fxcm:
-    contact: tbd
-    description: Firefox Credential Management Team whiteboard tag
-    enabled: true
-    parameters:
-      jira_project_key: FXCM
-      whiteboard_tag: fxcm
-  fxsync:
-    contact: tbd
-    description: Firefox Sync Team whiteboard tag
-    enabled: true
-    parameters:
-      jira_project_key: SYNC
-      whiteboard_tag: fxsync
-  gv:
-    contact: tbd
-    description: GeckoView Team whiteboard tag
-    enabled: true
-    parameters:
-      jira_project_key: ANDP
-      whiteboard_tag: gv
-  mv3:
-    contact: tbd
-    description: MV3 whiteboard tag
-    enabled: true
-    parameters:
-      jira_project_key: WEBEXT
-      whiteboard_tag: mv3
-  nimbus:
-    contact: tbd
-    description: Nimbus whiteboard tag
-    enabled: true
-    parameters:
-      jira_project_key: EXP
-      whiteboard_tag: nimbus
-  prodtest:
-    contact: tbd
-    description: ProdTest tag
-    enabled: true
-    parameters:
-      jira_project_key: OSS
-      whiteboard_tag: prodtest
-  proton:
-    contact: tbd
-    description: Proton whiteboard tag for Firefox Frontend
-    enabled: true
-    parameters:
-      jira_project_key: FIDEFE
-      whiteboard_tag: proton
-  relops:
-    contact: tbd
-    description: Release Operations Team Tag
-    enabled: true
-    parameters:
-      jira_project_key: RELOPS
-      whiteboard_tag: relops
-  snt:
-    contact: tbd
-    description: Search/NewTab Team Tag
-    enabled: true
-    parameters:
-      jira_project_key: SNT
-      whiteboard_tag: snt
+addons:
+  #  action: src.jbi.whiteboard_actions.default
+  contact: tbd
+  description: Addons whiteboard tag for AMO Team
+  enabled: true
+  parameters:
+    jira_project_key: WEBEXT
+    whiteboard_tag: addons
+fidedi:
+  contact: tbd
+  description: Firefox Desktop Integration whiteboard tag
+  enabled: true
+  parameters:
+    jira_project_key: FIDEDI
+    whiteboard_tag: fidedi
+fidefe:
+  contact: tbd
+  description: Firefox Front End whiteboard tag
+  enabled: true
+  parameters:
+    jira_project_key: FIDEFE
+    whiteboard_tag: fidefe
+flowstate:
+  allow_private: true
+  contact: dtownsend@mozilla.com
+  description: Flowstate whiteboard tag
+  enabled: true
+  parameters:
+    jira_project_key: MR2
+    whiteboard_tag: flowstate
+fxatps:
+  contact: tbd
+  description: Privacy & Security and Anti-Tracking Team whiteboard tag
+  enabled: true
+  parameters:
+    jira_project_key: FXATPS
+    whiteboard_tag: fxatps
+fxcm:
+  contact: tbd
+  description: Firefox Credential Management Team whiteboard tag
+  enabled: true
+  parameters:
+    jira_project_key: FXCM
+    whiteboard_tag: fxcm
+fxsync:
+  contact: tbd
+  description: Firefox Sync Team whiteboard tag
+  enabled: true
+  parameters:
+    jira_project_key: SYNC
+    whiteboard_tag: fxsync
+gv:
+  contact: tbd
+  description: GeckoView Team whiteboard tag
+  enabled: true
+  parameters:
+    jira_project_key: ANDP
+    whiteboard_tag: gv
+mv3:
+  contact: tbd
+  description: MV3 whiteboard tag
+  enabled: true
+  parameters:
+    jira_project_key: WEBEXT
+    whiteboard_tag: mv3
+nimbus:
+  contact: tbd
+  description: Nimbus whiteboard tag
+  enabled: true
+  parameters:
+    jira_project_key: EXP
+    whiteboard_tag: nimbus
+prodtest:
+  contact: tbd
+  description: ProdTest tag
+  enabled: true
+  parameters:
+    jira_project_key: OSS
+    whiteboard_tag: prodtest
+proton:
+  contact: tbd
+  description: Proton whiteboard tag for Firefox Frontend
+  enabled: true
+  parameters:
+    jira_project_key: FIDEFE
+    whiteboard_tag: proton
+relops:
+  contact: tbd
+  description: Release Operations Team Tag
+  enabled: true
+  parameters:
+    jira_project_key: RELOPS
+    whiteboard_tag: relops
+snt:
+  contact: tbd
+  description: Search/NewTab Team Tag
+  enabled: true
+  parameters:
+    jira_project_key: SNT
+    whiteboard_tag: snt

--- a/src/app/api.py
+++ b/src/app/api.py
@@ -110,7 +110,7 @@ def get_whiteboard_tag(
     """API for viewing whiteboard_tags and associated data"""
     if existing := actions.get(whiteboard_tag):
         return {whiteboard_tag: existing}
-    return actions.all()
+    return actions
 
 
 @app.get("/jira_projects/")
@@ -128,11 +128,10 @@ def powered_by_jbi(
     actions: Actions = Depends(configuration.get_actions),
 ):
     """API for `Powered By` endpoint"""
-    entries = actions.all()
     context = {
         "request": request,
         "title": "Powered by JBI",
-        "num_configs": len(entries),
+        "num_configs": len(actions),
         "data": entries,
         "enable_query": enabled,
     }

--- a/src/app/api.py
+++ b/src/app/api.py
@@ -10,6 +10,7 @@ from typing import Dict, List, Optional
 import sentry_sdk
 import uvicorn  # type: ignore
 from fastapi import Body, Depends, FastAPI, Request
+from fastapi.encoders import jsonable_encoder
 from fastapi.responses import HTMLResponse, ORJSONResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
@@ -132,7 +133,7 @@ def powered_by_jbi(
         "request": request,
         "title": "Powered by JBI",
         "num_configs": len(actions),
-        "data": entries,
+        "data": jsonable_encoder(actions),
         "enable_query": enabled,
     }
     return templates.TemplateResponse("powered_by_template.html", context)

--- a/src/app/configuration.py
+++ b/src/app/configuration.py
@@ -22,12 +22,9 @@ def get_actions(
     jbi_config_file: str = f"config/config.{settings.env}.yaml",
 ) -> Actions:
     """Convert and validate YAML configuration to `Action` objects"""
-
-    with open(jbi_config_file, encoding="utf-8") as file:
-        try:
-            yaml_data = file.read()
-            actions: Actions = Actions.parse_raw(yaml_data)
-            return actions
-        except ValidationError as exception:
-            logger.exception(exception)
-            raise ConfigError("Errors exist.") from exception
+    try:
+        actions: Actions = Actions.parse_file(jbi_config_file)
+        return actions
+    except ValidationError as exception:
+        logger.exception(exception)
+        raise ConfigError("Errors exist.") from exception

--- a/src/jbi/models.py
+++ b/src/jbi/models.py
@@ -16,6 +16,7 @@ class Action(YamlModel):
     Action is the inner model for each action in the configuration file"""
 
     action: str = "src.jbi.whiteboard_actions.default"
+    contact: str
     description: str
     enabled: bool = False
     allow_private: bool = False

--- a/src/jbi/models.py
+++ b/src/jbi/models.py
@@ -16,8 +16,8 @@ class Action(YamlModel):
     Action is the inner model for each action in the configuration file"""
 
     action: str = "src.jbi.whiteboard_actions.default"
-    enabled: bool = False
     description: str
+    enabled: bool = False
     allow_private: bool = False
     parameters: dict = {}
 

--- a/src/jbi/models.py
+++ b/src/jbi/models.py
@@ -17,6 +17,7 @@ class Action(YamlModel):
 
     action: str = "src.jbi.whiteboard_actions.default"
     enabled: bool = False
+    description: str
     allow_private: bool = False
     parameters: dict = {}
 

--- a/src/jbi/models.py
+++ b/src/jbi/models.py
@@ -66,6 +66,9 @@ class Actions(YamlModel):
     def __len__(self):
         return len(self.__root__)
 
+    def __getitem__(self, item):
+        return self.__root__[item]
+
     def get(self, tag: Optional[str]) -> Optional[Action]:
         """Lookup actions by whiteboard tag"""
         return self.__root__.get(tag.lower()) if tag else None

--- a/src/jbi/models.py
+++ b/src/jbi/models.py
@@ -58,22 +58,21 @@ class Action(YamlModel):
 
 class Actions(YamlModel):
     """
-    Actions is the overall model for the list of `actions` in the configuration file
+    Actions is the container model for the list of actions in the configuration file
     """
 
-    actions: Mapping[str, Action]
+    __root__: Mapping[str, Action]
+
+    def __len__(self):
+        return len(self.__root__)
 
     def get(self, tag: Optional[str]) -> Optional[Action]:
         """Lookup actions by whiteboard tag"""
-        return self.actions.get(tag.lower()) if tag else None
+        return self.__root__.get(tag.lower()) if tag else None
 
-    def all(self):
-        """Return mapping of all actions"""
-        return self.actions
-
-    @validator("actions")
+    @validator("__root__")
     def validate_action_matches_whiteboard(
-        cls, actions
+        cls, actions: Mapping[str, Action]
     ):  # pylint: disable=no-self-argument, no-self-use
         """
         Validate that the inner actions are named as expected

--- a/tests/unit/app/bad-config.yaml
+++ b/tests/unit/app/bad-config.yaml
@@ -1,12 +1,10 @@
 ---
-
 # Action Config
-actions:
-  should-be-A:
-    action: src.jbi.whiteboard_actions.default
-    contact: tbd
-    description: Mock Test Config
-    enabled: true
-    parameters:
-      jira_project_key: KEY
-      whiteboard_tag: A
+should-be-A:
+  action: src.jbi.whiteboard_actions.default
+  contact: tbd
+  description: test config
+  enabled: true
+  parameters:
+    jira_project_key: KEY
+    whiteboard_tag: A

--- a/tests/unit/app/test_configuration.py
+++ b/tests/unit/app/test_configuration.py
@@ -21,17 +21,17 @@ def test_actual_jbi_files():
 
 def test_no_actions_fails():
     with pytest.raises(ValueError) as exc_info:
-        Actions.parse_obj({"actions": {}})
+        Actions.parse_obj({})
     assert "no actions configured" in str(exc_info.value)
 
 
 def test_unknown_module_fails():
     with pytest.raises(ValueError) as exc_info:
-        Actions.parse_obj({"actions": {"x": {"action": "path.to.unknown"}}})
+        Actions.parse_obj({"x": {"action": "path.to.unknown"}})
     assert "unknown action `path.to.unknown`" in str(exc_info.value)
 
 
 def test_bad_module_fails():
     with pytest.raises(ValueError) as exc_info:
-        Actions.parse_obj({"actions": {"x": {"action": "src.jbi.runner"}}})
+        Actions.parse_obj({"x": {"action": "src.jbi.runner"}})
     assert "action is not properly setup" in str(exc_info.value)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -169,14 +169,12 @@ def webhook_modify_private_example(
 def actions_example() -> Actions:
     return Actions.parse_obj(
         {
-            "actions": {
-                "devtest": {
-                    "action": "tests.unit.jbi.noop_action",
-                    "description": "Mocked config file",
-                    "parameters": {
-                        "whiteboard_tag": "devtest",
-                    },
-                }
+            "devtest": {
+                "action": "tests.unit.jbi.noop_action",
+                "description": "test config",
+                "parameters": {
+                    "whiteboard_tag": "devtest",
+                },
             }
         }
     )

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -171,6 +171,7 @@ def actions_example() -> Actions:
         {
             "devtest": {
                 "action": "tests.unit.jbi.noop_action",
+                "contact": "tbd",
                 "description": "test config",
                 "parameters": {
                     "whiteboard_tag": "devtest",

--- a/tests/unit/jbi/test_bugzilla.py
+++ b/tests/unit/jbi/test_bugzilla.py
@@ -61,7 +61,7 @@ def test_lookup_action(actions_example):
     )
     tag, action = bug.lookup_action(actions_example)
     assert tag == "devtest"
-    assert "Mocked config" in action.description
+    assert "test config" in action.description
 
 
 def test_lookup_action_missing(actions_example):

--- a/tests/unit/jbi/test_runner.py
+++ b/tests/unit/jbi/test_runner.py
@@ -37,12 +37,11 @@ def test_private_request_is_allowed(
 ):
     actions = Actions.parse_obj(
         {
-            "actions": {
-                "devtest": {
-                    "action": "tests.unit.jbi.noop_action",
-                    "allow_private": True,
-                    "parameters": {"whiteboard_tag": "devtest"},
-                }
+            "devtest": {
+                "action": "tests.unit.jbi.noop_action",
+                "allow_private": True,
+                "description": "test config",
+                "parameters": {"whiteboard_tag": "devtest"},
             }
         }
     )

--- a/tests/unit/jbi/test_runner.py
+++ b/tests/unit/jbi/test_runner.py
@@ -34,21 +34,14 @@ def test_private_request_is_allowed(
     caplog,
     webhook_create_private_example: BugzillaWebhookRequest,
     settings: Settings,
+    actions_example,
 ):
-    actions = Actions.parse_obj(
-        {
-            "devtest": {
-                "action": "tests.unit.jbi.noop_action",
-                "allow_private": True,
-                "description": "test config",
-                "parameters": {"whiteboard_tag": "devtest"},
-            }
-        }
-    )
+
+    actions_example["devtest"].allow_private = True
 
     result = execute_action(
         request=webhook_create_private_example,
-        actions=actions,
+        actions=actions_example,
         settings=settings,
     )
 


### PR DESCRIPTION
I noticed that we had a top-level actions key in project config. This seemed somewhat unnecessary since there aren't any other config objects besides actions. That meant that any time we wanted to access actions, we'd need to do `actions_instance.actions.<whatever>`.

This PR removes the top-level `actions` key in config and modifies the `Actions` Pydantic model to give it a [`__root__`](https://pydantic-docs.helpmanual.io/usage/models/#custom-root-types) property to contain the actions.