### PR TITLE
Bump v3.1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "jira-bugzilla-integration"
-version = "3.0.3"
+version = "3.1.0"
 description = "jira-bugzilla-integration"
 authors = ["@mozilla/jbi-core"]
 license = "MPL"

--- a/src/app/api.py
+++ b/src/app/api.py
@@ -32,7 +32,7 @@ settings = get_settings()
 app = FastAPI(
     title="Jira Bugzilla Integration (JBI)",
     description="JBI v2 Platform",
-    version="3.0.3",
+    version="3.1.0",
     debug=settings.app_debug,
 )
 


### PR DESCRIPTION
**Bug Fixes**

- Retrieve comments from the API if they are private (fixes #154) (#163)

**New Features**

- Show 'Bug XXXX' instead of Bugzilla Ticket in Jira link (#159)
- Add Jira details to log context (#157)
- Retry Jira and Bugzilla on error (fixes #33)  (#152)
- Add counter and timer for action execution (fixes #23, #62, #160, #164)
- Tweak logging (log `500` requests), other logging-adjacent tweaks (#161)

**Configuration**

- Use JB instead of OSS in config.prod.yaml and config.nonprod.yaml (#151, #153)
- Add local config for tests (fixes #121) (#138)

**Documentation**

- Start (naive) troubleshooting section in README (#156)

**Internal Changes**

- Run app as a single uvicorn process (fixes #133) (#162)
- Move initialized action callable to private field (#145)
- Do not sleep in retry tests (#158)

- Bump sentry-sdk from 1.8.0 to 1.9.0 (#167)
- Bump yamllint from 1.26.3 to 1.27.1 (#166)
- Bump atlassian-python-api from 3.20.1 to 3.25.0 (#149)
- Bump dockerflow from 2022.1.0 to 2022.7.0 (#147)
- Bump sentry-sdk from 1.7.2 to 1.8.0 (#146)
- Bump detect-secrets from 1.2.0 to 1.3.0 (#148)
- Bump mypy from 0.910 to 0.971 (#150)
- Bump fastapi from 0.73.0 to 0.79.0 (#168)