### PR TITLE
Rewrite build-publish workflow to use mainly Docker actions

### DIFF
--- a/.github/workflows/build-publish.yaml
+++ b/.github/workflows/build-publish.yaml
@@ -3,113 +3,49 @@ name: Build and Publish Docker image
 on:
   pull_request:
     branches:
-    - main
-
+      - main
   push:
     branches:
-    - main
+      - main
     tags:
-    - v[0-9]+.[0-9]+.[0-9]+
+      - v[0-9]+.[0-9]+.[0-9]+
 
 jobs:
-  prepare:
+  build-and-publish:
     runs-on: ubuntu-latest
-    outputs:
-      FULL_IMAGE_TAG: ${{ steps.tag.outputs.tag }}
     steps:
-      - name: Set Tag
-        id: tag
+      - name: Check out the repo
+        uses: actions/checkout@v3
+
+      - name: Build `version.json` file
         run: |
-          export CI_COMMIT_SHORT_SHA=$(echo $GITHUB_SHA | cut -c1-8)
-          echo $CI_COMMIT_SHORT_SHA;
-          echo ${GITHUB_REF##*/};
-          echo $version_pattern;
-          if [[ ${GITHUB_REF} =~ $version_pattern ]]; then
-            echo "::set-output name=tag::${GITHUB_REF##*/}"
-          else
-            echo "::set-output name=tag::${GITHUB_REF##*/}-$CI_COMMIT_SHORT_SHA"
-          fi
-        env:
-          version_pattern: "tags\\/v[0-9]+\\.[0-9]+\\.[0-9]+"
-  build:
-    runs-on: ubuntu-latest
-    needs: prepare
-    environment:
-        name: cloudops
-
-    steps:
-      - name: Docker image tag
-        env:
-          IMAGE_TAG: ${{ needs.prepare.outputs.FULL_IMAGE_TAG }}
-        run: |
-          echo "Building an image with the following tag:"
-          echo $IMAGE_TAG
-
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Extract metadata (tags, labels) for Docker
-        uses: docker/metadata-action@v3
-        with:
-          images: $GITHUB_REPOSITORY
-
-      - name: Build Docker image
-        env:
-          IMAGE_TAG: ${{ needs.prepare.outputs.FULL_IMAGE_TAG }}
-        run: |
-          printf '{\n    "commit": "%s",\n    "version": "%s",\n    "image_tag": "%s",\n    "source": "%s",\n    "build": "%s"\n}\n' \
+          printf '{\n    "commit": "%s",\n    "version": "%s",\n    "source": "%s",\n    "build": "%s"\n}\n' \
             "$GITHUB_SHA" \
             "$GITHUB_REF" \
-            "$IMAGE_TAG" \
             "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY" \
             "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" > ./version.json
-          docker build --file Dockerfile -t $GITHUB_REPOSITORY:$IMAGE_TAG .
 
-      - name: Save image as artifact
-        env:
-          IMAGE_TAG: ${{ needs.prepare.outputs.FULL_IMAGE_TAG }}
-        run: |
-          docker save -o /tmp/container.tar.gz $GITHUB_REPOSITORY:$IMAGE_TAG
-
-      - uses: actions/upload-artifact@v3
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4
         with:
-          name: container-image
-          path: /tmp/container.tar.gz
-          retention-days: 1  # Instead of default 90 days
-
-  publish:
-    runs-on: ubuntu-latest
-    needs:
-      - prepare
-      - build
-    if: ${{ !github.event.pull_request }} # Exclude pull-requests (see `on:` above)
-
-    steps:
-      - uses: actions/download-artifact@v3
-        with:
-          name: container-image
-          path: /tmp/container.tar.gz
-
-      - name: Load container from artifact
-        run: |
-          docker load -i /tmp/container.tar.gz
+          images: $GITHUB_REPOSITORY
+          # https://github.com/marketplace/actions/docker-metadata-action#tags-input
+          tags: |
+            type=semver,pattern={{version}}
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=sha,enable={{is_default_branch}}
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v1
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Build Docker image
-        env:
-          IMAGE_TAG: ${{ needs.prepare.outputs.FULL_IMAGE_TAG }}
-        run: |
-          docker image tag $GITHUB_REPOSITORY:$IMAGE_TAG $GITHUB_REPOSITORY:latest
-          docker push $GITHUB_REPOSITORY:$IMAGE_TAG
-          docker push $GITHUB_REPOSITORY:latest
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
This PR rewrites the `build-publish` workflow to mainly use:
- https://github.com/marketplace/actions/docker-metadata-action
- https://github.com/marketplace/actions/build-and-push-docker-images

As a result of this PR, the following should be true:
- the image is built on every PR (as a CI check)
- the image is published in this way:

| Event             | Tags                        |
|-------------------|-----------------------------|
| push tag vX.Y.Z   | `latest`, `X.Y.Z`           |
| PR merged to main | `latest`, `sha-<short sha>` |