### PR TITLE
Test build on pull requests

### DIFF
--- a/.github/workflows/build-publish.yaml
+++ b/.github/workflows/build-publish.yaml
@@ -1,6 +1,8 @@
-name: Build Docker image
+name: Build and Publish Docker image
 
 on:
+  pull_request
+
   push:
     branches:
     - main
@@ -27,13 +29,13 @@ jobs:
           fi
         env:
           version_pattern: "tags\\/v[0-9]+\\.[0-9]+\\.[0-9]+"
-  build-image:
+  build:
     runs-on: ubuntu-latest
     needs: prepare
     environment:
         name: cloudops
     outputs:
-      BUILD_TAG: ${{ steps.build-push.outputs.build-tag }}
+      BUILD_TAG: ${{ steps.build.outputs.build-tag }}
 
     steps:
       - name: Echo tag
@@ -59,9 +61,8 @@ jobs:
         with:
           images: $GITHUB_REPOSITORY
 
-
-      - name: Build and push to Docker Hub
-        id: build-push
+      - name: Build Docker image
+        id: build
         env:
           IMAGE_TAG: ${{ needs.prepare.outputs.FULL_IMAGE_TAG }}
         run: |
@@ -73,7 +74,23 @@ jobs:
             "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" > ./version.json
           docker build --file Dockerfile -t $GITHUB_REPOSITORY:$IMAGE_TAG .
           docker image tag $GITHUB_REPOSITORY:$IMAGE_TAG $GITHUB_REPOSITORY:latest
+
+  publish:
+    runs-on: ubuntu-latest
+    needs: build
+    if: ${{ !github.event.pull_request }} # Exclude pull-requests (see `on:` above)
+
+    steps:
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build Docker image
+        id: push
+        env:
+          IMAGE_TAG: ${{ needs.prepare.outputs.FULL_IMAGE_TAG }}
+        run: |
           docker push $GITHUB_REPOSITORY:$IMAGE_TAG
           docker push $GITHUB_REPOSITORY:latest
-          echo "::set-output name=build-tag::$IMAGE_TAG"
-          echo "::debug::Set the build-tag output as $IMAGE_TAG"

--- a/.github/workflows/build-publish.yaml
+++ b/.github/workflows/build-publish.yaml
@@ -90,7 +90,9 @@ jobs:
 
   publish:
     runs-on: ubuntu-latest
-    needs: build
+    needs:
+      - prepare
+      - build
     if: ${{ !github.event.pull_request }} # Exclude pull-requests (see `on:` above)
 
     steps:

--- a/.github/workflows/build-publish.yaml
+++ b/.github/workflows/build-publish.yaml
@@ -36,12 +36,9 @@ jobs:
     needs: prepare
     environment:
         name: cloudops
-    outputs:
-      BUILD_TAG: ${{ steps.build.outputs.build-tag }}
 
     steps:
-      - name: Echo tag
-        id: echotag
+      - name: Docker image tag
         env:
           IMAGE_TAG: ${{ needs.prepare.outputs.FULL_IMAGE_TAG }}
         run: |
@@ -58,13 +55,11 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Extract metadata (tags, labels) for Docker
-        id: meta
         uses: docker/metadata-action@v3
         with:
           images: $GITHUB_REPOSITORY
 
       - name: Build Docker image
-        id: build
         env:
           IMAGE_TAG: ${{ needs.prepare.outputs.FULL_IMAGE_TAG }}
         run: |
@@ -112,7 +107,6 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build Docker image
-        id: push
         env:
           IMAGE_TAG: ${{ needs.prepare.outputs.FULL_IMAGE_TAG }}
         run: |

--- a/.github/workflows/build-publish.yaml
+++ b/.github/workflows/build-publish.yaml
@@ -75,7 +75,16 @@ jobs:
             "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY" \
             "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" > ./version.json
           docker build --file Dockerfile -t $GITHUB_REPOSITORY:$IMAGE_TAG .
-          docker image tag $GITHUB_REPOSITORY:$IMAGE_TAG $GITHUB_REPOSITORY:latest
+
+      - name: Save image as artifact
+        run: |
+          docker save -o /tmp/container.tar.gz $GITHUB_REPOSITORY:$IMAGE_TAG
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: container-image
+          path: /tmp/container.tar.gz
+          retention-days: 1  # Instead of default 90 days
 
   publish:
     runs-on: ubuntu-latest
@@ -83,6 +92,15 @@ jobs:
     if: ${{ !github.event.pull_request }} # Exclude pull-requests (see `on:` above)
 
     steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: container-image
+          path: /tmp/container.tar.gz
+
+      - name: Load container from artifact
+        run: |
+          docker load -i /tmp/container.tar.gz
+
       - name: Login to Docker Hub
         uses: docker/login-action@v1
         with:
@@ -94,5 +112,6 @@ jobs:
         env:
           IMAGE_TAG: ${{ needs.prepare.outputs.FULL_IMAGE_TAG }}
         run: |
+          docker image tag $GITHUB_REPOSITORY:$IMAGE_TAG $GITHUB_REPOSITORY:latest
           docker push $GITHUB_REPOSITORY:$IMAGE_TAG
           docker push $GITHUB_REPOSITORY:latest

--- a/.github/workflows/build-publish.yaml
+++ b/.github/workflows/build-publish.yaml
@@ -77,6 +77,8 @@ jobs:
           docker build --file Dockerfile -t $GITHUB_REPOSITORY:$IMAGE_TAG .
 
       - name: Save image as artifact
+        env:
+          IMAGE_TAG: ${{ needs.prepare.outputs.FULL_IMAGE_TAG }}
         run: |
           docker save -o /tmp/container.tar.gz $GITHUB_REPOSITORY:$IMAGE_TAG
 

--- a/.github/workflows/build-publish.yaml
+++ b/.github/workflows/build-publish.yaml
@@ -1,7 +1,9 @@
 name: Build and Publish Docker image
 
 on:
-  pull_request
+  pull_request:
+    branches:
+    - main
 
   push:
     branches:


### PR DESCRIPTION
Since #88 we don't build the container images anymore. 

The problem with this, is that we discover container issues only when we push tags.

This pull-request is an attempt to improve that, by building the container on each pull-request. 
I tried to reuse the existing Github Action, and executing the `publish` step only on main branch and tags. I'm not sure how to test that though.