### PR TITLE
Tidy up FastAPI route functions

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -470,14 +470,6 @@ signals = ["blinker (>=1.4.0)"]
 signedtoken = ["cryptography (>=3.0.0)", "pyjwt (>=2.0.0,<3)"]
 
 [[package]]
-name = "orjson"
-version = "3.7.7"
-description = "Fast, correct Python JSON library supporting dataclasses, datetimes, and numpy"
-category = "main"
-optional = false
-python-versions = ">=3.7"
-
-[[package]]
 name = "packaging"
 version = "21.3"
 description = "Core utilities for Python packages"
@@ -1010,7 +1002,7 @@ pyyaml = "*"
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.8, <3.11"
-content-hash = "4b744e087bbe3f83bc53d24a9f31791317f0c78eb65ee35a798453ea8b7684a8"
+content-hash = "f1728733a7f204817dc6eea1b62b2d968f019ae78601021dd1ecaf119ffa1a2b"
 
 [metadata.files]
 anyio = [
@@ -1353,46 +1345,6 @@ nodeenv = [
 oauthlib = [
     {file = "oauthlib-3.2.0-py3-none-any.whl", hash = "sha256:6db33440354787f9b7f3a6dbd4febf5d0f93758354060e802f6c06cb493022fe"},
     {file = "oauthlib-3.2.0.tar.gz", hash = "sha256:23a8208d75b902797ea29fd31fa80a15ed9dc2c6c16fe73f5d346f83f6fa27a2"},
-]
-orjson = [
-    {file = "orjson-3.7.7-cp310-cp310-macosx_10_7_x86_64.whl", hash = "sha256:092fde5b1768ca68af0d3764746e93b4b7200050fdd9c1ea044fd106e2379951"},
-    {file = "orjson-3.7.7-cp310-cp310-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:313bcab8cd59d61e12bbf76a9b5f3eaf50848e3fb370a54f712ad3e3e0a48165"},
-    {file = "orjson-3.7.7-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7f80825fa7a48c4abcd636d3c182a71ad1cb548db66b8aafad50dfd328c29ae0"},
-    {file = "orjson-3.7.7-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ead2c1dce61c2e3bad31af48c2dccbbc23c55bbe70870af437203a7c4b229bae"},
-    {file = "orjson-3.7.7-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:d8f1aa7fd08f001b5f13d0c8c862609bb7de7291b256630f97590eb7c78d2dda"},
-    {file = "orjson-3.7.7-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:6e5ea0fcf3452cd19ad34b37ca6279c4395b859c77fe1cf7e26d31a3e6ebafd5"},
-    {file = "orjson-3.7.7-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:70cffd48faafabdd7e42f35e38731c43200d525fdbabc587b1e2aa731d182f85"},
-    {file = "orjson-3.7.7-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:aee6715db93b3d743adc69f55ed20df6a782b5e354d26a7817e507e2bd6d2231"},
-    {file = "orjson-3.7.7-cp310-none-win_amd64.whl", hash = "sha256:d9af18e8200b500585627414ec7b0806b5b569a318d6c84447afb02e7eae5bfa"},
-    {file = "orjson-3.7.7-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:5c8141895c8b0a8b4d0bc1879d1c1e3ec3f7d7e29e0bd8a0146ef3f9cf13c325"},
-    {file = "orjson-3.7.7-cp37-cp37m-macosx_10_7_x86_64.whl", hash = "sha256:5f20d0d48335262ca3695f98599446bf5ca8825193d1f4bf6eb08fb0c414befa"},
-    {file = "orjson-3.7.7-cp37-cp37m-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:6fbf29bb7897d345bd0120c466cd923c70a5d661144221457cbed637f4c93d1b"},
-    {file = "orjson-3.7.7-cp37-cp37m-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2c43fd0317a7114e617f5b8aefd0d0a61b387927a1914b79ebd0d1235c658f5b"},
-    {file = "orjson-3.7.7-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fa9451779dba8546962bc02ce2aeed9de6e069f7101f8db2784beaf71ede4dd0"},
-    {file = "orjson-3.7.7-cp37-cp37m-manylinux_2_28_aarch64.whl", hash = "sha256:e8bfad95df150d95ca67a4484d9f56e2bd0a932a5eb4635bbb5cd45130ca9251"},
-    {file = "orjson-3.7.7-cp37-cp37m-manylinux_2_28_x86_64.whl", hash = "sha256:ce3acc906a6aa7923bc7c78472196b2b7cf7c160aff01946984d51fcde9e9483"},
-    {file = "orjson-3.7.7-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:c1e8489d50bb0cffb5ccb70c3459f79dee1aeb997abfd97751d3862b32bce412"},
-    {file = "orjson-3.7.7-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:891c0f2cb44beafa911cf7e15165dee8b8acaa5b48a75abaf37d529e1de68344"},
-    {file = "orjson-3.7.7-cp37-none-win_amd64.whl", hash = "sha256:6a743e05de78758f9ff81a4e705e6226b06a5f8abba63b39cb0f56926c2045c5"},
-    {file = "orjson-3.7.7-cp38-cp38-macosx_10_7_x86_64.whl", hash = "sha256:b6a6d00e917e1844d3a9b6ed68d31f824d98e1e4a3578618dd146db58b5d901b"},
-    {file = "orjson-3.7.7-cp38-cp38-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:3e9b1f19b408199af4d4ad590f6935ba77342a3fe1d64cbbfe428025a03a2405"},
-    {file = "orjson-3.7.7-cp38-cp38-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6340e57fece4fa0eebd1e5c48e2c844b329491d97bfe6843149eb45365ff837a"},
-    {file = "orjson-3.7.7-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5ff90b571023787dcbb504a1695ad137149df30d213128b1aa02fc82dd12a526"},
-    {file = "orjson-3.7.7-cp38-cp38-manylinux_2_28_aarch64.whl", hash = "sha256:ea3eaa8823bbbaae7af9669ca68b0e0bd794ee0938900d73f5f321fb13bb5ab5"},
-    {file = "orjson-3.7.7-cp38-cp38-manylinux_2_28_x86_64.whl", hash = "sha256:8da26f1fd335e466e79779571326679b179bb7cf3cce9750bf9c1077e9298a6f"},
-    {file = "orjson-3.7.7-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:3f9fbf760c6612d08a4ea873e4fab1e657f826834deda58c2ba1406ef150b1b6"},
-    {file = "orjson-3.7.7-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:ee2cd3ac6283832d93085910df8367a469bd9dbfafeb8d4dc8c5cc8648bf965c"},
-    {file = "orjson-3.7.7-cp38-none-win_amd64.whl", hash = "sha256:0033c7279f0ffa2720d72a6234a1d22c86c13bf5217a99c5ba523a0aebb27b75"},
-    {file = "orjson-3.7.7-cp39-cp39-macosx_10_7_x86_64.whl", hash = "sha256:559f40a91bfde23137e107f2f8baaf0bef35e066d0b35dcf4e1dac8bc83a05b3"},
-    {file = "orjson-3.7.7-cp39-cp39-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:9f7f420ab7efde90c7277e92dccf217b4bac628b044fdc857888cdba23126214"},
-    {file = "orjson-3.7.7-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ba48e06659c43ed6658f203893b74b4e8392231959bcb2421fdde39eca62520c"},
-    {file = "orjson-3.7.7-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a34002a6b6eb105d3ac493368f0a8911ab8e5f005282d43cc75912bbbdf50734"},
-    {file = "orjson-3.7.7-cp39-cp39-manylinux_2_28_aarch64.whl", hash = "sha256:dbf716120886776706781c2c05ebbc254355e384bfe387b76ca07ee97da6fbfc"},
-    {file = "orjson-3.7.7-cp39-cp39-manylinux_2_28_x86_64.whl", hash = "sha256:f0c512efeee1fb94426b1e4c64f07c4af5eec08b96cf4835c3a05ad395e0b83a"},
-    {file = "orjson-3.7.7-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:657ce6d735dc3a6fba5043d831e769698db849915d581dd4d1e62fcc2eaed876"},
-    {file = "orjson-3.7.7-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:8c30ad18fad795690527b030cfed3e8402ebe3a15e7a1a779a00acc0b3587e89"},
-    {file = "orjson-3.7.7-cp39-none-win_amd64.whl", hash = "sha256:ea0f6da9089e155acf234c0cd0883f84812547174be8d0fef478bce2b00bd6f9"},
-    {file = "orjson-3.7.7.tar.gz", hash = "sha256:2850cf49537c246000f5f89555d6fb7042bb4612214605a60bea89cbe0add213"},
 ]
 packaging = [
     {file = "packaging-21.3-py3-none-any.whl", hash = "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,6 @@ dockerflow = "2022.1.0"
 Jinja2 = "^3.0.3"
 pydantic-yaml = {extras = ["pyyaml","ruamel"], version = "^0.6.1"}
 sentry-sdk = "^1.5.7"
-orjson = "^3.7.7"
 
 
 [tool.poetry.dev-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,7 @@ python_version = "3.10"
 warn_return_any = true
 
 [[tool.mypy.overrides]]
-module = ["ruamel"]
+module = ["ruamel", "bugzilla", "atlassian"]
 ignore_missing_imports = true
 
 [tool.coverage]

--- a/src/app/api.py
+++ b/src/app/api.py
@@ -11,7 +11,7 @@ import sentry_sdk
 import uvicorn  # type: ignore
 from fastapi import Body, Depends, FastAPI, Request
 from fastapi.encoders import jsonable_encoder
-from fastapi.responses import HTMLResponse, ORJSONResponse
+from fastapi.responses import HTMLResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 from sentry_sdk.integrations.asgi import SentryAsgiMiddleware
@@ -49,7 +49,7 @@ app.add_middleware(SentryAsgiMiddleware)
 
 
 @app.get("/", include_in_schema=False)
-def root(request: Request):
+def root():
     """Expose key configuration"""
     return {
         "title": app.title,
@@ -98,9 +98,9 @@ def bugzilla_webhook(
     """API endpoint that Bugzilla Webhook Events request"""
     try:
         result = execute_action(request, actions, settings)
-        return ORJSONResponse(content=result, status_code=200)
+        return result
     except IgnoreInvalidRequestError as exception:
-        return ORJSONResponse(content={"error": str(exception)}, status_code=200)
+        return {"error": str(exception)}
 
 
 @app.get("/whiteboard_tags/")

--- a/src/app/monitor.py
+++ b/src/app/monitor.py
@@ -1,8 +1,6 @@
 """
 Router dedicated to Dockerflow APIs
 """
-from typing import Dict
-
 from fastapi import APIRouter, Response
 
 from src.app import environment
@@ -15,12 +13,10 @@ api_router = APIRouter(tags=["Monitor"])
 @api_router.head("/__heartbeat__")
 def heartbeat(response: Response):
     """Return status of backing services, as required by Dockerflow."""
-    data: Dict = {**jbi_service_health_map()}
-    for _, health in data.items():
-        if not health.get("up"):
-            response.status_code = 503
-            break
-    return data
+    health_map = jbi_service_health_map()
+    if not all(health["up"] for health in health_map.values()):
+        response.status_code = 503
+    return health_map
 
 
 @api_router.get("/__lbheartbeat__")

--- a/src/app/monitor.py
+++ b/src/app/monitor.py
@@ -3,8 +3,7 @@ Router dedicated to Dockerflow APIs
 """
 from typing import Dict
 
-from fastapi import APIRouter, Depends, Request
-from fastapi.responses import ORJSONResponse
+from fastapi import APIRouter, Response
 
 from src.app import environment
 from src.jbi.services import jbi_service_health_map
@@ -12,50 +11,23 @@ from src.jbi.services import jbi_service_health_map
 api_router = APIRouter(tags=["Monitor"])
 
 
-def heartbeat(request: Request, settings: environment.Settings):
+@api_router.get("/__heartbeat__")
+@api_router.head("/__heartbeat__")
+def heartbeat(response: Response):
     """Return status of backing services, as required by Dockerflow."""
     data: Dict = {**jbi_service_health_map()}
-    status_code = 200
     for _, health in data.items():
         if not health.get("up"):
-            status_code = 503
-
-    return ORJSONResponse(content=data, status_code=status_code)
-
-
-@api_router.get("/__heartbeat__")
-def get_heartbeat(
-    request: Request,
-    settings: environment.Settings = Depends(environment.get_settings),
-):
-    """Dockerflow API for heartbeat: GET"""
-    return heartbeat(request, settings)
-
-
-@api_router.head("/__heartbeat__")
-def head_heartbeat(
-    request: Request,
-    settings: environment.Settings = Depends(environment.get_settings),
-):
-    """Dockerflow API for heartbeat: HEAD"""
-    return heartbeat(request, settings)
-
-
-def lbheartbeat(request: Request):
-    """Return response when application is running, as required by Dockerflow."""
-    return {"status": "OK"}
+            response.status_code = 503
+            break
+    return data
 
 
 @api_router.get("/__lbheartbeat__")
-def get_lbheartbeat(request: Request):
-    """Dockerflow API for lbheartbeat: GET"""
-    return lbheartbeat(request)
-
-
 @api_router.head("/__lbheartbeat__")
-def head_lbheartbeat(request: Request):
+def lbheartbeat():
     """Dockerflow API for lbheartbeat: HEAD"""
-    return lbheartbeat(request)
+    return {"status": "OK"}
 
 
 @api_router.get("/__version__")

--- a/src/jbi/services.py
+++ b/src/jbi/services.py
@@ -1,6 +1,6 @@
 """Services and functions that can be used to create custom actions"""
-import bugzilla as rh_bugzilla  # type: ignore
-from atlassian import Jira  # type: ignore
+import bugzilla as rh_bugzilla
+from atlassian import Jira
 
 from src.app import environment
 

--- a/src/jbi/services.py
+++ b/src/jbi/services.py
@@ -1,10 +1,15 @@
 """Services and functions that can be used to create custom actions"""
+from typing import TypedDict
+
 import bugzilla as rh_bugzilla
 from atlassian import Jira
 
 from src.app import environment
 
 settings = environment.get_settings()
+
+
+ServiceHealth = TypedDict("ServiceHealth", {"up": bool})
 
 
 def get_jira():
@@ -24,18 +29,18 @@ def get_bugzilla():
     )
 
 
-def bugzilla_check_health():
+def bugzilla_check_health() -> ServiceHealth:
     """Check health for Bugzilla Service"""
     bugzilla = get_bugzilla()
-    health = {"up": bugzilla.logged_in}
+    health: ServiceHealth = {"up": bugzilla.logged_in}
     return health
 
 
-def jira_check_health():
+def jira_check_health() -> ServiceHealth:
     """Check health for Jira Service"""
     jira = get_jira()
     server_info = jira.get_server_info(True)
-    health = {"up": server_info is not None}
+    health: ServiceHealth = {"up": server_info is not None}
     return health
 
 


### PR DESCRIPTION
In this PR, we:
* return objects directly instead of wrapping in response classes
FastAPI will automatically encode objects as JSON when they are returned
directly ([docs](https://fastapi.tiangolo.com/advanced/response-directly/?h=jsonable#return-a-response-directly))*

* use multiple route decorators for monitor functions with the same response
* remove extraneous route function parameters

*@Mossop, I believe this also means we can remove `orjson` (and revert #86)