### PR TITLE
Do not serialize raw Action objects and their callable (fixes #136, #137)

### DIFF
--- a/src/app/api.py
+++ b/src/app/api.py
@@ -10,7 +10,6 @@ from typing import Dict, List, Optional
 import sentry_sdk
 import uvicorn  # type: ignore
 from fastapi import Body, Depends, FastAPI, Request
-from fastapi.encoders import jsonable_encoder
 from fastapi.responses import HTMLResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
@@ -112,7 +111,7 @@ def get_whiteboard_tags(
     if existing := actions.get(whiteboard_tag):
         filtered = {whiteboard_tag: existing}
     else:
-        filtered = actions.by_tag
+        filtered = actions.by_tag  # type: ignore
     return {k: v.dict() for k, v in filtered.items()}
 
 

--- a/src/app/api.py
+++ b/src/app/api.py
@@ -104,14 +104,16 @@ def bugzilla_webhook(
 
 
 @app.get("/whiteboard_tags/")
-def get_whiteboard_tag(
+def get_whiteboard_tags(
     whiteboard_tag: Optional[str] = None,
     actions: Actions = Depends(configuration.get_actions),
 ):
     """API for viewing whiteboard_tags and associated data"""
     if existing := actions.get(whiteboard_tag):
-        return {whiteboard_tag: existing}
-    return actions.by_tag
+        filtered = {whiteboard_tag: existing}
+    else:
+        filtered = actions.by_tag
+    return {k: v.dict() for k, v in filtered.items()}
 
 
 @app.get("/jira_projects/")
@@ -131,7 +133,7 @@ def powered_by_jbi(
     context = {
         "request": request,
         "title": "Powered by JBI",
-        "actions": jsonable_encoder(actions),
+        "actions": [action.dict() for action in actions],
         "enable_query": enabled,
     }
     return templates.TemplateResponse("powered_by_template.html", context)

--- a/src/jbi/models.py
+++ b/src/jbi/models.py
@@ -56,6 +56,7 @@ class Action(YamlModel):
 
         extra = Extra.allow
         keep_untouched = (functools.cached_property,)
+        fields = {"callable": {"exclude": True}}
 
 
 class Actions(YamlModel):


### PR DESCRIPTION
Fixes #137
Fixes #136 

I could reproduce these issues by:

- setting up real clients (Bugzilla API key, JIRA API key) in `.env`
- running locally with `make start`
- checking that clients can connect with `http :8000/__heartbeat__`

In order to force initialization of actions on the `/whiteboard_tags/` endpoint I added this:

```diff
 app.include_router(monitor_router)
@@ -109,6 +110,9 @@ def get_whiteboard_tags(
     actions: Actions = Depends(configuration.get_actions),
 ):
     """API for viewing whiteboard_tags and associated data"""
+    for action in actions:
+        assert callable(action.callable)  # will load Python module
+
```

And then, reaching out `/whiteboard_tags/` would crash, trying to serialize:
1. the action executor class (`callable` attribute)
2. the bugzilla client
3. some internal requests/pool/socket object

I could only fix it by using `.dict(exclude={"callable"})` (or using model config and just `.dict()` as in the present patch)


I failed at reproducing the situation in a unit test (naive version below):
```diff

+def test_whiteboard_tags_with_initialized_actions(
+    anon_client, mocked_jira, webhook_create_example
+):
+    assert configuration.get_actions(), "There is at least one configured action"
+    for action in configuration.get_actions():
+        action.callable(webhook_create_example)
+
+    resp = anon_client.get("/whiteboard_tags/")
+    assert resp.status_code == 200  # not crashing :)
+
```
because the issue comes from an internal urlib object that only gets initialized when session is established