### PR TITLE
Add workflow to check that PR has label(s)

### DIFF
--- a/.github/workflows/labels.yaml
+++ b/.github/workflows/labels.yaml
@@ -1,0 +1,14 @@
+name: Force pull-requests label(s)
+
+on:
+  pull_request:
+    types: [opened, labeled, unlabeled]
+jobs:
+  pr-has-label:
+    name: Will be skipped if labelled
+    runs-on: ubuntu-latest
+    if: ${{ join(github.event.pull_request.labels.*.name, ', ') == '' }}
+    steps:
+      - run: |
+          echo 'Pull-request must have at least one label'
+          exit 1


### PR DESCRIPTION
In the latest release notes, the bug fix of #184 was listed in *Other changes*, because the pull-request had no label.

This workflow will force us to put labels on pull-requests