### PR TITLE
Ensure container runs as a CI check

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,3 +7,4 @@
 !/poetry.lock
 !/pyproject.toml
 !/version.json
+!/asgi.py

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,10 +1,10 @@
 # ignore everything
 *
 # use exceptions to create an "allow list"
-!/config
-!/src
+!/asgi.py
 !/bin
+!/config
 !/poetry.lock
 !/pyproject.toml
+!/src
 !/version.json
-!/asgi.py

--- a/.github/workflows/build-publish.yaml
+++ b/.github/workflows/build-publish.yaml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       TEST_TAG: ${{ github.repository }}:test
+      TEST_CONTAINER_NAME: jbi-healthcheck
     steps:
       - name: Check out the repo
         uses: actions/checkout@v3
@@ -56,6 +57,7 @@ jobs:
       - name: Spin up container
         run: |
           docker run \
+          --name ${{ env.TEST_CONTAINER_NAME }} \
           --detach \
           --env-file .env.example \
           --publish 8000:8000 \
@@ -63,21 +65,11 @@ jobs:
 
       - name: Check that container is running
         run: |
-          curl \
-          --show-error \
-          --silent \
-          --output /dev/null \
-          --connect-timeout 5 \
-          --max-time 10 \
-          --retry-connrefused \
-          --retry 5 \
-          --retry-delay 0 \
-          --retry-max-time 10 \
-          localhost:8000/
+          docker exec ${{ env.TEST_CONTAINER_NAME }} python bin/healthcheck.py
 
       - name: Spin down container
         run: |
-          docker rm $(docker stop $(docker ps -a -q --filter='ancestor=${{ env.TEST_TAG }}'))
+          docker rm -f ${{ env.TEST_CONTAINER_NAME }}
 
       - name: Build and push
         uses: docker/build-push-action@v3

--- a/.github/workflows/build-publish.yaml
+++ b/.github/workflows/build-publish.yaml
@@ -73,7 +73,7 @@ jobs:
           --retry 5 \
           --retry-delay 0 \
           --retry-max-time 10 \
-          0.0.0.0:8000/
+          localhost:8000/
 
       - name: Spin down container
         run: |

--- a/.github/workflows/build-publish.yaml
+++ b/.github/workflows/build-publish.yaml
@@ -13,6 +13,8 @@ on:
 jobs:
   build-and-publish:
     runs-on: ubuntu-latest
+    env:
+      TEST_TAG: ${{ github.repository }}:test
     steps:
       - name: Check out the repo
         uses: actions/checkout@v3
@@ -42,6 +44,40 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and export to Docker
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          load: true
+          push: false
+          tags: ${{ env.TEST_TAG }}
+
+      - name: Spin up container
+        run: |
+          docker run \
+          --detach \
+          --env-file .env.example \
+          --publish 8000:8000 \
+          ${{ env.TEST_TAG }}
+
+      - name: Check that container is running
+        run: |
+          curl \
+          --show-error \
+          --silent \
+          --output /dev/null \
+          --connect-timeout 5 \
+          --max-time 10 \
+          --retry-connrefused \
+          --retry 5 \
+          --retry-delay 0 \
+          --retry-max-time 10 \
+          0.0.0.0:8000/
+
+      - name: Spin down container
+        run: |
+          docker rm $(docker stop $(docker ps -a -q --filter='ancestor=${{ env.TEST_TAG }}'))
 
       - name: Build and push
         uses: docker/build-push-action@v3

--- a/bin/healthcheck.py
+++ b/bin/healthcheck.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python
+
+import os
+
+import requests
+from requests.adapters import HTTPAdapter, Retry
+
+PORT = os.environ["PORT"]
+
+session = requests.Session()
+
+retries = Retry(total=5, backoff_factor=0.1, status_forcelist=[500, 502, 503, 504])
+session.mount("http://", HTTPAdapter(max_retries=retries))
+if __name__ == "__main__":
+    response = session.get(f"http://0.0.0.0:{PORT}/")
+    response.raise_for_status()


### PR DESCRIPTION
This PR ensures that we copy the new `asgi.py` file (introduced in #161) into the container, which fixes #178.

It also adds a step in the build / publish workflow to spin up the container and check that it starts successfully. 
