### PR TITLE
Move initialized action callable to private field

### DIFF
--- a/src/app/api.py
+++ b/src/app/api.py
@@ -10,6 +10,7 @@ from typing import Dict, List, Optional
 import sentry_sdk
 import uvicorn  # type: ignore
 from fastapi import Body, Depends, FastAPI, Request
+from fastapi.encoders import jsonable_encoder
 from fastapi.responses import HTMLResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
@@ -109,10 +110,8 @@ def get_whiteboard_tags(
 ):
     """API for viewing whiteboard_tags and associated data"""
     if existing := actions.get(whiteboard_tag):
-        filtered = {whiteboard_tag: existing}
-    else:
-        filtered = actions.by_tag  # type: ignore
-    return {k: v.dict(exclude={"callable"}) for k, v in filtered.items()}
+        return {whiteboard_tag: existing}
+    return actions.by_tag
 
 
 @app.get("/jira_projects/")
@@ -132,7 +131,7 @@ def powered_by_jbi(
     context = {
         "request": request,
         "title": "Powered by JBI",
-        "actions": [action.dict(exclude={"callable"}) for action in actions],
+        "actions": jsonable_encoder(actions),
         "enable_query": enabled,
     }
     return templates.TemplateResponse("powered_by_template.html", context)

--- a/src/jbi/models.py
+++ b/src/jbi/models.py
@@ -8,7 +8,7 @@ from inspect import signature
 from types import ModuleType
 from typing import Any, Callable, Dict, List, Literal, Mapping, Optional, Set, Union
 
-from pydantic import EmailStr, Extra, Field, root_validator, validator
+from pydantic import EmailStr, Extra, Field, PrivateAttr, root_validator, validator
 from pydantic_yaml import YamlModel
 
 
@@ -24,13 +24,18 @@ class Action(YamlModel):
     enabled: bool = False
     allow_private: bool = False
     parameters: dict = {}
+    _caller: Callable = PrivateAttr(default=None)
 
-    @functools.cached_property
-    def callable(self) -> Callable:
-        """Return the initialized callable for this action."""
+    def _initialize_caller(self):
         action_module: ModuleType = importlib.import_module(self.module)
-        initialized: Callable = action_module.init(**self.parameters)  # type: ignore
-        return initialized
+        initialized_caller: Callable = action_module.init(**self.parameters)  # type: ignore
+        self._caller = initialized_caller
+
+    def call(self, payload):
+        """Run action callable"""
+        if not self._caller:
+            self._initialize_caller()
+        return self._caller(payload)
 
     @root_validator
     def validate_action_config(cls, values):  # pylint: disable=no-self-argument
@@ -56,7 +61,6 @@ class Action(YamlModel):
 
         extra = Extra.allow
         keep_untouched = (functools.cached_property,)
-        fields = {"callable": {"exclude": True}}
 
 
 class Actions(YamlModel):

--- a/src/jbi/models.py
+++ b/src/jbi/models.py
@@ -8,7 +8,7 @@ from inspect import signature
 from types import ModuleType
 from typing import Any, Callable, Dict, List, Literal, Mapping, Optional, Set, Union
 
-from pydantic import EmailStr, Extra, Field, PrivateAttr, root_validator, validator
+from pydantic import EmailStr, Field, PrivateAttr, root_validator, validator
 from pydantic_yaml import YamlModel
 
 
@@ -55,12 +55,6 @@ class Action(YamlModel):
         except (TypeError, AttributeError) as exception:
             raise ValueError(f"action is not properly setup.{exception}") from exception
         return values
-
-    class Config:
-        """Pydantic configuration"""
-
-        extra = Extra.allow
-        keep_untouched = (functools.cached_property,)
 
 
 class Actions(YamlModel):

--- a/src/jbi/runner.py
+++ b/src/jbi/runner.py
@@ -77,7 +77,7 @@ def execute_action(
             extra={"operation": Operations.EXECUTE, **log_context},
         )
 
-        content = action.callable(payload=request)
+        content = action.call(payload=request)
 
         logger.info(
             "Action %r executed successfully for Bug %s",

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -8,9 +8,8 @@ from fastapi.testclient import TestClient
 
 from src.app.api import app
 from src.app.environment import Settings
-from src.jbi.bugzilla import BugzillaBug, BugzillaWebhookComment, BugzillaWebhookRequest
-from src.jbi.models import Actions
-from src.jbi.services import get_bugzilla
+from src.jbi.bugzilla import BugzillaWebhookComment, BugzillaWebhookRequest
+from src.jbi.models import Action, Actions
 
 
 @pytest.fixture
@@ -25,13 +24,13 @@ def settings():
     return Settings()
 
 
-@pytest.fixture
+@pytest.fixture(autouse=True)
 def mocked_bugzilla():
     with mock.patch("src.jbi.services.rh_bugzilla.Bugzilla") as mocked_bz:
         yield mocked_bz
 
 
-@pytest.fixture
+@pytest.fixture(autouse=True)
 def mocked_jira():
     with mock.patch("src.jbi.services.Jira") as mocked_jira:
         yield mocked_jira
@@ -167,14 +166,17 @@ def webhook_modify_private_example(
 
 
 @pytest.fixture
-def actions_example() -> Actions:
-    return Actions.parse_obj(
-        [
-            {
-                "whiteboard_tag": "devtest",
-                "contact": "contact@corp.com",
-                "description": "test config",
-                "module": "tests.unit.jbi.noop_action",
-            }
-        ]
+def action_example() -> Action:
+    return Action.parse_obj(
+        {
+            "whiteboard_tag": "devtest",
+            "contact": "contact@corp.com",
+            "description": "test config",
+            "module": "tests.unit.jbi.noop_action",
+        }
     )
+
+
+@pytest.fixture
+def actions_example(action_example) -> Actions:
+    return Actions.parse_obj([action_example])

--- a/tests/unit/jbi/bugzilla_action.py
+++ b/tests/unit/jbi/bugzilla_action.py
@@ -1,0 +1,16 @@
+from bugzilla import Bugzilla
+from requests import Session
+
+session = Session()
+
+
+class TestBugzillaAction:
+    def __init__(self):
+        self.bz = Bugzilla(url=None, requests_session=session)
+
+    def __call__(self):
+        return lambda: "test"
+
+
+def init():
+    return TestBugzillaAction()

--- a/tests/unit/jbi/test_models.py
+++ b/tests/unit/jbi/test_models.py
@@ -1,0 +1,35 @@
+from unittest.mock import patch
+
+from fastapi.encoders import jsonable_encoder
+
+from src.jbi.models import Action
+
+
+def test_model_serializes():
+    """Regression test to assert that action with initialzed Bugzilla client serializes"""
+    action = Action.parse_obj(
+        {
+            "whiteboard_tag": "devtest",
+            "contact": "person@example.com",
+            "description": "test config",
+            "module": "tests.unit.jbi.bugzilla_action",
+        }
+    )
+    action._initialize_caller()
+    serialized_action = jsonable_encoder(action)
+    assert not serialized_action.get("_caller")
+
+
+def test_caller_initialization_defered(webhook_create_example, action_example):
+    with patch.object(
+        Action, "_initialize_caller", wraps=action_example._initialize_caller
+    ) as spy:
+        # when the action_example has not been called yet
+        # then the caller has not been initialized
+        assert not action_example._caller
+
+        # when the action is called
+        action_example.call(webhook_create_example)
+        action_example.call(webhook_create_example)
+        # then the caller is only initialized once
+        spy.assert_called_once()


### PR DESCRIPTION
When we included the callable in a public model field, we ran into a bug (#136 and #137) where `jsonable_encoder` couldn't serialize an action with an initialized `requests.Session` object.

Here's how I recreated the error we saw:

```diff
diff --git a/tests/unit/jbi/bugzilla_action.py b/tests/unit/jbi/bugzilla_action.py
new file mode 100644
index 0000000..d91e324
--- /dev/null
+++ b/tests/unit/jbi/bugzilla_action.py
@@ -0,0 +1,16 @@
+from bugzilla import Bugzilla
+from requests import Session
+
+session = Session()
+
+
+class TestBugzillaAction:
+    def __init__(self):
+        self.bz = Bugzilla(url=None, requests_session=session)
+
+    def __call__(self):
+        return lambda: "test"
+
+
+def init():
+    return TestBugzillaAction()
diff --git a/tests/unit/test_models.py b/tests/unit/test_models.py
new file mode 100644
index 0000000..6dc37ca
--- /dev/null
+++ b/tests/unit/test_models.py
@@ -0,0 +1,15 @@
+from src.jbi.models import Action
+from fastapi.encoders import jsonable_encoder
+
+
+def test_model_serializes():
+    action = Action.parse_obj(
+        {
+            "whiteboard_tag": "devtest",
+            "contact": "person@example.com",
+            "description": "test config",
+            "module": "tests.unit.jbi.bugzilla_action",
+        }
+    )
+    assert callable(action.callable)
+    jsonable_encoder(action)
```

For some reason, excluding the `callable` field with `Config` didn't seem to fix the bug. So instead, in this PR we move the callable to a private field with Pydantic's `PrivateAttr`. 

We also add a test case as a regression test for the bug we observed.

This seems like more of a bug with `jsonable_encoder`, but it's probably good to remove the callable from the dict representation of the model anyway.