### PR TITLE
Add local config for tests (fixes #121)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 # Environment variables for the local development environment
 
-ENV=nonprod
+ENV=local
 
 # Jira API Secrets
 JIRA_USERNAME="fake_jira_username"

--- a/config/config.local.yaml
+++ b/config/config.local.yaml
@@ -1,0 +1,8 @@
+---
+# Action Config
+- whiteboard_tag: devtest
+  contact: tbd
+  description: DevTest whiteboard tag
+  enabled: true
+  parameters:
+    jira_project_key: DevTest

--- a/config/config.nonprod.yaml
+++ b/config/config.nonprod.yaml
@@ -1,11 +1,11 @@
 ---
 # Action Config
-- whiteboard_tag: jst
+- whiteboard_tag: nonprodtest
   contact: bsieber@mozilla.com
-  description: What does JST mean?
+  description: Nonprod testing whiteboard tag
   enabled: true
   parameters:
-    jira_project_key: JST
+    jira_project_key: OSS
 
 - whiteboard_tag: flowstate
   allow_private: true

--- a/config/config.nonprod.yaml
+++ b/config/config.nonprod.yaml
@@ -1,8 +1,8 @@
 ---
 # Action Config
-- whiteboard_tag: devtest
-  contact: tbd
-  description: DevTest whiteboard tag
+- whiteboard_tag: jst
+  contact: bsieber@mozilla.com
+  description: What does JST mean?
   enabled: true
   parameters:
     jira_project_key: JST

--- a/tests/unit/app/test_api.py
+++ b/tests/unit/app/test_api.py
@@ -71,7 +71,7 @@ def test_whiteboard_tags_filtered(anon_client):
 
     resp = anon_client.get("/whiteboard_tags/?whiteboard_tag=foo")
     infos = resp.json()
-    assert sorted(infos.keys()) == ["devtest", "flowstate"]
+    assert sorted(infos.keys()) == ["devtest"]
 
 
 def test_powered_by_jbi(exclude_middleware, anon_client):

--- a/tests/unit/app/test_monitor.py
+++ b/tests/unit/app/test_monitor.py
@@ -65,7 +65,7 @@ def test_read_heartbeat_bugzilla_services_fails(
     """/__heartbeat__ returns 503 when one service is unavailable."""
     mocked_bugzilla().logged_in = False
     mocked_jira().get_server_info.return_value = {}
-    mocked_jira().projects.return_value = [{"key": "MR2"}, {"key": "JST"}]
+    mocked_jira().projects.return_value = [{"key": "DevTest"}]
 
     resp = anon_client.get("/__heartbeat__")
 
@@ -85,7 +85,7 @@ def test_read_heartbeat_success(anon_client, mocked_jira, mocked_bugzilla):
     """/__heartbeat__ returns 200 when checks succeed."""
     mocked_bugzilla().logged_in = True
     mocked_jira().get_server_info.return_value = {}
-    mocked_jira().projects.return_value = [{"key": "MR2"}, {"key": "JST"}]
+    mocked_jira().projects.return_value = [{"key": "DevTest"}]
 
     resp = anon_client.get("/__heartbeat__")
 
@@ -124,7 +124,7 @@ def test_head_heartbeat(anon_client, mocked_jira, mocked_bugzilla):
     """/__heartbeat__ support head requests"""
     mocked_bugzilla().logged_in = True
     mocked_jira().get_server_info.return_value = {}
-    mocked_jira().projects.return_value = [{"key": "MR2"}, {"key": "JST"}]
+    mocked_jira().projects.return_value = [{"key": "DevTest"}]
 
     resp = anon_client.head("/__heartbeat__")
 


### PR DESCRIPTION
Fixes #121

Without this, adding actions to the nonprod config would require tests to be changed.