### PR TITLE
Use `exclude` keyword in dict method to exclude Action `callable` field

### DIFF
--- a/src/app/api.py
+++ b/src/app/api.py
@@ -112,7 +112,7 @@ def get_whiteboard_tags(
         filtered = {whiteboard_tag: existing}
     else:
         filtered = actions.by_tag  # type: ignore
-    return {k: v.dict() for k, v in filtered.items()}
+    return {k: v.dict(exclude={"callable"}) for k, v in filtered.items()}
 
 
 @app.get("/jira_projects/")
@@ -132,7 +132,7 @@ def powered_by_jbi(
     context = {
         "request": request,
         "title": "Powered by JBI",
-        "actions": [action.dict() for action in actions],
+        "actions": [action.dict(exclude={"callable"}) for action in actions],
         "enable_query": enabled,
     }
     return templates.TemplateResponse("powered_by_template.html", context)


### PR DESCRIPTION
As a follow-on to #139 (which addresses #136 and #137):

The model config approach we used in d46eb39 seemed to help with the `/powered_by_jbi` endpoint, but errors were still appearing in `/whiteboard_tags`.

We found that using the `action.dict(exclude=<...>)` method seemed to _actually_ exclude the `callable` field. ([pydantic docs](https://pydantic-docs.helpmanual.io/usage/exporting_models/#advanced-include-and-exclude))

It's unclear at this point why this method works and the model config approach doesn't. 