### PR TITLE
Create standardized release template

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,26 @@
+changelog:
+  exclude:
+    authors:
+      - dependabot
+  categories:
+    - title: Breaking Changes
+      labels:
+        - "breaking-change"
+    - title: Bug Fixes
+      labels:
+        - "bug"
+    - title: New Features
+      labels:
+        - "enhancement"
+    - title: Configuration
+      labels:
+        - "configuration"
+    - title: Documentation
+      labels:
+        - "documentation"
+    - title: Dependency Updates
+      labels:
+        - "dependencies"
+    - title: Other Changes
+      labels:
+        - "*"


### PR DESCRIPTION
Create a [release notes template](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#configuring-automatically-generated-release-notes) so that we have standardized sections for each release. 

This method kind of encourages us to make better use of labels as well. I'm guessing that a section heading defined in this template will only show up if there's a PR that has that label.  Though it's easy enough to copy from the "Other Changes" section and paste to the correct section heading.