### PR TITLE
Refactor Docker build and push jobs

### DIFF
--- a/.github/workflows/build-publish.yaml
+++ b/.github/workflows/build-publish.yaml
@@ -57,12 +57,12 @@ jobs:
 
       - name: Save image as artifact
         run: |
-          docker save -o /tmp/container-$IMAGE_TAG.tar.gz $GITHUB_REPOSITORY:$IMAGE_TAG
+          docker save -o /tmp/container-$GITHUB_HEAD_REF.tar.gz $GITHUB_REPOSITORY:$IMAGE_TAG
 
       - uses: actions/upload-artifact@v3
         with:
           name: container-image
-          path: /tmp/container-${{ env.IMAGE_TAG }}.tar.gz
+          path: /tmp/container-${{ env.GITHUB_HEAD_REF }}.tar.gz
           retention-days: 7 # Instead of default 90 days
 
   publish:
@@ -78,11 +78,11 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           name: container-image
-          path: /tmp/container-${{ env.IMAGE_TAG }}.tar.gz
+          path: /tmp/container-${{ env.GITHUB_HEAD_REF }}.tar.gz
 
       - name: Load container from artifact
         run: |
-          docker load -i /tmp/container-$IMAGE_TAG.tar.gz
+          docker load -i /tmp/container-$GITHUB_HEAD_REF.tar.gz
 
       - name: Login to Docker Hub
         uses: docker/login-action@v1

--- a/.github/workflows/build-publish.yaml
+++ b/.github/workflows/build-publish.yaml
@@ -62,7 +62,7 @@ jobs:
       - uses: actions/upload-artifact@v3
         with:
           name: container-image
-          path: /tmp/container-$IMAGE_TAG.tar.gz
+          path: /tmp/container-${{ env.IMAGE_TAG }}.tar.gz
           retention-days: 7 # Instead of default 90 days
 
   publish:
@@ -78,7 +78,7 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           name: container-image
-          path: /tmp/container-$IMAGE_TAG.tar.gz
+          path: /tmp/container-${{ env.IMAGE_TAG }}.tar.gz
 
       - name: Load container from artifact
         run: |
@@ -90,9 +90,7 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Build Docker image
-        env:
-          IMAGE_TAG: ${{ needs.prepare.outputs.FULL_IMAGE_TAG }}
+      - name: Publish Docker image
         run: |
           docker image tag $GITHUB_REPOSITORY:$IMAGE_TAG $GITHUB_REPOSITORY:latest
           docker push $GITHUB_REPOSITORY:$IMAGE_TAG

--- a/.github/workflows/build-publish.yaml
+++ b/.github/workflows/build-publish.yaml
@@ -3,13 +3,13 @@ name: Build and Publish Docker image
 on:
   pull_request:
     branches:
-    - main
+      - main
 
   push:
     branches:
-    - main
+      - main
     tags:
-    - v[0-9]+.[0-9]+.[0-9]+
+      - v[0-9]+.[0-9]+.[0-9]+
 
 jobs:
   prepare:
@@ -34,13 +34,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     needs: prepare
-    environment:
-        name: cloudops
-
+    env:
+      IMAGE_TAG: ${{ needs.prepare.outputs.FULL_IMAGE_TAG }}
     steps:
       - name: Docker image tag
-        env:
-          IMAGE_TAG: ${{ needs.prepare.outputs.FULL_IMAGE_TAG }}
         run: |
           echo "Building an image with the following tag:"
           echo $IMAGE_TAG
@@ -48,20 +45,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Login to Docker Hub
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Extract metadata (tags, labels) for Docker
-        uses: docker/metadata-action@v3
-        with:
-          images: $GITHUB_REPOSITORY
-
       - name: Build Docker image
-        env:
-          IMAGE_TAG: ${{ needs.prepare.outputs.FULL_IMAGE_TAG }}
         run: |
           printf '{\n    "commit": "%s",\n    "version": "%s",\n    "image_tag": "%s",\n    "source": "%s",\n    "build": "%s"\n}\n' \
             "$GITHUB_SHA" \
@@ -72,33 +56,33 @@ jobs:
           docker build --file Dockerfile -t $GITHUB_REPOSITORY:$IMAGE_TAG .
 
       - name: Save image as artifact
-        env:
-          IMAGE_TAG: ${{ needs.prepare.outputs.FULL_IMAGE_TAG }}
         run: |
-          docker save -o /tmp/container.tar.gz $GITHUB_REPOSITORY:$IMAGE_TAG
+          docker save -o /tmp/container-$IMAGE_TAG.tar.gz $GITHUB_REPOSITORY:$IMAGE_TAG
 
       - uses: actions/upload-artifact@v3
         with:
           name: container-image
-          path: /tmp/container.tar.gz
-          retention-days: 1  # Instead of default 90 days
+          path: /tmp/container-$IMAGE_TAG.tar.gz
+          retention-days: 7 # Instead of default 90 days
 
   publish:
     runs-on: ubuntu-latest
     needs:
       - prepare
       - build
+    env:
+      IMAGE_TAG: ${{ needs.prepare.outputs.FULL_IMAGE_TAG }}
     if: ${{ !github.event.pull_request }} # Exclude pull-requests (see `on:` above)
 
     steps:
       - uses: actions/download-artifact@v3
         with:
           name: container-image
-          path: /tmp/container.tar.gz
+          path: /tmp/container-$IMAGE_TAG.tar.gz
 
       - name: Load container from artifact
         run: |
-          docker load -i /tmp/container.tar.gz
+          docker load -i /tmp/container-$IMAGE_TAG.tar.gz
 
       - name: Login to Docker Hub
         uses: docker/login-action@v1


### PR DESCRIPTION
- remove login for build step since it was blocking CI passing for dependabot
  PRs
- remove `cloudops` key environment since we don't use Actions deployment
  environments
- remove `medatadata-action` since we weren't using any of its output
- save built images with a filepath that includes the commit SHA to
  prevent overwriting
- save containers for 7 days to prevent the container being deleted
  before a PR is merged