### PR TITLE
Refactor usage of actions whiteboard tags (fixes #89)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -106,7 +106,7 @@
         "filename": "README.md",
         "hashed_secret": "04e78d6e804f2b59e6cb282cb9ed2c7bfd8a9737",
         "is_verified": false,
-        "line_number": 152
+        "line_number": 183
       }
     ],
     "config/local_dev.env": [
@@ -126,5 +126,5 @@
       }
     ]
   },
-  "generated_at": "2022-07-13T07:01:04Z"
+  "generated_at": "2022-07-13T09:34:14Z"
 }

--- a/.yamllint
+++ b/.yamllint
@@ -13,7 +13,6 @@ ignore: |
 
 rules:
   key-duplicates: enable
-  key-ordering: enable
 
 
 yaml-files:

--- a/README.md
+++ b/README.md
@@ -194,16 +194,17 @@ For the list of configured whiteboard tags:
 
 ```
 GET /whiteboard_tags/
-[
-  {
-    "action_tag": "addons",
-    "contact": "example@allizom.com",
-    "description": "Addons whiteboard tag for AMO Team",
-    "enabled": true,
-    "module": "src.jbi.whiteboard_actions.default",
-    "parameters": {
-        "jira_project_key": "WEBEXT"
-  }
-  ...
-]
+{
+    "addons": {
+        "action_tag": "addons",
+        "contact": "example@allizom.com",
+        "description": "Addons whiteboard tag for AMO Team",
+        "enabled": true,
+        "module": "src.jbi.whiteboard_actions.default",
+        "parameters": {
+            "jira_project_key": "WEBEXT"
+        }
+    }
+    ...
+}
 ```

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The system reads the actions configuration from a YAML file, one per environment
 
 Below is a full example of an action configuration:
 ```yaml
-- action_tag: example
+- whiteboard_tag: example
   allow_private: false
   contact: example@allizom.com
   description: example configuration
@@ -28,7 +28,7 @@ Below is a full example of an action configuration:
 ```
 
 A bit more about the different fields...
-- `action_tag`
+- `whiteboard_tag`
     - string
     - The tag to be matched in the Bugzilla `whiteboard` field
 - `allow_private` (optional)
@@ -77,7 +77,7 @@ It will also set the Jira issue URL in the Bugzilla bug `see_also` field.
 
 Example configuration:
 ```yaml
-    action_tag: example
+    whiteboard_tag: example
     contact: example@allizom.com
     description: example configuration
     module: src.jbi.whiteboard_actions.default
@@ -106,7 +106,7 @@ If configured, the action supports setting the Jira issues's status when the Bug
 
 Example configuration:
 ```yaml
-    action_tag: example
+    whiteboard_tag: example
     contact: example@allizom.com
     description: example configuration
     enabled: true
