### PR TITLE
Log object dicts instead of JSON strings

### DIFF
--- a/src/jbi/runner.py
+++ b/src/jbi/runner.py
@@ -37,7 +37,7 @@ def execute_action(
         "bug": {
             "id": request.bug.id if request.bug else None,
         },
-        "request": request.json(),
+        "request": request.dict(),
     }
     try:
         logger.debug(
@@ -48,7 +48,7 @@ def execute_action(
             raise IgnoreInvalidRequestError("no bug data received")
 
         bug_obj: BugzillaBug = getbug_as_bugzilla_object(request=request)
-        log_context["bug"] = bug_obj.json()
+        log_context["bug"] = bug_obj.dict()
 
         try:
             action_name, current_action = bug_obj.lookup_action(actions)

--- a/src/jbi/whiteboard_actions/default.py
+++ b/src/jbi/whiteboard_actions/default.py
@@ -50,7 +50,7 @@ class DefaultExecutor:
             "Ignore event target %r",
             target,
             extra={
-                "request": payload.json(),
+                "request": payload.dict(),
             },
         )
 
@@ -61,8 +61,8 @@ class DefaultExecutor:
         linked_issue_key = bug_obj.extract_from_see_also()
 
         log_context = {
-            "request": payload.json(),
-            "bug": bug_obj.json(),
+            "request": payload.dict(),
+            "bug": bug_obj.dict(),
         }
         if not linked_issue_key:
             logger.debug(
@@ -108,8 +108,8 @@ class DefaultExecutor:
             return self.create_and_link_issue(payload, bug_obj)
 
         log_context = {
-            "request": payload.json(),
-            "bug": bug_obj.json(),
+            "request": payload.dict(),
+            "bug": bug_obj.dict(),
         }
         logger.debug(
             "Update fields of Jira issue %s for Bug %s",
@@ -148,8 +148,8 @@ class DefaultExecutor:
     ):  # pylint: disable=too-many-locals
         """create jira issue and establish link between bug and issue; rollback/delete if required"""
         log_context = {
-            "request": payload.json(),
-            "bug": bug_obj.json(),
+            "request": payload.dict(),
+            "bug": bug_obj.dict(),
         }
         logger.debug(
             "Create new Jira issue for Bug %s",


### PR DESCRIPTION
<img width="375" alt="Screenshot 2022-07-11 at 10 26 35" src="https://user-images.githubusercontent.com/546692/178221466-4654ed7a-28a6-49ef-8014-9fbe5c982313.png">

Bug payloads and requests are coming in as string otherwise