### PR TITLE
Show 'Bug XXXX' instead of Bugzilla Ticket in Jira link

### DIFF
--- a/src/jbi/whiteboard_actions/default.py
+++ b/src/jbi/whiteboard_actions/default.py
@@ -215,7 +215,7 @@ class DefaultExecutor:
         jira_response = self.jira_client.create_or_update_issue_remote_links(
             issue_key=jira_key_in_response,
             link_url=bugzilla_url,
-            title=f"Bug {bug_obj.id}",
+            title=f"Bugzilla Bug {bug_obj.id}",
         )
 
         self.update_issue(payload, bug_obj, jira_key_in_response, is_new=True)

--- a/src/jbi/whiteboard_actions/default.py
+++ b/src/jbi/whiteboard_actions/default.py
@@ -215,7 +215,7 @@ class DefaultExecutor:
         jira_response = self.jira_client.create_or_update_issue_remote_links(
             issue_key=jira_key_in_response,
             link_url=bugzilla_url,
-            title="Bugzilla Ticket",
+            title=f"Bug {bug_obj.id}",
         )
 
         self.update_issue(payload, bug_obj, jira_key_in_response, is_new=True)


### PR DESCRIPTION
<img width="363" alt="Screenshot 2022-07-27 at 13 56 17" src="https://user-images.githubusercontent.com/546692/181240960-af5685b5-d92f-40af-bce8-ff0c7528f876.png">

In the Firefox world, bugs are always referred as `Bug <number>`