### PR TITLE
Updating dev tag--test flowstate with JST project

### DIFF
--- a/config/config.nonprod.yaml
+++ b/config/config.nonprod.yaml
@@ -1,11 +1,17 @@
 ---
 # Action Config
 - whiteboard_tag: devtest
-  contact: tbd
-  description: DevTest whiteboard tag
+  allow_private: true
+  contact: dtownsend@mozilla.com
+  description: Flowstate whiteboard tag
   enabled: true
+  module: src.jbi.whiteboard_actions.default_with_assignee_and_status
   parameters:
     jira_project_key: JST
+    status_map:
+      ASSIGNED: In Progress
+      FIXED: In Review
+      REOPENED: In Progress
 
 - whiteboard_tag: flowstate
   allow_private: true


### PR DESCRIPTION
Since the Jira Prod and Nonprod do not match; there are projects that don't exist in staging.

Potentially, we can use the JST environment and test the new extended action to unblock progress on this?