### PR TITLE
Do not sleep in retry tests

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,6 +1,7 @@
 """
 Module for setting up pytest fixtures
 """
+import time
 from unittest import mock
 
 import pytest
@@ -180,3 +181,9 @@ def action_example() -> Action:
 @pytest.fixture
 def actions_example(action_example) -> Actions:
     return Actions.parse_obj([action_example])
+
+
+@pytest.fixture
+def sleepless(monkeypatch):
+    # https://stackoverflow.com/a/54829577
+    monkeypatch.setattr(time, "sleep", lambda s: None)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -183,7 +183,7 @@ def actions_example(action_example) -> Actions:
     return Actions.parse_obj([action_example])
 
 
-@pytest.fixture
+@pytest.fixture(autouse=True)
 def sleepless(monkeypatch):
     # https://stackoverflow.com/a/54829577
     monkeypatch.setattr(time, "sleep", lambda s: None)

--- a/tests/unit/jbi/test_services.py
+++ b/tests/unit/jbi/test_services.py
@@ -48,7 +48,7 @@ def test_timer_is_used_on_bugzilla_getcomments():
     assert mocked.called, "Timer was used on get_comments()"
 
 
-def test_bugzilla_methods_are_retried_if_raising(sleepless):
+def test_bugzilla_methods_are_retried_if_raising():
     with mock.patch(
         "src.jbi.services.rh_bugzilla.Bugzilla.return_value.get_comments"
     ) as mocked:

--- a/tests/unit/jbi/test_services.py
+++ b/tests/unit/jbi/test_services.py
@@ -48,7 +48,7 @@ def test_timer_is_used_on_bugzilla_getcomments():
     assert mocked.called, "Timer was used on get_comments()"
 
 
-def test_bugzilla_methods_are_retried_if_raising():
+def test_bugzilla_methods_are_retried_if_raising(sleepless):
     with mock.patch(
         "src.jbi.services.rh_bugzilla.Bugzilla.return_value.get_comments"
     ) as mocked:


### PR DESCRIPTION
`poetry run pytest --durations=5`

**Before**

```
==================================== slowest 5 durations ====================================
0.75s call     tests/unit/jbi/test_services.py::test_bugzilla_methods_are_retried_if_raising
0.02s call     tests/unit/app/test_sentry.py::test_errors_are_reported_to_sentry
0.02s call     tests/unit/app/test_api.py::test_read_root
0.01s call     tests/unit/app/test_configuration.py::test_actual_jbi_files
0.01s call     tests/unit/app/test_api.py::test_whiteboard_tags
```

**After**

```
==================================== slowest 5 durations ====================================
0.02s call     tests/unit/app/test_sentry.py::test_errors_are_reported_to_sentry
0.01s call     tests/unit/app/test_api.py::test_read_root
0.01s call     tests/unit/app/test_configuration.py::test_actual_jbi_files
0.01s call     tests/unit/app/test_api.py::test_whiteboard_tags
0.01s call     tests/unit/app/test_api.py::test_whiteboard_tags_filtered
```