### PR TITLE
Update config.nonprod.yaml

### DIFF
--- a/config/config.nonprod.yaml
+++ b/config/config.nonprod.yaml
@@ -2,10 +2,10 @@
 # Action Config
 - whiteboard_tag: nonprodtest
   contact: bsieber@mozilla.com
-  description: Nonprod testing whiteboard tag
+  description: Nonprod testing whiteboard tag (JBI Bin Project)
   enabled: true
   parameters:
-    jira_project_key: OSS
+    jira_project_key: JB
 
 - whiteboard_tag: flowstate
   allow_private: true


### PR DESCRIPTION
A request was made for a `JB` JBI Bin for both mozit-test and mozilla-hub jira environments: https://mozilla-hub.atlassian.net/browse/SDD-7493

The intent is to create a project space for defaulting/testing.

By making the project key consistent in non-prod and prod--and having the jira environments aligned--it makes me wonder if we need multiple configuration files.