@@ -196,7 +196,7 @@ For the list of configured whiteboard tags:
 GET /whiteboard_tags/
 {
     "addons": {
-        "action_tag": "addons",
+        "whiteboard_tag": "addons",
         "contact": "example@allizom.com",
         "description": "Addons whiteboard tag for AMO Team",
         "enabled": true,

--- a/config/config.nonprod.yaml
+++ b/config/config.nonprod.yaml
@@ -1,22 +1,21 @@
 ---
 # Action Config
-devtest:
+- action_tag: devtest
   contact: tbd
   description: DevTest whiteboard tag
   enabled: true
   parameters:
     jira_project_key: JST
-    whiteboard_tag: devtest
-flowstate:
-  action: src.jbi.whiteboard_actions.default_with_assignee_and_status
+
+- action_tag: flowstate
   allow_private: true
   contact: dtownsend@mozilla.com
   description: Flowstate whiteboard tag
   enabled: true
+  module: src.jbi.whiteboard_actions.default_with_assignee_and_status
   parameters:
     jira_project_key: MR2
     status_map:
       ASSIGNED: In Progress
       FIXED: In Review
       REOPENED: In Progress
-    whiteboard_tag: flowstate

--- a/config/config.nonprod.yaml
+++ b/config/config.nonprod.yaml
@@ -1,13 +1,13 @@
 ---
 # Action Config
-- action_tag: devtest
+- whiteboard_tag: devtest
   contact: tbd
   description: DevTest whiteboard tag
   enabled: true
   parameters:
     jira_project_key: JST
 
-- action_tag: flowstate
+- whiteboard_tag: flowstate
   allow_private: true
   contact: dtownsend@mozilla.com
   description: Flowstate whiteboard tag

--- a/config/config.prod.yaml
+++ b/config/config.prod.yaml
@@ -1,6 +1,6 @@
 ---
 # Action Config
-- action_tag: addons
+- whiteboard_tag: addons
   contact: tbd
   description: Addons whiteboard tag for AMO Team
   enabled: true
@@ -8,21 +8,21 @@
   parameters:
     jira_project_key: WEBEXT
 
-- action_tag: fidedi
+- whiteboard_tag: fidedi
   contact: tbd
   description: Firefox Desktop Integration whiteboard tag
   enabled: true
   parameters:
     jira_project_key: FIDEDI
 
-- action_tag: fidefe
+- whiteboard_tag: fidefe
   contact: tbd
   description: Firefox Front End whiteboard tag
   enabled: true
   parameters:
     jira_project_key: FIDEFE
 
-- action_tag: flowstate
+- whiteboard_tag: flowstate
   allow_private: true
   contact: dtownsend@mozilla.com
   description: Flowstate whiteboard tag
@@ -35,70 +35,70 @@
       FIXED: In Review
       REOPENED: In Progress
 
-- action_tag: fxatps
+- whiteboard_tag: fxatps
   contact: tbd
   description: Privacy & Security and Anti-Tracking Team whiteboard tag
   enabled: true
   parameters:
     jira_project_key: FXATPS
 
-- action_tag: fxcm
+- whiteboard_tag: fxcm
   contact: tbd
   description: Firefox Credential Management Team whiteboard tag
   enabled: true
   parameters:
     jira_project_key: FXCM
 
-- action_tag: fxsync
+- whiteboard_tag: fxsync
   contact: tbd
   description: Firefox Sync Team whiteboard tag
   enabled: true
   parameters:
     jira_project_key: SYNC
 
-- action_tag: gv
+- whiteboard_tag: gv
   contact: tbd
   description: GeckoView Team whiteboard tag
   enabled: true
   parameters:
     jira_project_key: ANDP
 
-- action_tag: mv3
+- whiteboard_tag: mv3
   contact: tbd
   description: MV3 whiteboard tag
   enabled: true
   parameters:
     jira_project_key: WEBEXT
 
-- action_tag: nimbus
+- whiteboard_tag: nimbus
   contact: tbd
   description: Nimbus whiteboard tag
   enabled: true
   parameters:
     jira_project_key: EXP
 
-- action_tag: prodtest
+- whiteboard_tag: prodtest
   contact: tbd
   description: ProdTest tag
   enabled: true
   parameters:
     jira_project_key: OSS
 
-- action_tag: proton
+- whiteboard_tag: proton
   contact: tbd
   description: Proton whiteboard tag for Firefox Frontend
   enabled: true
   parameters:
     jira_project_key: FIDEFE
 
-- action_tag: relops
+- whiteboard_tag: relops
   contact: tbd
   description: Release Operations Team Tag
   enabled: true
   parameters:
     jira_project_key: RELOPS
 
-- action_tag: snt
+- whiteboard_tag: snt
   contact: tbd
   description: Search/NewTab Team Tag
   enabled: true

--- a/config/config.prod.yaml
+++ b/config/config.prod.yaml
@@ -1,107 +1,106 @@
 ---
 # Action Config
-addons:
-  #  action: src.jbi.whiteboard_actions.default
+- action_tag: addons
   contact: tbd
   description: Addons whiteboard tag for AMO Team
   enabled: true
+  # module: src.jbi.whiteboard_actions.default
   parameters:
     jira_project_key: WEBEXT
-    whiteboard_tag: addons
-fidedi:
+
+- action_tag: fidedi
   contact: tbd
   description: Firefox Desktop Integration whiteboard tag
   enabled: true
   parameters:
     jira_project_key: FIDEDI
-    whiteboard_tag: fidedi
-fidefe:
+
+- action_tag: fidefe
   contact: tbd
   description: Firefox Front End whiteboard tag
   enabled: true
   parameters:
     jira_project_key: FIDEFE
-    whiteboard_tag: fidefe
-flowstate:
-  action: src.jbi.whiteboard_actions.default_with_assignee_and_status
+
+- action_tag: flowstate
   allow_private: true
   contact: dtownsend@mozilla.com
   description: Flowstate whiteboard tag
   enabled: true
+  module: src.jbi.whiteboard_actions.default_with_assignee_and_status
   parameters:
     jira_project_key: MR2
     status_map:
       ASSIGNED: In Progress
       FIXED: In Review
       REOPENED: In Progress
-    whiteboard_tag: flowstate
-fxatps:
+
+- action_tag: fxatps
   contact: tbd
   description: Privacy & Security and Anti-Tracking Team whiteboard tag
   enabled: true
   parameters:
     jira_project_key: FXATPS
-    whiteboard_tag: fxatps
-fxcm:
+
+- action_tag: fxcm
   contact: tbd
   description: Firefox Credential Management Team whiteboard tag
   enabled: true
   parameters:
     jira_project_key: FXCM
-    whiteboard_tag: fxcm
-fxsync:
+
+- action_tag: fxsync
   contact: tbd
   description: Firefox Sync Team whiteboard tag
   enabled: true
   parameters:
     jira_project_key: SYNC
-    whiteboard_tag: fxsync
-gv:
+
+- action_tag: gv
   contact: tbd
   description: GeckoView Team whiteboard tag
   enabled: true
   parameters:
     jira_project_key: ANDP
-    whiteboard_tag: gv
-mv3:
+
+- action_tag: mv3
   contact: tbd
   description: MV3 whiteboard tag
   enabled: true
   parameters:
     jira_project_key: WEBEXT
-    whiteboard_tag: mv3
-nimbus:
+
+- action_tag: nimbus
   contact: tbd
   description: Nimbus whiteboard tag
   enabled: true
   parameters:
     jira_project_key: EXP
-    whiteboard_tag: nimbus
-prodtest:
+
+- action_tag: prodtest
   contact: tbd
   description: ProdTest tag
   enabled: true
   parameters:
     jira_project_key: OSS
-    whiteboard_tag: prodtest
-proton:
+
+- action_tag: proton
   contact: tbd
   description: Proton whiteboard tag for Firefox Frontend
   enabled: true
   parameters:
     jira_project_key: FIDEFE
-    whiteboard_tag: proton
-relops:
+
+- action_tag: relops
   contact: tbd
   description: Release Operations Team Tag
   enabled: true
   parameters:
     jira_project_key: RELOPS
-    whiteboard_tag: relops
-snt:
+
+- action_tag: snt
   contact: tbd
   description: Search/NewTab Team Tag
   enabled: true
   parameters:
     jira_project_key: SNT
-    whiteboard_tag: snt

--- a/src/app/api.py
+++ b/src/app/api.py
@@ -110,7 +110,7 @@ def get_whiteboard_tag(
 ):
     """API for viewing whiteboard_tags and associated data"""
     if existing := actions.get(whiteboard_tag):
-        return {whiteboard_tag: existing}
+        return [existing]
     return actions
 
 
@@ -132,8 +132,7 @@ def powered_by_jbi(
     context = {
         "request": request,
         "title": "Powered by JBI",
-        "num_configs": len(actions),
-        "data": jsonable_encoder(actions),
+        "actions": jsonable_encoder(actions),
         "enable_query": enabled,
     }
     return templates.TemplateResponse("powered_by_template.html", context)

--- a/src/app/api.py
+++ b/src/app/api.py
@@ -110,8 +110,8 @@ def get_whiteboard_tag(
 ):
     """API for viewing whiteboard_tags and associated data"""
     if existing := actions.get(whiteboard_tag):
-        return [existing]
-    return actions
+        return {whiteboard_tag: existing}
+    return actions.by_tag
 
 
 @app.get("/jira_projects/")

--- a/src/jbi/bugzilla.py
+++ b/src/jbi/bugzilla.py
@@ -7,7 +7,7 @@ import datetime
 import json
 import logging
 from functools import cached_property
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Optional
 from urllib.parse import ParseResult, urlparse
 
 from pydantic import BaseModel  # pylint: disable=no-name-in-module
@@ -148,7 +148,7 @@ class BugzillaBug(BaseModel):
         return ["bugzilla"] + wb_list + wb_bracket_list
 
     def get_potential_whiteboard_config_list(self) -> List[str]:
-        """Get all possible whiteboard_tag configuration values"""
+        """Get all possible tags from `whiteboard` field"""
         converted_list: List = []
         for whiteboard in self.get_whiteboard_as_list():
             first_tag = whiteboard.strip().lower().split(sep="-", maxsplit=1)[0]
@@ -198,13 +198,12 @@ class BugzillaBug(BaseModel):
 
         return None
 
-    def lookup_action(self, actions: Actions) -> Tuple[str, Action]:
+    def lookup_action(self, actions: Actions) -> Action:
         """Find first matching action from bug's whiteboard list"""
         tags: List[str] = self.get_potential_whiteboard_config_list()
         for tag in tags:
-            tag = tag.lower()
             if action := actions.get(tag):
-                return tag, action
+                return action
         raise ActionNotFoundError(", ".join(tags))
 
 

--- a/src/jbi/models.py
+++ b/src/jbi/models.py
@@ -16,7 +16,7 @@ class Action(YamlModel):
     """
     Action is the inner model for each action in the configuration file"""
 
-    action_tag: str
+    whiteboard_tag: str
     module: str = "src.jbi.whiteboard_actions.default"
     # TODO: Remove the tbd literal option when all actions have contact info # pylint: disable=fixme
     contact: Union[EmailStr, List[EmailStr], Literal["tbd"]]
@@ -68,7 +68,7 @@ class Actions(YamlModel):
     @functools.cached_property
     def by_tag(self) -> Mapping[str, Action]:
         """Build mapping of actions by lookup tag."""
-        return {a.action_tag: a for a in self.__root__}
+        return {a.whiteboard_tag: a for a in self.__root__}
 
     def __len__(self):
         return len(self.__root__)
@@ -93,14 +93,16 @@ class Actions(YamlModel):
         if not actions:
             raise ValueError("no actions configured")
 
-        tags = [a.action_tag.lower() for a in actions]
+        tags = [a.whiteboard_tag.lower() for a in actions]
         duplicated_tags = [t for i, t in enumerate(tags) if t in tags[:i]]
         if duplicated_tags:
             raise ValueError(f"actions have duplicated lookup tags: {duplicated_tags}")
 
         for action in actions:
             if action.contact == "tbd":
-                warnings.warn(f"Provide contact data for `{action.action_tag}` action.")
+                warnings.warn(
+                    f"Provide contact data for `{action.whiteboard_tag}` action."
+                )
 
         return actions
 

--- a/src/jbi/models.py
+++ b/src/jbi/models.py
@@ -93,6 +93,11 @@ class Actions(YamlModel):
         if not actions:
             raise ValueError("no actions configured")
 
+        tags = [a.action_tag.lower() for a in actions]
+        duplicated_tags = [t for i, t in enumerate(tags) if t in tags[:i]]
+        if duplicated_tags:
+            raise ValueError(f"actions have duplicated lookup tags: {duplicated_tags}")
+
         for action in actions:
             if action.contact == "tbd":
                 warnings.warn(f"Provide contact data for `{action.action_tag}` action.")

--- a/src/jbi/models.py
+++ b/src/jbi/models.py
@@ -68,7 +68,7 @@ class Actions(YamlModel):
     @functools.cached_property
     def by_tag(self) -> Mapping[str, Action]:
         """Build mapping of actions by lookup tag."""
-        return {a.whiteboard_tag: a for a in self.__root__}
+        return {action.whiteboard_tag: action for action in self.__root__}
 
     def __len__(self):
         return len(self.__root__)

--- a/src/jbi/models.py
+++ b/src/jbi/models.py
@@ -8,7 +8,7 @@ from inspect import signature
 from types import ModuleType
 from typing import Any, Callable, Dict, List, Literal, Mapping, Optional, Union
 
-from pydantic import EmailStr, Extra, root_validator, validator
+from pydantic import EmailStr, Extra, Field, root_validator, validator
 from pydantic_yaml import YamlModel
 
 
@@ -63,7 +63,7 @@ class Actions(YamlModel):
     Actions is the container model for the list of actions in the configuration file
     """
 
-    __root__: List[Action]
+    __root__: List[Action] = Field(..., min_items=1)
 
     @functools.cached_property
     def by_tag(self) -> Mapping[str, Action]:
@@ -86,14 +86,10 @@ class Actions(YamlModel):
     ):
         """
         Inspect the list of actions:
-         - There is at least one action
          - Validate that lookup tags are uniques
          - If the action's contact is "tbd", emit a warning.
         """
-        if not actions:
-            raise ValueError("no actions configured")
-
-        tags = [a.whiteboard_tag.lower() for a in actions]
+        tags = [action.whiteboard_tag.lower() for action in actions]
         duplicated_tags = [t for i, t in enumerate(tags) if t in tags[:i]]
         if duplicated_tags:
             raise ValueError(f"actions have duplicated lookup tags: {duplicated_tags}")

--- a/src/jbi/runner.py
+++ b/src/jbi/runner.py
@@ -66,12 +66,12 @@ def execute_action(
 
         if bug_obj.is_private and not action.allow_private:
             raise IgnoreInvalidRequestError(
-                f"private bugs are not valid for action {action.action_tag!r}"
+                f"private bugs are not valid for action {action.whiteboard_tag!r}"
             )
 
         logger.info(
             "Execute action '%s:%s' for Bug %s",
-            action.action_tag,
+            action.whiteboard_tag,
             action.module,
             bug_obj.id,
             extra={"operation": Operations.EXECUTE, **log_context},
@@ -81,7 +81,7 @@ def execute_action(
 
         logger.info(
             "Action %r executed successfully for Bug %s",
-            action.action_tag,
+            action.whiteboard_tag,
             bug_obj.id,
             extra={"operation": Operations.SUCCESS, **log_context},
         )

--- a/src/jbi/runner.py
+++ b/src/jbi/runner.py
@@ -56,32 +56,32 @@ def execute_action(
         log_context["bug"] = bug_obj.dict()
 
         try:
-            action_name, current_action = bug_obj.lookup_action(actions)
+            action = bug_obj.lookup_action(actions)
         except ActionNotFoundError as err:
             raise IgnoreInvalidRequestError(
                 f"no action matching bug whiteboard tags: {err}"
             ) from err
 
-        log_context["action"] = current_action.dict()
+        log_context["action"] = action.dict()
 
-        if bug_obj.is_private and not current_action.allow_private:
+        if bug_obj.is_private and not action.allow_private:
             raise IgnoreInvalidRequestError(
-                f"private bugs are not valid for action {action_name!r}"
+                f"private bugs are not valid for action {action.action_tag!r}"
             )
 
         logger.info(
             "Execute action '%s:%s' for Bug %s",
-            action_name,
-            current_action.action,
+            action.action_tag,
+            action.module,
             bug_obj.id,
             extra={"operation": Operations.EXECUTE, **log_context},
         )
 
-        content = current_action.callable(payload=request)
+        content = action.callable(payload=request)
 
         logger.info(
             "Action %r executed successfully for Bug %s",
-            action_name,
+            action.action_tag,
             bug_obj.id,
             extra={"operation": Operations.SUCCESS, **log_context},
         )

--- a/src/jbi/whiteboard_actions/README.md
+++ b/src/jbi/whiteboard_actions/README.md
@@ -11,7 +11,7 @@ Let's create a `new_action`!
         return lambda payload: print(f"{optional_param}, going to {jira_project_key}!")
     ```
     1. In the above example the `jira_project_key` parameter is required
-    1. `optional_param`, which has a default value and is not required to run this action
+    1. `optional_param`, which has a default value, is not required to run this action
     1. `init()` returns a `__call__`able object that the system calls with the Bugzilla request payload
 1. Use the `payload` to perform the desired processing!
 1. Use the available service calls from `src/jbi/services.py' (or make new ones)

--- a/src/jbi/whiteboard_actions/README.md
+++ b/src/jbi/whiteboard_actions/README.md
@@ -15,5 +15,5 @@ Let's create a `new_action`!
     1. `init()` returns a `__call__`able object that the system calls with the Bugzilla request payload
 1. Use the `payload` to perform the desired processing!
 1. Use the available service calls from `src/jbi/services.py' (or make new ones)
-1. Update the `README.md` to promote your action
+1. Update the `README.md` to document your action
 1. Now the action `src.jbi.whiteboard_actions.my_team_actions` can be used in the YAML configuration, under the `module` key.

--- a/src/jbi/whiteboard_actions/README.md
+++ b/src/jbi/whiteboard_actions/README.md
@@ -1,19 +1,19 @@
 ## Looking to add a new action?
-"actions" are python modules that, if available in the PYTHONPATH,
-can be run by updating the `action` attribute of the yaml config file.
+"actions" are Python modules that, if available in the `PYTHONPATH`,
+can be run by updating the `module` attribute of the YAML config file.
 
 ### Create a new action...
 Let's create a `new_action`!
-1. First, add a new python file called `my_team_action.py` in the `src/jbi/whiteboard_actions/` directory.
-1. Add the python function `init` to a new "my_team_action" module, let's use the following:
+1. First, add a new Python file (eg. `my_team_action.py`) in the `src/jbi/whiteboard_actions/` directory.
+1. Add the Python function `init` to the module, for example:
     ```python
-    def init(whiteboard_tag, jira_project_key, optional_param=42):
-        return lambda payload: print(f"{whiteboard_tag}, going to {jira_project_key}!")
+    def init(jira_project_key, optional_param=42):
+        return lambda payload: print(f"{optional_param}, going to {jira_project_key}!")
     ```
-    1. In the above example `whiteboard_tag` and `jira_project_key` parameters are required
+    1. In the above example the `jira_project_key` parameter is required
     1. `optional_param`, which has a default value and is not required to run this action
-    1. init returns a `__call__`able object that the system calls with the bugzilla request and yaml configuration objects
-1. Using `payload` and `context` perform the desired processing!
-    1. `payload` is bugzilla webhook payload
-    1. Use the available service calls from `src/jbi/services.py' (or make new ones)
-1. Now the action `src.jbi.whiteboard_actions.my_team_actions` can be added to a configuration yaml under the `action` key.
+    1. `init()` returns a `__call__`able object that the system calls with the Bugzilla request payload
+1. Use the `payload` to perform the desired processing!
+1. Use the available service calls from `src/jbi/services.py' (or make new ones)
+1. Update the `README.md` to promote your action
+1. Now the action `src.jbi.whiteboard_actions.my_team_actions` can be used in the YAML configuration, under the `module` key.

--- a/src/jbi/whiteboard_actions/default.py
+++ b/src/jbi/whiteboard_actions/default.py
@@ -1,7 +1,6 @@
 """
-Default actions is listed below.
-`init` is required; and requires at minimum the
-`whiteboard_tag` and `jira_project_key`.
+Default action is listed below.
+`init` is required; and requires at minimum the `jira_project_key` parameter.
 
 `init` should return a __call__able
 """
@@ -17,19 +16,16 @@ settings = get_settings()
 logger = logging.getLogger(__name__)
 
 
-def init(whiteboard_tag, jira_project_key, **kwargs):
+def init(jira_project_key, **kwargs):
     """Function that takes required and optional params and returns a callable object"""
-    return DefaultExecutor(
-        whiteboard_tag=whiteboard_tag, jira_project_key=jira_project_key, **kwargs
-    )
+    return DefaultExecutor(jira_project_key=jira_project_key, **kwargs)
 
 
 class DefaultExecutor:
     """Callable class that encapsulates the default action."""
 
-    def __init__(self, whiteboard_tag, jira_project_key, **kwargs):
+    def __init__(self, jira_project_key, **kwargs):
         """Initialize DefaultExecutor Object"""
-        self.whiteboard_tag = whiteboard_tag
         self.jira_project_key = jira_project_key
 
         self.bugzilla_client = get_bugzilla()

--- a/src/jbi/whiteboard_actions/default_with_assignee_and_status.py
+++ b/src/jbi/whiteboard_actions/default_with_assignee_and_status.py
@@ -3,8 +3,7 @@ Extended action that provides some additional features over the default:
   * Updates the Jira assignee when the bug's assignee changes.
   * Optionally updates the Jira status when the bug's resolution or status changes.
 
-`init` is required; and requires at minimum the
-`whiteboard_tag` and `jira_project_key`. `status_map` is optional.
+`init` is required; and requires at minimum the `jira_project_key` parameter. `status_map` is optional.
 
 `init` should return a __call__able
 """

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -45,3 +45,21 @@ tbody tr:last-of-type {
   content: "▼";
   opacity: 1;
 }
+
+dl {
+  display: grid;
+  grid-template-columns: max-content auto;
+}
+
+dt {
+  grid-column-start: 1;
+}
+
+dt:after {
+  content: ':';
+}
+
+dd {
+  grid-column-start: 2;
+  margin-left: 5;
+}

--- a/src/templates/powered_by_template.html
+++ b/src/templates/powered_by_template.html
@@ -28,7 +28,12 @@
                             <td class="enabled">{{action.enabled}}</td>
                             <td class="module">{{action.module}}</td>
                             <td class="parameters">
-                                <dl>{% for param, value in action.parameters.items() %}<dt>{{param}}</dt><dd>{{value}}</dd>{% endfor %}</dl>
+                                <dl>
+                                    {% for param, value in action.parameters.items() %}
+                                    <dt>{{param}}</dt>
+                                    <dd>{{value}}</dd>
+                                    {% endfor %}
+                                </dl>
                             </td>
                         </tr>
                         {% endif %}

--- a/src/templates/powered_by_template.html
+++ b/src/templates/powered_by_template.html
@@ -22,7 +22,7 @@
                     {% for action in actions %}
                         {% if enable_query == none or action.enabled == enable_query %}
                         <tr>
-                            <td class="identifier">{{action.action_tag}}</td>
+                            <td class="identifier">{{action.whiteboard_tag}}</td>
                             <td class="contact">{{action.contact}}</td>
                             <td class="description">{{action.description}}</td>
                             <td class="enabled">{{action.enabled}}</td>

--- a/src/templates/powered_by_template.html
+++ b/src/templates/powered_by_template.html
@@ -5,29 +5,30 @@
     </head>
     <body>
         <h1>{{title}}</h1>
-        <p>{{num_configs}} actions.</p>
+        <p>{{actions|length}} actions.</p>
         <div id="collections">
             <table>
                 <thead>
                     <tr>
-                        <th>Identifier</th>
-                        <th>Action</th>
+                        <th>Tag</th>
                         <th>Contact</th>
                         <th>Description </th>
                         <th>Enabled</th>
+                        <th>Module</th>
                         <th>Parameters</th>
                     </tr>
                 </thead>
                 <tbody class="list">
-                    {% for key, value in data.items() %}
-                        {% if enable_query == none or value.enabled == enable_query %}
+                    {% for action in actions %}
+                        {% if enable_query == none or action.enabled == enable_query %}
                         <tr>
-                            <td class="identifier">{{key}}</td>
-                            <td class="action">{{value.action}}</td>
-                            <td class="contact">{{value.contact}}</td>
-                            <td class="description">{{value.description}}</td>
-                            <td class="enabled">{{value.enabled}}</td>
-                            <td class="parameters">{% for key, value in value.parameters.items() %}{{key ~ ": " ~ value}}{{ ", " if not loop.last else "" }}{% endfor %}
+                            <td class="identifier">{{action.action_tag}}</td>
+                            <td class="contact">{{action.contact}}</td>
+                            <td class="description">{{action.description}}</td>
+                            <td class="enabled">{{action.enabled}}</td>
+                            <td class="module">{{action.module}}</td>
+                            <td class="parameters">
+                                <dl>{% for param, value in action.parameters.items() %}<dt>{{param}}</dt><dd>{{value}}</dd>{% endfor %}</dl>
                             </td>
                         </tr>
                         {% endif %}
@@ -35,6 +36,5 @@
                 </tbody>
             </table>
         </div>
-
     </body>
 </html>

--- a/tests/unit/app/bad-config.yaml
+++ b/tests/unit/app/bad-config.yaml
@@ -1,10 +1,9 @@
 ---
 # Action Config
-should-be-A:
-  action: src.jbi.whiteboard_actions.default
+- action_tag: A
   contact: foobar
   description: test config
   enabled: true
+  module: src.jbi.whiteboard_actions.default
   parameters:
     jira_project_key: KEY
-    whiteboard_tag: A

--- a/tests/unit/app/bad-config.yaml
+++ b/tests/unit/app/bad-config.yaml
@@ -1,6 +1,6 @@
 ---
 # Action Config
-- action_tag: A
+- whiteboard_tag: A
   contact: foobar
   description: test config
   enabled: true

--- a/tests/unit/app/test_api.py
+++ b/tests/unit/app/test_api.py
@@ -52,7 +52,7 @@ def test_whiteboard_tags(anon_client):
     resp = anon_client.get("/whiteboard_tags")
     actions = resp.json()
 
-    assert actions[0]["description"] == "DevTest whiteboard tag"
+    assert actions["devtest"]["description"] == "DevTest whiteboard tag"
 
 
 def test_jira_projects(anon_client, mocked_jira):
@@ -66,12 +66,12 @@ def test_jira_projects(anon_client, mocked_jira):
 
 def test_whiteboard_tags_filtered(anon_client):
     resp = anon_client.get("/whiteboard_tags/?whiteboard_tag=devtest")
-    actions = resp.json()
-    assert sorted([a["action_tag"] for a in actions]) == ["devtest"]
+    infos = resp.json()
+    assert sorted(infos.keys()) == ["devtest"]
 
     resp = anon_client.get("/whiteboard_tags/?whiteboard_tag=foo")
-    actions = resp.json()
-    assert sorted([a["action_tag"] for a in actions]) == ["devtest", "flowstate"]
+    infos = resp.json()
+    assert sorted(infos.keys()) == ["devtest", "flowstate"]
 
 
 def test_powered_by_jbi(exclude_middleware, anon_client):

--- a/tests/unit/app/test_api.py
+++ b/tests/unit/app/test_api.py
@@ -50,9 +50,9 @@ def test_request_summary_is_logged(caplog):
 
 def test_whiteboard_tags(anon_client):
     resp = anon_client.get("/whiteboard_tags")
-    infos = resp.json()
+    actions = resp.json()
 
-    assert infos["devtest"]["description"] == "DevTest whiteboard tag"
+    assert actions[0]["description"] == "DevTest whiteboard tag"
 
 
 def test_jira_projects(anon_client, mocked_jira):
@@ -66,12 +66,12 @@ def test_jira_projects(anon_client, mocked_jira):
 
 def test_whiteboard_tags_filtered(anon_client):
     resp = anon_client.get("/whiteboard_tags/?whiteboard_tag=devtest")
-    infos = resp.json()
-    assert sorted(infos.keys()) == ["devtest"]
+    actions = resp.json()
+    assert sorted([a["action_tag"] for a in actions]) == ["devtest"]
 
     resp = anon_client.get("/whiteboard_tags/?whiteboard_tag=foo")
-    infos = resp.json()
-    assert sorted(infos.keys()) == ["devtest", "flowstate"]
+    actions = resp.json()
+    assert sorted([a["action_tag"] for a in actions]) == ["devtest", "flowstate"]
 
 
 def test_powered_by_jbi(exclude_middleware, anon_client):

--- a/tests/unit/app/test_configuration.py
+++ b/tests/unit/app/test_configuration.py
@@ -15,8 +15,8 @@ def test_mock_jbi_files():
 
 
 def test_actual_jbi_files():
-    jbi_map = configuration.get_actions()
-    assert jbi_map
+    assert configuration.get_actions(jbi_config_file="config/config.nonprod.yaml")
+    assert configuration.get_actions(jbi_config_file="config/config.prod.yaml")
 
 
 def test_no_actions_fails():

--- a/tests/unit/app/test_configuration.py
+++ b/tests/unit/app/test_configuration.py
@@ -35,3 +35,21 @@ def test_bad_module_fails():
     with pytest.raises(ValueError) as exc_info:
         Actions.parse_obj([{"action_tag": "x", "module": "src.jbi.runner"}])
     assert "action is not properly setup" in str(exc_info.value)
+
+
+def test_duplicated_action_tag_fails():
+    action = {
+        "action_tag": "x",
+        "contact": "tbd",
+        "description": "foo",
+        "module": "tests.unit.jbi.noop_action",
+    }
+    with pytest.raises(ValueError) as exc_info:
+        Actions.parse_obj(
+            [
+                action,
+                {**action, "action_tag": "y"},
+                action,
+            ]
+        )
+    assert "actions have duplicated lookup tags: ['x']" in str(exc_info.value)

--- a/tests/unit/app/test_configuration.py
+++ b/tests/unit/app/test_configuration.py
@@ -21,17 +21,17 @@ def test_actual_jbi_files():
 
 def test_no_actions_fails():
     with pytest.raises(ValueError) as exc_info:
-        Actions.parse_obj({})
+        Actions.parse_obj([])
     assert "no actions configured" in str(exc_info.value)
 
 
 def test_unknown_module_fails():
     with pytest.raises(ValueError) as exc_info:
-        Actions.parse_obj({"x": {"action": "path.to.unknown"}})
-    assert "unknown action `path.to.unknown`" in str(exc_info.value)
+        Actions.parse_obj([{"action_tag": "x", "module": "path.to.unknown"}])
+    assert "unknown Python module `path.to.unknown`" in str(exc_info.value)
 
 
 def test_bad_module_fails():
     with pytest.raises(ValueError) as exc_info:
-        Actions.parse_obj({"x": {"action": "src.jbi.runner"}})
+        Actions.parse_obj([{"action_tag": "x", "module": "src.jbi.runner"}])
     assert "action is not properly setup" in str(exc_info.value)

--- a/tests/unit/app/test_configuration.py
+++ b/tests/unit/app/test_configuration.py
@@ -27,19 +27,19 @@ def test_no_actions_fails():
 
 def test_unknown_module_fails():
     with pytest.raises(ValueError) as exc_info:
-        Actions.parse_obj([{"action_tag": "x", "module": "path.to.unknown"}])
+        Actions.parse_obj([{"whiteboard_tag": "x", "module": "path.to.unknown"}])
     assert "unknown Python module `path.to.unknown`" in str(exc_info.value)
 
 
 def test_bad_module_fails():
     with pytest.raises(ValueError) as exc_info:
-        Actions.parse_obj([{"action_tag": "x", "module": "src.jbi.runner"}])
+        Actions.parse_obj([{"whiteboard_tag": "x", "module": "src.jbi.runner"}])
     assert "action is not properly setup" in str(exc_info.value)
 
 
-def test_duplicated_action_tag_fails():
+def test_duplicated_whiteboard_tag_fails():
     action = {
-        "action_tag": "x",
+        "whiteboard_tag": "x",
         "contact": "tbd",
         "description": "foo",
         "module": "tests.unit.jbi.noop_action",
@@ -48,7 +48,7 @@ def test_duplicated_action_tag_fails():
         Actions.parse_obj(
             [
                 action,
-                {**action, "action_tag": "y"},
+                {**action, "whiteboard_tag": "y"},
                 action,
             ]
         )

--- a/tests/unit/app/test_configuration.py
+++ b/tests/unit/app/test_configuration.py
@@ -22,7 +22,7 @@ def test_actual_jbi_files():
 def test_no_actions_fails():
     with pytest.raises(ValueError) as exc_info:
         Actions.parse_obj([])
-    assert "no actions configured" in str(exc_info.value)
+    assert "ensure this value has at least 1 items" in str(exc_info.value)
 
 
 def test_unknown_module_fails():

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -171,7 +171,7 @@ def actions_example() -> Actions:
     return Actions.parse_obj(
         [
             {
-                "action_tag": "devtest",
+                "whiteboard_tag": "devtest",
                 "contact": "contact@corp.com",
                 "description": "test config",
                 "module": "tests.unit.jbi.noop_action",

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -169,14 +169,12 @@ def webhook_modify_private_example(
 @pytest.fixture
 def actions_example() -> Actions:
     return Actions.parse_obj(
-        {
-            "devtest": {
-                "action": "tests.unit.jbi.noop_action",
-                "contact": "tbd",
+        [
+            {
+                "action_tag": "devtest",
+                "contact": "contact@corp.com",
                 "description": "test config",
-                "parameters": {
-                    "whiteboard_tag": "devtest",
-                },
+                "module": "tests.unit.jbi.noop_action",
             }
-        }
+        ]
     )

--- a/tests/unit/jbi/test_bugzilla.py
+++ b/tests/unit/jbi/test_bugzilla.py
@@ -59,8 +59,8 @@ def test_lookup_action(actions_example):
     bug = bugzilla.BugzillaBug.parse_obj(
         {"id": 1234, "whiteboard": "[example][DevTest]"}
     )
-    tag, action = bug.lookup_action(actions_example)
-    assert tag == "devtest"
+    action = bug.lookup_action(actions_example)
+    assert action.action_tag == "devtest"
     assert "test config" in action.description
 
 

--- a/tests/unit/jbi/test_bugzilla.py
+++ b/tests/unit/jbi/test_bugzilla.py
@@ -60,7 +60,7 @@ def test_lookup_action(actions_example):
         {"id": 1234, "whiteboard": "[example][DevTest]"}
     )
     action = bug.lookup_action(actions_example)
-    assert action.action_tag == "devtest"
+    assert action.whiteboard_tag == "devtest"
     assert "test config" in action.description
 
 

--- a/tests/unit/jbi/whiteboard_actions/test_default.py
+++ b/tests/unit/jbi/whiteboard_actions/test_default.py
@@ -18,7 +18,7 @@ def test_default_invalid_init():
 
 
 def test_default_returns_callable_without_data(mocked_bugzilla, mocked_jira):
-    callable_object = default.init(whiteboard_tag="", jira_project_key="")
+    callable_object = default.init(jira_project_key="")
     assert callable_object
     with pytest.raises(TypeError) as exc_info:
         assert callable_object()
@@ -27,7 +27,7 @@ def test_default_returns_callable_without_data(mocked_bugzilla, mocked_jira):
 
 
 def test_default_returns_callable_with_data(webhook_create_example, mocked_jira):
-    callable_object = default.init(whiteboard_tag="", jira_project_key="")
+    callable_object = default.init(jira_project_key="")
 
     value = callable_object(payload=webhook_create_example)
 
@@ -35,7 +35,7 @@ def test_default_returns_callable_with_data(webhook_create_example, mocked_jira)
 
 
 def test_created_public(webhook_create_example: BugzillaWebhookRequest, mocked_jira):
-    callable_object = default.init(whiteboard_tag="", jira_project_key="JBI")
+    callable_object = default.init(jira_project_key="JBI")
 
     value = callable_object(payload=webhook_create_example)
 
@@ -54,7 +54,7 @@ def test_created_public(webhook_create_example: BugzillaWebhookRequest, mocked_j
 def test_created_private(
     webhook_create_private_example: BugzillaWebhookRequest, mocked_jira
 ):
-    callable_object = default.init(whiteboard_tag="", jira_project_key="JBI")
+    callable_object = default.init(jira_project_key="JBI")
 
     value = callable_object(payload=webhook_create_private_example)
 
@@ -72,7 +72,7 @@ def test_created_private(
 
 def test_modified_public(webhook_modify_example: BugzillaWebhookRequest, mocked_jira):
     assert webhook_modify_example.bug
-    callable_object = default.init(whiteboard_tag="", jira_project_key="")
+    callable_object = default.init(jira_project_key="")
 
     value = callable_object(payload=webhook_modify_example)
 
@@ -88,7 +88,7 @@ def test_modified_public(webhook_modify_example: BugzillaWebhookRequest, mocked_
 def test_modified_private(
     webhook_modify_private_example: BugzillaWebhookRequest, mocked_jira
 ):
-    callable_object = default.init(whiteboard_tag="", jira_project_key="")
+    callable_object = default.init(jira_project_key="")
 
     value = callable_object(payload=webhook_modify_private_example)
 
@@ -101,7 +101,7 @@ def test_modified_private(
 
 def test_added_comment(webhook_comment_example: BugzillaWebhookRequest, mocked_jira):
 
-    callable_object = default.init(whiteboard_tag="", jira_project_key="")
+    callable_object = default.init(jira_project_key="")
 
     value = callable_object(payload=webhook_comment_example)
 
@@ -117,7 +117,7 @@ def test_added_comment_without_linked_issue(
 ):
     assert webhook_comment_example.bug
     webhook_comment_example.bug.see_also = []
-    callable_object = default.init(whiteboard_tag="", jira_project_key="")
+    callable_object = default.init(jira_project_key="")
 
     value = callable_object(payload=webhook_comment_example)
 
@@ -130,7 +130,7 @@ def test_jira_returns_an_error(
     mocked_jira().create_issue.return_value = [
         {"errors": ["Boom"]},
     ]
-    callable_object = default.init(whiteboard_tag="", jira_project_key="")
+    callable_object = default.init(jira_project_key="")
 
     with pytest.raises(ActionError) as exc_info:
         callable_object(payload=webhook_create_example)

--- a/tests/unit/jbi/whiteboard_actions/test_default_with_assignee_and_status.py
+++ b/tests/unit/jbi/whiteboard_actions/test_default_with_assignee_and_status.py
@@ -12,7 +12,7 @@ from src.jbi.whiteboard_actions import default_with_assignee_and_status as actio
 
 
 def test_create_with_no_assignee(webhook_create_example, mocked_jira):
-    callable_object = action.init(whiteboard_tag="", jira_project_key="JBI")
+    callable_object = action.init(jira_project_key="JBI")
     value = callable_object(payload=webhook_create_example)
 
     mocked_jira().create_issue.assert_called_once_with(
@@ -38,7 +38,7 @@ def test_create_with_assignee(webhook_create_example, mocked_jira, mocked_bugzil
         "bugs": {"654321": {"comments": [{"text": "Initial comment"}]}}
     }
 
-    callable_object = action.init(whiteboard_tag="", jira_project_key="JBI")
+    callable_object = action.init(jira_project_key="JBI")
     value = callable_object(payload=webhook_create_example)
 
     mocked_jira().create_issue.assert_called_once_with(
@@ -68,7 +68,7 @@ def test_clear_assignee(webhook_create_example, mocked_jira):
     webhook_create_example.event.action = "modify"
     webhook_create_example.event.routing_key = "bug.modify:assigned_to"
 
-    callable_object = action.init(whiteboard_tag="", jira_project_key="JBI")
+    callable_object = action.init(jira_project_key="JBI")
     value = callable_object(payload=webhook_create_example)
 
     mocked_jira().create_issue.assert_not_called()
@@ -98,7 +98,7 @@ def test_set_assignee(webhook_create_example, mocked_jira):
 
     mocked_jira().user_find_by_user_string.return_value = [{"accountId": "6254"}]
 
-    callable_object = action.init(whiteboard_tag="", jira_project_key="JBI")
+    callable_object = action.init(jira_project_key="JBI")
     value = callable_object(payload=webhook_create_example)
 
     mocked_jira().create_issue.assert_not_called()
@@ -130,7 +130,6 @@ def test_create_with_unknown_status(
     }
 
     callable_object = action.init(
-        whiteboard_tag="",
         jira_project_key="JBI",
         status_map={
             "ASSIGNED": "In Progress",
@@ -165,7 +164,6 @@ def test_create_with_known_status(webhook_create_example, mocked_jira, mocked_bu
     }
 
     callable_object = action.init(
-        whiteboard_tag="",
         jira_project_key="JBI",
         status_map={
             "ASSIGNED": "In Progress",
@@ -199,7 +197,6 @@ def test_change_to_unknown_status(webhook_create_example, mocked_jira):
     webhook_create_example.event.routing_key = "bug.modify:status"
 
     callable_object = action.init(
-        whiteboard_tag="",
         jira_project_key="JBI",
         status_map={
             "ASSIGNED": "In Progress",
@@ -231,7 +228,6 @@ def test_change_to_known_status(webhook_create_example, mocked_jira):
     webhook_create_example.event.routing_key = "bug.modify:status"
 
     callable_object = action.init(
-        whiteboard_tag="",
         jira_project_key="JBI",
         status_map={
             "ASSIGNED": "In Progress",
@@ -263,7 +259,6 @@ def test_change_to_known_resolution(webhook_create_example, mocked_jira):
     webhook_create_example.event.routing_key = "bug.modify:resolution"
 
     callable_object = action.init(
-        whiteboard_tag="",
         jira_project_key="JBI",
         status_map={
             "ASSIGNED": "In Progress",


### PR DESCRIPTION
Fixes #89 

I went for `action_tag` as the whiteboard tag attribute, just because we enforce key ordering in the YAML file and it's more obvious to lookup actions if the field comes first. 

Alternatively, we could disable the key ordering rule and rename the field to `tag`, `whiteboard_tag`, `lookup_tag`, ...