### PR TITLE
Avoid unnecessary typing imports

### DIFF
--- a/jbi/__init__.py
+++ b/jbi/__init__.py
@@ -4,7 +4,6 @@ Module domain specific code related to JBI.
 This part of the code is not aware of the HTTP context it runs in.
 """
 from enum import Enum
-from typing import Dict, Tuple
 
 
 class Operation(str, Enum):
@@ -22,4 +21,4 @@ class Operation(str, Enum):
     LINK = "link"
 
 
-ActionResult = Tuple[bool, Dict]
+ActionResult = tuple[bool, dict]

--- a/jbi/log.py
+++ b/jbi/log.py
@@ -6,7 +6,6 @@ import logging.config
 import sys
 import time
 from datetime import datetime
-from typing import Dict
 
 from fastapi import Request
 
@@ -46,7 +45,7 @@ CONFIG = {
 
 def format_request_summary_fields(
     request: Request, request_time: float, status_code: int
-) -> Dict:
+) -> dict:
     """Prepare Fields for Mozlog request summary"""
 
     current_time = time.time()

--- a/jbi/router.py
+++ b/jbi/router.py
@@ -2,7 +2,7 @@
 Core FastAPI app (setup, middleware)
 """
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Optional
 
 from fastapi import APIRouter, Body, Depends, Request, Response
 from fastapi.encoders import jsonable_encoder
@@ -87,7 +87,7 @@ def get_whiteboard_tags(
 @router.get("/jira_projects/")
 def get_jira_projects():
     """API for viewing projects that are currently accessible by API"""
-    visible_projects: List[Dict] = jira_visible_projects()
+    visible_projects: list[dict] = jira_visible_projects()
     return [project["key"] for project in visible_projects]
 
 

--- a/jbi/services.py
+++ b/jbi/services.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import concurrent.futures
 import logging
-from typing import TYPE_CHECKING, Dict, List
+from typing import TYPE_CHECKING
 
 import backoff
 import bugzilla as rh_bugzilla
@@ -20,7 +20,7 @@ settings = environment.get_settings()
 logger = logging.getLogger(__name__)
 
 
-ServiceHealth = Dict[str, bool]
+ServiceHealth = dict[str, bool]
 
 
 class InstrumentedClient:
@@ -77,10 +77,10 @@ def get_jira():
     )
 
 
-def jira_visible_projects(jira=None) -> List[Dict]:
+def jira_visible_projects(jira=None) -> list[dict]:
     """Return list of projects that are visible with the configured Jira credentials"""
     jira = jira or get_jira()
-    projects: List[Dict] = jira.projects(included_archived=None)
+    projects: list[dict] = jira.projects(included_archived=None)
     return projects
 
 


### PR DESCRIPTION
- Use collection keyword instead of `typing.{Dict|List|Tuple|Set}` ([Since Python 3.9](https://peps.python.org/pep-0585/))
- replace `typing.Union` with `|` ([Since Python 3.10](https://peps.python.org/pep-0604/))