### PR TITLE
Refactor some test fixtures / setup

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,7 @@ from jbi.app import app
 from jbi.environment import Settings
 from jbi.models import Action, Actions, BugzillaWebhookComment, BugzillaWebhookRequest
 from tests.fixtures.factories import (
+    action_factory,
     bug_factory,
     webhook_event_factory,
     webhook_factory,
@@ -121,14 +122,7 @@ def webhook_modify_private_example() -> BugzillaWebhookRequest:
 
 @pytest.fixture
 def action_example() -> Action:
-    return Action.parse_obj(
-        {
-            "whiteboard_tag": "devtest",
-            "contact": "contact@corp.com",
-            "description": "test config",
-            "module": "tests.fixtures.noop_action",
-        }
-    )
+    return action_factory()
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,13 +33,13 @@ def settings():
 @pytest.fixture(autouse=True)
 def mocked_bugzilla():
     with mock.patch("jbi.services.rh_bugzilla.Bugzilla") as mocked_bz:
-        yield mocked_bz
+        yield mocked_bz()
 
 
 @pytest.fixture(autouse=True)
 def mocked_jira():
     with mock.patch("jbi.services.Jira") as mocked_jira:
-        yield mocked_jira
+        yield mocked_jira()
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,12 @@ from fastapi.testclient import TestClient
 from jbi.app import app
 from jbi.environment import Settings
 from jbi.models import Action, Actions, BugzillaWebhookComment, BugzillaWebhookRequest
+from tests.fixtures.factories import (
+    bug_factory,
+    webhook_event_factory,
+    webhook_factory,
+    webhook_user_factory,
+)
 
 
 @pytest.fixture
@@ -37,185 +43,80 @@ def mocked_jira():
 
 
 @pytest.fixture
-def webhook_create_example(mocked_bugzilla) -> BugzillaWebhookRequest:
-    webhook_payload = BugzillaWebhookRequest.parse_obj(
-        {
-            "bug": {
-                "assigned_to": "nobody@mozilla.org",
-                "comment": None,
-                "component": "General",
-                "creator": "nobody@mozilla.org",
-                "flags": [],
-                "id": 654321,
-                "is_private": False,
-                "keywords": [],
-                "priority": "",
-                "product": "JBI",
-                "resolution": "",
-                "see_also": [],
-                "severity": "--",
-                "status": "NEW",
-                "summary": "JBI Test",
-                "type": "defect",
-                "whiteboard": "devtest",
-            },
-            "event": {
-                "action": "create",
-                "changes": None,
-                "routing_key": "bug.create",
-                "target": "bug",
-                "time": "2022-03-23T20:10:17.495000+00:00",
-                "user": {
-                    "id": 123456,
-                    "login": "nobody@mozilla.org",
-                    "real_name": "Nobody [ :nobody ]",
-                },
-            },
-            "webhook_id": 34,
-            "webhook_name": "local-test",
-        }
-    )
-
-    mocked_bugzilla().getbug.return_value = webhook_payload.bug
-    mocked_bugzilla().get_comments.return_value = {
-        "bugs": {"654321": {"comments": [{"text": "Initial comment"}]}}
-    }
+def webhook_create_example() -> BugzillaWebhookRequest:
+    webhook_payload = webhook_factory()
 
     return webhook_payload
 
 
 @pytest.fixture
-def webhook_comment_example(webhook_create_example) -> BugzillaWebhookRequest:
-    webhook_comment_example: BugzillaWebhookRequest = webhook_create_example
-    webhook_comment_example.event.target = "comment"
-    webhook_comment_example.event.user.login = "mathieu@mozilla.org"  # type: ignore
-    assert webhook_comment_example.bug
-    webhook_comment_example.bug.comment = BugzillaWebhookComment.parse_obj(
-        {"number": 2, "body": "hello"}
+def webhook_comment_example() -> BugzillaWebhookRequest:
+    user = webhook_user_factory(login="mathieu@mozilla.org")
+    comment = BugzillaWebhookComment.parse_obj({"number": 2, "body": "hello"})
+    bug = bug_factory(
+        see_also=["https://mozilla.atlassian.net/browse/JBI-234"],
+        comment=comment,
     )
-    webhook_comment_example.bug.see_also = [
-        "https://mozilla.atlassian.net/browse/JBI-234"
-    ]
-    return webhook_comment_example
+    event = webhook_event_factory(target="comment", user=user)
+    webhook_payload = webhook_factory(bug=bug, event=event)
+
+    return webhook_payload
 
 
 @pytest.fixture
-def webhook_private_comment_example(
-    webhook_create_example, mocked_bugzilla
-) -> BugzillaWebhookRequest:
-    webhook_comment_example: BugzillaWebhookRequest = webhook_create_example
-    webhook_comment_example.event.target = "comment"
-    webhook_comment_example.event.user.login = "mathieu@mozilla.org"  # type: ignore
-    assert webhook_comment_example.bug
-    webhook_comment_example.bug.comment = BugzillaWebhookComment.parse_obj(
-        {"id": 344, "number": 2, "is_private": True}
+def webhook_private_comment_example() -> BugzillaWebhookRequest:
+    user = webhook_user_factory(login="mathieu@mozilla.org")
+    event = webhook_event_factory(target="comment", user=user)
+    bug = bug_factory(
+        comment={"id": 344, "number": 2, "is_private": True},
+        see_also=["https://mozilla.atlassian.net/browse/JBI-234"],
     )
-    webhook_comment_example.bug.see_also = [
-        "https://mozilla.atlassian.net/browse/JBI-234"
-    ]
-
-    # Call to Bugzilla returns the actual bug comments.
-    mocked_bugzilla().get_comments.return_value = {
-        "bugs": {
-            str(webhook_comment_example.bug.id): {
-                "comments": [
-                    {
-                        "id": 343,
-                        "text": "not this one",
-                        "bug_id": webhook_comment_example.bug.id,
-                        "count": 1,
-                        "is_private": True,
-                        "creator": "mathieu@mozilla.org",
-                    },
-                    {
-                        "id": 344,
-                        "text": "hello",
-                        "bug_id": webhook_comment_example.bug.id,
-                        "count": 2,
-                        "is_private": True,
-                        "creator": "mathieu@mozilla.org",
-                    },
-                    {
-                        "id": 345,
-                        "text": "or this one",
-                        "bug_id": webhook_comment_example.bug.id,
-                        "count": 3,
-                        "is_private": True,
-                        "creator": "mathieu@mozilla.org",
-                    },
-                ]
-            }
-        },
-        "comments": {},
-    }
-
-    return webhook_comment_example
+    webhook_payload = webhook_factory(bug=bug, event=event)
+    return webhook_payload
 
 
 @pytest.fixture
-def webhook_create_private_example(
-    webhook_create_example, mocked_bugzilla
-) -> BugzillaWebhookRequest:
-    private_bug = webhook_create_example.bug
-    private_bug.is_private = True
-    # Call to Bugzilla returns the actual bug object.
-    mocked_bugzilla().getbug.return_value = private_bug
+def webhook_create_private_example() -> BugzillaWebhookRequest:
+    return webhook_factory(
+        event=webhook_event_factory(),
+        bug={"id": 654321, "is_private": True},
+    )
 
-    # But webhook payload only contains private attribute.
-    webhook_create_private_example = BugzillaWebhookRequest.parse_obj(
+
+@pytest.fixture
+def webhook_modify_example() -> BugzillaWebhookRequest:
+    bug = bug_factory(see_also=["https://mozilla.atlassian.net/browse/JBI-234"])
+    event = webhook_event_factory(action="modify", routing_key="bug.modify:status")
+    webhook_payload = webhook_factory(bug=bug, event=event)
+    return webhook_payload
+
+
+@pytest.fixture
+def webhook_change_status_assignee():
+    changes = [
         {
-            **webhook_create_example.dict(),
-            "bug": {"id": private_bug.id, "is_private": True},
-        }
-    )
-    return webhook_create_private_example
-
-
-@pytest.fixture
-def webhook_modify_example(webhook_create_example) -> BugzillaWebhookRequest:
-    webhook_modify_example: BugzillaWebhookRequest = webhook_create_example
-    assert webhook_modify_example.bug
-    webhook_modify_example.bug.see_also = [
-        "https://mozilla.atlassian.net/browse/JBI-234"
-    ]
-
-    webhook_modify_example.event.action = "modify"
-    webhook_modify_example.event.routing_key = "bug.modify:status"
-    return webhook_modify_example
-
-
-@pytest.fixture
-def webhook_change_status_assignee(webhook_modify_example):
-    payload = webhook_modify_example.dict()
-    payload["event"]["routing_key"] = "bug.modify"
-    payload["event"]["changes"] = [
-        {"field": "status", "removed": "OPEN", "added": "FIXED"},
+            "field": "status",
+            "removed": "OPEN",
+            "added": "FIXED",
+        },
         {
             "field": "assignee",
             "removed": "nobody@mozilla.org",
             "added": "mathieu@mozilla.com",
         },
     ]
-    return BugzillaWebhookRequest.parse_obj(payload)
+    event = webhook_event_factory(routing_key="bug.modify", changes=changes)
+    webhook_payload = webhook_factory(event=event)
+    return webhook_payload
 
 
 @pytest.fixture
-def webhook_modify_private_example(
-    webhook_modify_example, mocked_bugzilla
-) -> BugzillaWebhookRequest:
-    private_bug = webhook_modify_example.bug
-    private_bug.is_private = True
-    # Call to Bugzilla returns the actual bug object.
-    mocked_bugzilla().getbug.return_value = private_bug
-
-    # But webhook payload only contains private attribute.
-    webhook_modify_private_example = BugzillaWebhookRequest.parse_obj(
-        {
-            **webhook_modify_example.dict(),
-            "bug": {"id": private_bug.id, "is_private": True},
-        }
+def webhook_modify_private_example() -> BugzillaWebhookRequest:
+    event = webhook_event_factory(action="modify", routing_key="bug.modify:status")
+    webhook_payload = webhook_factory(
+        bug={"id": 654321, "is_private": True}, event=event
     )
-    return webhook_modify_private_example
+    return webhook_payload
 
 
 @pytest.fixture

--- a/tests/fixtures/factories.py
+++ b/tests/fixtures/factories.py
@@ -1,9 +1,21 @@
 from jbi.models import (
+    Action,
     BugzillaBug,
     BugzillaWebhookEvent,
     BugzillaWebhookRequest,
     BugzillaWebhookUser,
 )
+
+
+def action_factory(**overrides):
+    action = {
+        "whiteboard_tag": "devtest",
+        "contact": "tbd",
+        "description": "test config",
+        "module": "tests.fixtures.noop_action",
+        **overrides,
+    }
+    return Action.parse_obj(action)
 
 
 def bug_factory(**overrides):

--- a/tests/fixtures/factories.py
+++ b/tests/fixtures/factories.py
@@ -1,0 +1,76 @@
+from jbi.models import (
+    BugzillaBug,
+    BugzillaWebhookEvent,
+    BugzillaWebhookRequest,
+    BugzillaWebhookUser,
+)
+
+
+def bug_factory(**overrides):
+    bug = {
+        "assigned_to": "nobody@mozilla.org",
+        "comment": None,
+        "component": "General",
+        "creator": "nobody@mozilla.org",
+        "flags": [],
+        "id": 654321,
+        "is_private": False,
+        "keywords": [],
+        "priority": "",
+        "product": "JBI",
+        "resolution": "",
+        "see_also": [],
+        "severity": "--",
+        "status": "NEW",
+        "summary": "JBI Test",
+        "type": "defect",
+        "whiteboard": "devtest",
+        **overrides,
+    }
+    return BugzillaBug.parse_obj(bug)
+
+
+def webhook_user_factory(**overrides):
+    user = {
+        "id": 123456,
+        "login": "nobody@mozilla.org",
+        "real_name": "Nobody [ :nobody ]",
+        **overrides,
+    }
+    return BugzillaWebhookUser.parse_obj(user)
+
+
+def webhook_event_factory(**overrides):
+    event = {
+        "action": "create",
+        "changes": None,
+        "routing_key": "bug.create",
+        "target": "bug",
+        "time": "2022-03-23T20:10:17.495000+00:00",
+        "user": webhook_user_factory(),
+        **overrides,
+    }
+    return BugzillaWebhookEvent.parse_obj(event)
+
+
+def webhook_factory(**overrides):
+    webhook_event = {
+        "bug": bug_factory(),
+        "event": webhook_event_factory(),
+        "webhook_id": 34,
+        "webhook_name": "local-test",
+        **overrides,
+    }
+    return BugzillaWebhookRequest.parse_obj(webhook_event)
+
+
+def comment_factory(**overrides):
+    return {
+        "id": 343,
+        "text": "comment text",
+        "bug_id": 654321,
+        "count": 1,
+        "is_private": True,
+        "creator": "mathieu@mozilla.org",
+        **overrides,
+    }

--- a/tests/unit/actions/test_default.py
+++ b/tests/unit/actions/test_default.py
@@ -30,8 +30,8 @@ def test_default_returns_callable_with_data(
     webhook_create_example, mocked_jira, mocked_bugzilla
 ):
     sentinel = mock.sentinel
-    mocked_jira().create_or_update_issue_remote_links.return_value = sentinel
-    mocked_bugzilla().getbug.return_value = webhook_create_example.bug
+    mocked_jira.create_or_update_issue_remote_links.return_value = sentinel
+    mocked_bugzilla.getbug.return_value = webhook_create_example.bug
     callable_object = default.init(jira_project_key="")
 
     handled, details = callable_object(payload=webhook_create_example)
@@ -43,15 +43,15 @@ def test_default_returns_callable_with_data(
 def test_created_public(
     webhook_create_example: BugzillaWebhookRequest, mocked_jira, mocked_bugzilla
 ):
-    mocked_bugzilla().getbug.return_value = webhook_create_example.bug
-    mocked_bugzilla().get_comments.return_value = {
+    mocked_bugzilla.getbug.return_value = webhook_create_example.bug
+    mocked_bugzilla.get_comments.return_value = {
         "bugs": {"654321": {"comments": [{"text": "Initial comment"}]}}
     }
     callable_object = default.init(jira_project_key="JBI")
 
     callable_object(payload=webhook_create_example)
 
-    mocked_jira().create_issue.assert_called_once_with(
+    mocked_jira.create_issue.assert_called_once_with(
         fields={
             "summary": "JBI Test",
             "labels": ["bugzilla", "devtest", "[devtest]"],
@@ -69,15 +69,15 @@ def test_created_private(
         id=webhook_create_private_example.bug.id,
         is_private=webhook_create_private_example.bug.is_private,
     )
-    mocked_bugzilla().getbug.return_value = fetched_private_bug
-    mocked_bugzilla().get_comments.return_value = {
+    mocked_bugzilla.getbug.return_value = fetched_private_bug
+    mocked_bugzilla.get_comments.return_value = {
         "bugs": {"654321": {"comments": [{"text": "Initial comment"}]}}
     }
     callable_object = default.init(jira_project_key="JBI")
 
     callable_object(payload=webhook_create_private_example)
 
-    mocked_jira().create_issue.assert_called_once_with(
+    mocked_jira.create_issue.assert_called_once_with(
         fields={
             "summary": "JBI Test",
             "labels": ["bugzilla", "devtest", "[devtest]"],
@@ -96,7 +96,7 @@ def test_modified_public(webhook_modify_example: BugzillaWebhookRequest, mocked_
 
     assert webhook_modify_example.bug.extract_from_see_also(), "see_also is not empty"
 
-    mocked_jira().update_issue_field.assert_called_once_with(
+    mocked_jira.update_issue_field.assert_called_once_with(
         key="JBI-234",
         fields={"summary": "JBI Test", "labels": ["bugzilla", "devtest", "[devtest]"]},
     )
@@ -110,12 +110,12 @@ def test_modified_private(
         is_private=webhook_modify_private_example.bug.is_private,
         see_also=["https://mozilla.atlassian.net/browse/JBI-234"],
     )
-    mocked_bugzilla().getbug.return_value = fetched_private_bug
+    mocked_bugzilla.getbug.return_value = fetched_private_bug
     callable_object = default.init(jira_project_key="")
 
     callable_object(payload=webhook_modify_private_example)
 
-    mocked_jira().update_issue_field.assert_called_once_with(
+    mocked_jira.update_issue_field.assert_called_once_with(
         key="JBI-234",
         fields={"summary": "JBI Test", "labels": ["bugzilla", "devtest", "[devtest]"]},
     )
@@ -127,7 +127,7 @@ def test_added_comment(webhook_comment_example: BugzillaWebhookRequest, mocked_j
 
     callable_object(payload=webhook_comment_example)
 
-    mocked_jira().issue_add_comment.assert_called_once_with(
+    mocked_jira.issue_add_comment.assert_called_once_with(
         issue_key="JBI-234",
         comment="*(mathieu@mozilla.org)* commented: \n{quote}hello{quote}",
     )
@@ -143,7 +143,7 @@ def test_added_private_comment(
         comment_factory(id=345, text="not this one", count=3),
     ]
 
-    mocked_bugzilla().get_comments.return_value = {
+    mocked_bugzilla.get_comments.return_value = {
         "bugs": {"654321": {"comments": comments}},
         "comments": {},
     }
@@ -154,7 +154,7 @@ def test_added_private_comment(
     callable_object(payload=webhook_private_comment_example)
 
     # then
-    mocked_jira().issue_add_comment.assert_called_once_with(
+    mocked_jira.issue_add_comment.assert_called_once_with(
         issue_key="JBI-234",
         comment="*(mathieu@mozilla.org)* commented: \n{quote}hello{quote}",
     )
@@ -167,14 +167,14 @@ def test_added_missing_private_comment(
 ):
 
     callable_object = default.init(jira_project_key="")
-    mocked_bugzilla().get_comments.return_value = {
+    mocked_bugzilla.get_comments.return_value = {
         "bugs": {str(webhook_private_comment_example.bug.id): {"comments": []}},
         "comments": {},
     }
 
     handled, _ = callable_object(payload=webhook_private_comment_example)
 
-    mocked_jira().issue_add_comment.assert_not_called()
+    mocked_jira.issue_add_comment.assert_not_called()
     assert not handled
 
 
@@ -193,7 +193,7 @@ def test_added_comment_without_linked_issue(
 def test_jira_returns_an_error(
     webhook_create_example: BugzillaWebhookRequest, mocked_jira
 ):
-    mocked_jira().create_issue.return_value = [
+    mocked_jira.create_issue.return_value = [
         {"errors": ["Boom"]},
     ]
     callable_object = default.init(jira_project_key="")

--- a/tests/unit/actions/test_default.py
+++ b/tests/unit/actions/test_default.py
@@ -3,14 +3,13 @@ Module for testing jbi/actions/default.py functionality
 """
 # pylint: disable=cannot-enumerate-pytest-fixtures
 from unittest import mock
-from unittest.mock import MagicMock
 
 import pytest
 
-from jbi import Operation
 from jbi.actions import default
 from jbi.errors import ActionError
-from jbi.models import BugzillaBug, BugzillaWebhookRequest
+from jbi.models import BugzillaWebhookRequest
+from tests.fixtures.factories import bug_factory, comment_factory
 
 
 def test_default_invalid_init():
@@ -27,9 +26,12 @@ def test_default_returns_callable_without_data(mocked_bugzilla, mocked_jira):
     assert "missing 1 required positional argument: 'payload'" in str(exc_info.value)
 
 
-def test_default_returns_callable_with_data(webhook_create_example, mocked_jira):
+def test_default_returns_callable_with_data(
+    webhook_create_example, mocked_jira, mocked_bugzilla
+):
     sentinel = mock.sentinel
     mocked_jira().create_or_update_issue_remote_links.return_value = sentinel
+    mocked_bugzilla().getbug.return_value = webhook_create_example.bug
     callable_object = default.init(jira_project_key="")
 
     handled, details = callable_object(payload=webhook_create_example)
@@ -38,7 +40,13 @@ def test_default_returns_callable_with_data(webhook_create_example, mocked_jira)
     assert details["jira_response"] == sentinel
 
 
-def test_created_public(webhook_create_example: BugzillaWebhookRequest, mocked_jira):
+def test_created_public(
+    webhook_create_example: BugzillaWebhookRequest, mocked_jira, mocked_bugzilla
+):
+    mocked_bugzilla().getbug.return_value = webhook_create_example.bug
+    mocked_bugzilla().get_comments.return_value = {
+        "bugs": {"654321": {"comments": [{"text": "Initial comment"}]}}
+    }
     callable_object = default.init(jira_project_key="JBI")
 
     callable_object(payload=webhook_create_example)
@@ -55,8 +63,16 @@ def test_created_public(webhook_create_example: BugzillaWebhookRequest, mocked_j
 
 
 def test_created_private(
-    webhook_create_private_example: BugzillaWebhookRequest, mocked_jira
+    webhook_create_private_example: BugzillaWebhookRequest, mocked_jira, mocked_bugzilla
 ):
+    fetched_private_bug = bug_factory(
+        id=webhook_create_private_example.bug.id,
+        is_private=webhook_create_private_example.bug.is_private,
+    )
+    mocked_bugzilla().getbug.return_value = fetched_private_bug
+    mocked_bugzilla().get_comments.return_value = {
+        "bugs": {"654321": {"comments": [{"text": "Initial comment"}]}}
+    }
     callable_object = default.init(jira_project_key="JBI")
 
     callable_object(payload=webhook_create_private_example)
@@ -87,8 +103,14 @@ def test_modified_public(webhook_modify_example: BugzillaWebhookRequest, mocked_
 
 
 def test_modified_private(
-    webhook_modify_private_example: BugzillaWebhookRequest, mocked_jira
+    webhook_modify_private_example: BugzillaWebhookRequest, mocked_jira, mocked_bugzilla
 ):
+    fetched_private_bug = bug_factory(
+        id=webhook_modify_private_example.bug.id,
+        is_private=webhook_modify_private_example.bug.is_private,
+        see_also=["https://mozilla.atlassian.net/browse/JBI-234"],
+    )
+    mocked_bugzilla().getbug.return_value = fetched_private_bug
     callable_object = default.init(jira_project_key="")
 
     callable_object(payload=webhook_modify_private_example)
@@ -112,13 +134,26 @@ def test_added_comment(webhook_comment_example: BugzillaWebhookRequest, mocked_j
 
 
 def test_added_private_comment(
-    webhook_private_comment_example: BugzillaWebhookRequest, mocked_jira
+    webhook_private_comment_example, mocked_jira, mocked_bugzilla
 ):
+    # given
+    comments = [
+        comment_factory(id=343, text="not this one", count=1),
+        comment_factory(id=344, text="hello", count=2),
+        comment_factory(id=345, text="not this one", count=3),
+    ]
+
+    mocked_bugzilla().get_comments.return_value = {
+        "bugs": {"654321": {"comments": comments}},
+        "comments": {},
+    }
 
     callable_object = default.init(jira_project_key="")
 
+    # when the default action receives a webhook with a private comment (number 2)
     callable_object(payload=webhook_private_comment_example)
 
+    # then
     mocked_jira().issue_add_comment.assert_called_once_with(
         issue_key="JBI-234",
         comment="*(mathieu@mozilla.org)* commented: \n{quote}hello{quote}",

--- a/tests/unit/actions/test_default_with_assignee_and_status.py
+++ b/tests/unit/actions/test_default_with_assignee_and_status.py
@@ -2,15 +2,15 @@ from jbi.actions import default_with_assignee_and_status as action
 
 
 def test_create_with_no_assignee(webhook_create_example, mocked_jira, mocked_bugzilla):
-    mocked_bugzilla().getbug.return_value = webhook_create_example.bug
-    mocked_bugzilla().get_comments.return_value = {
+    mocked_bugzilla.getbug.return_value = webhook_create_example.bug
+    mocked_bugzilla.get_comments.return_value = {
         "bugs": {"654321": {"comments": [{"text": "Initial comment"}]}}
     }
     callable_object = action.init(jira_project_key="JBI")
     handled, _ = callable_object(payload=webhook_create_example)
 
     assert handled
-    mocked_jira().create_issue.assert_called_once_with(
+    mocked_jira.create_issue.assert_called_once_with(
         fields={
             "summary": "JBI Test",
             "labels": ["bugzilla", "devtest", "[devtest]"],
@@ -19,24 +19,24 @@ def test_create_with_no_assignee(webhook_create_example, mocked_jira, mocked_bug
             "project": {"key": "JBI"},
         },
     )
-    mocked_jira().user_find_by_user_string.assert_not_called()
-    mocked_jira().update_issue_field.assert_not_called()
-    mocked_jira().set_issue_status.assert_not_called()
+    mocked_jira.user_find_by_user_string.assert_not_called()
+    mocked_jira.update_issue_field.assert_not_called()
+    mocked_jira.set_issue_status.assert_not_called()
 
 
 def test_create_with_assignee(webhook_create_example, mocked_jira, mocked_bugzilla):
     webhook_create_example.bug.assigned_to = "dtownsend@mozilla.com"
-    mocked_bugzilla().getbug.return_value = webhook_create_example.bug
-    mocked_jira().create_issue.return_value = {"key": "JBI-534"}
-    mocked_jira().user_find_by_user_string.return_value = [{"accountId": "6254"}]
-    mocked_bugzilla().get_comments.return_value = {
+    mocked_bugzilla.getbug.return_value = webhook_create_example.bug
+    mocked_jira.create_issue.return_value = {"key": "JBI-534"}
+    mocked_jira.user_find_by_user_string.return_value = [{"accountId": "6254"}]
+    mocked_bugzilla.get_comments.return_value = {
         "bugs": {"654321": {"comments": [{"text": "Initial comment"}]}}
     }
 
     callable_object = action.init(jira_project_key="JBI")
     callable_object(payload=webhook_create_example)
 
-    mocked_jira().create_issue.assert_called_once_with(
+    mocked_jira.create_issue.assert_called_once_with(
         fields={
             "summary": "JBI Test",
             "labels": ["bugzilla", "devtest", "[devtest]"],
@@ -45,14 +45,14 @@ def test_create_with_assignee(webhook_create_example, mocked_jira, mocked_bugzil
             "project": {"key": "JBI"},
         },
     )
-    mocked_jira().user_find_by_user_string.assert_called_once_with(
+    mocked_jira.user_find_by_user_string.assert_called_once_with(
         query="dtownsend@mozilla.com"
     )
-    mocked_jira().update_issue_field.assert_called_once_with(
+    mocked_jira.update_issue_field.assert_called_once_with(
         key="JBI-534",
         fields={"assignee": {"accountId": "6254"}},
     )
-    mocked_jira().set_issue_status.assert_not_called()
+    mocked_jira.set_issue_status.assert_not_called()
 
 
 def test_clear_assignee(webhook_create_example, mocked_jira):
@@ -65,20 +65,20 @@ def test_clear_assignee(webhook_create_example, mocked_jira):
     callable_object = action.init(jira_project_key="JBI")
     callable_object(payload=webhook_create_example)
 
-    mocked_jira().create_issue.assert_not_called()
-    mocked_jira().user_find_by_user_string.assert_not_called()
-    mocked_jira().update_issue_field.assert_any_call(
+    mocked_jira.create_issue.assert_not_called()
+    mocked_jira.user_find_by_user_string.assert_not_called()
+    mocked_jira.update_issue_field.assert_any_call(
         key="JBI-234",
         fields={
             "summary": "JBI Test",
             "labels": ["bugzilla", "devtest", "[devtest]"],
         },
     )
-    mocked_jira().update_issue_field.assert_any_call(
+    mocked_jira.update_issue_field.assert_any_call(
         key="JBI-234",
         fields={"assignee": None},
     )
-    mocked_jira().set_issue_status.assert_not_called()
+    mocked_jira.set_issue_status.assert_not_called()
 
 
 def test_set_assignee(webhook_create_example, mocked_jira):
@@ -89,27 +89,27 @@ def test_set_assignee(webhook_create_example, mocked_jira):
     webhook_create_example.event.action = "modify"
     webhook_create_example.event.routing_key = "bug.modify:assigned_to"
 
-    mocked_jira().user_find_by_user_string.return_value = [{"accountId": "6254"}]
+    mocked_jira.user_find_by_user_string.return_value = [{"accountId": "6254"}]
 
     callable_object = action.init(jira_project_key="JBI")
     callable_object(payload=webhook_create_example)
 
-    mocked_jira().create_issue.assert_not_called()
-    mocked_jira().user_find_by_user_string.assert_called_once_with(
+    mocked_jira.create_issue.assert_not_called()
+    mocked_jira.user_find_by_user_string.assert_called_once_with(
         query="dtownsend@mozilla.com"
     )
-    mocked_jira().update_issue_field.assert_any_call(
+    mocked_jira.update_issue_field.assert_any_call(
         key="JBI-234",
         fields={
             "summary": "JBI Test",
             "labels": ["bugzilla", "devtest", "[devtest]"],
         },
     )
-    mocked_jira().update_issue_field.assert_any_call(
+    mocked_jira.update_issue_field.assert_any_call(
         key="JBI-234",
         fields={"assignee": {"accountId": "6254"}},
     )
-    mocked_jira().set_issue_status.assert_not_called()
+    mocked_jira.set_issue_status.assert_not_called()
 
 
 def test_create_with_unknown_status(
@@ -117,8 +117,8 @@ def test_create_with_unknown_status(
 ):
     webhook_create_example.bug.status = "NEW"
     webhook_create_example.bug.resolution = ""
-    mocked_bugzilla().getbug.return_value = webhook_create_example.bug
-    mocked_bugzilla().get_comments.return_value = {
+    mocked_bugzilla.getbug.return_value = webhook_create_example.bug
+    mocked_bugzilla.get_comments.return_value = {
         "bugs": {"654321": {"comments": [{"text": "Initial comment"}]}}
     }
 
@@ -131,7 +131,7 @@ def test_create_with_unknown_status(
     )
     callable_object(payload=webhook_create_example)
 
-    mocked_jira().create_issue.assert_called_once_with(
+    mocked_jira.create_issue.assert_called_once_with(
         fields={
             "summary": "JBI Test",
             "labels": ["bugzilla", "devtest", "[devtest]"],
@@ -140,19 +140,19 @@ def test_create_with_unknown_status(
             "project": {"key": "JBI"},
         },
     )
-    mocked_jira().user_find_by_user_string.assert_not_called()
-    mocked_jira().update_issue_field.assert_not_called()
-    mocked_jira().set_issue_status.assert_not_called()
+    mocked_jira.user_find_by_user_string.assert_not_called()
+    mocked_jira.update_issue_field.assert_not_called()
+    mocked_jira.set_issue_status.assert_not_called()
 
 
 def test_create_with_known_status(webhook_create_example, mocked_jira, mocked_bugzilla):
     webhook_create_example.bug.status = "ASSIGNED"
     webhook_create_example.bug.resolution = ""
 
-    mocked_jira().create_issue.return_value = {"key": "JBI-534"}
+    mocked_jira.create_issue.return_value = {"key": "JBI-534"}
 
-    mocked_bugzilla().getbug.return_value = webhook_create_example.bug
-    mocked_bugzilla().get_comments.return_value = {
+    mocked_bugzilla.getbug.return_value = webhook_create_example.bug
+    mocked_bugzilla.get_comments.return_value = {
         "bugs": {"654321": {"comments": [{"text": "Initial comment"}]}}
     }
 
@@ -165,7 +165,7 @@ def test_create_with_known_status(webhook_create_example, mocked_jira, mocked_bu
     )
     callable_object(payload=webhook_create_example)
 
-    mocked_jira().create_issue.assert_called_once_with(
+    mocked_jira.create_issue.assert_called_once_with(
         fields={
             "summary": "JBI Test",
             "labels": ["bugzilla", "devtest", "[devtest]"],
@@ -174,9 +174,9 @@ def test_create_with_known_status(webhook_create_example, mocked_jira, mocked_bu
             "project": {"key": "JBI"},
         },
     )
-    mocked_jira().user_find_by_user_string.assert_not_called()
-    mocked_jira().update_issue_field.assert_not_called()
-    mocked_jira().set_issue_status.assert_called_once_with("JBI-534", "In Progress")
+    mocked_jira.user_find_by_user_string.assert_not_called()
+    mocked_jira.update_issue_field.assert_not_called()
+    mocked_jira.set_issue_status.assert_called_once_with("JBI-534", "In Progress")
 
 
 def test_change_to_unknown_status(webhook_create_example, mocked_jira):
@@ -197,16 +197,16 @@ def test_change_to_unknown_status(webhook_create_example, mocked_jira):
     )
     callable_object(payload=webhook_create_example)
 
-    mocked_jira().create_issue.assert_not_called()
-    mocked_jira().user_find_by_user_string.assert_not_called()
-    mocked_jira().update_issue_field.assert_called_once_with(
+    mocked_jira.create_issue.assert_not_called()
+    mocked_jira.user_find_by_user_string.assert_not_called()
+    mocked_jira.update_issue_field.assert_called_once_with(
         key="JBI-234",
         fields={
             "summary": "JBI Test",
             "labels": ["bugzilla", "devtest", "[devtest]"],
         },
     )
-    mocked_jira().set_issue_status.assert_not_called()
+    mocked_jira.set_issue_status.assert_not_called()
 
 
 def test_change_to_known_status(webhook_create_example, mocked_jira):
@@ -227,16 +227,16 @@ def test_change_to_known_status(webhook_create_example, mocked_jira):
     )
     callable_object(payload=webhook_create_example)
 
-    mocked_jira().create_issue.assert_not_called()
-    mocked_jira().user_find_by_user_string.assert_not_called()
-    mocked_jira().update_issue_field.assert_called_once_with(
+    mocked_jira.create_issue.assert_not_called()
+    mocked_jira.user_find_by_user_string.assert_not_called()
+    mocked_jira.update_issue_field.assert_called_once_with(
         key="JBI-234",
         fields={
             "summary": "JBI Test",
             "labels": ["bugzilla", "devtest", "[devtest]"],
         },
     )
-    mocked_jira().set_issue_status.assert_called_once_with("JBI-234", "In Progress")
+    mocked_jira.set_issue_status.assert_called_once_with("JBI-234", "In Progress")
 
 
 def test_change_to_known_resolution(webhook_create_example, mocked_jira):
@@ -257,13 +257,13 @@ def test_change_to_known_resolution(webhook_create_example, mocked_jira):
     )
     callable_object(payload=webhook_create_example)
 
-    mocked_jira().create_issue.assert_not_called()
-    mocked_jira().user_find_by_user_string.assert_not_called()
-    mocked_jira().update_issue_field.assert_called_once_with(
+    mocked_jira.create_issue.assert_not_called()
+    mocked_jira.user_find_by_user_string.assert_not_called()
+    mocked_jira.update_issue_field.assert_called_once_with(
         key="JBI-234",
         fields={
             "summary": "JBI Test",
             "labels": ["bugzilla", "devtest", "[devtest]"],
         },
     )
-    mocked_jira().set_issue_status.assert_called_once_with("JBI-234", "Closed")
+    mocked_jira.set_issue_status.assert_called_once_with("JBI-234", "Closed")

--- a/tests/unit/actions/test_default_with_assignee_and_status.py
+++ b/tests/unit/actions/test_default_with_assignee_and_status.py
@@ -1,7 +1,11 @@
 from jbi.actions import default_with_assignee_and_status as action
 
 
-def test_create_with_no_assignee(webhook_create_example, mocked_jira):
+def test_create_with_no_assignee(webhook_create_example, mocked_jira, mocked_bugzilla):
+    mocked_bugzilla().getbug.return_value = webhook_create_example.bug
+    mocked_bugzilla().get_comments.return_value = {
+        "bugs": {"654321": {"comments": [{"text": "Initial comment"}]}}
+    }
     callable_object = action.init(jira_project_key="JBI")
     handled, _ = callable_object(payload=webhook_create_example)
 
@@ -22,6 +26,7 @@ def test_create_with_no_assignee(webhook_create_example, mocked_jira):
 
 def test_create_with_assignee(webhook_create_example, mocked_jira, mocked_bugzilla):
     webhook_create_example.bug.assigned_to = "dtownsend@mozilla.com"
+    mocked_bugzilla().getbug.return_value = webhook_create_example.bug
     mocked_jira().create_issue.return_value = {"key": "JBI-534"}
     mocked_jira().user_find_by_user_string.return_value = [{"accountId": "6254"}]
     mocked_bugzilla().get_comments.return_value = {
@@ -112,6 +117,7 @@ def test_create_with_unknown_status(
 ):
     webhook_create_example.bug.status = "NEW"
     webhook_create_example.bug.resolution = ""
+    mocked_bugzilla().getbug.return_value = webhook_create_example.bug
     mocked_bugzilla().get_comments.return_value = {
         "bugs": {"654321": {"comments": [{"text": "Initial comment"}]}}
     }
@@ -145,6 +151,7 @@ def test_create_with_known_status(webhook_create_example, mocked_jira, mocked_bu
 
     mocked_jira().create_issue.return_value = {"key": "JBI-534"}
 
+    mocked_bugzilla().getbug.return_value = webhook_create_example.bug
     mocked_bugzilla().get_comments.return_value = {
         "bugs": {"654321": {"comments": [{"text": "Initial comment"}]}}
     }

--- a/tests/unit/test_bugzilla.py
+++ b/tests/unit/test_bugzilla.py
@@ -104,7 +104,7 @@ def test_payload_changes_list_in_routing_key(webhook_change_status_assignee):
 
 def test_payload_bugzilla_object_public(mocked_bugzilla, webhook_modify_example):
     bug_obj = webhook_modify_example.bugzilla_object
-    mocked_bugzilla().getbug.assert_not_called()
+    mocked_bugzilla.getbug.assert_not_called()
     assert bug_obj.product == "JBI"
     assert bug_obj.status == "NEW"
     assert webhook_modify_example.bug == bug_obj
@@ -117,12 +117,12 @@ def test_bugzilla_object_private(mocked_bugzilla, webhook_modify_private_example
         is_private=webhook_modify_private_example.bug.is_private,
         see_also=["https://mozilla.atlassian.net/browse/JBI-234"],
     )
-    mocked_bugzilla().getbug.return_value = fetched_private_bug
+    mocked_bugzilla.getbug.return_value = fetched_private_bug
 
     # when a private bug's bugzilla_object property is accessed
     webhook_modify_private_example.bugzilla_object
     # then
-    mocked_bugzilla().getbug.assert_called_once_with(
+    mocked_bugzilla.getbug.assert_called_once_with(
         webhook_modify_private_example.bug.id
     )
     assert fetched_private_bug.product == "JBI"
@@ -131,4 +131,4 @@ def test_bugzilla_object_private(mocked_bugzilla, webhook_modify_private_example
     # when it is accessed again
     fetched_private_bug = webhook_modify_private_example.bugzilla_object
     # getbug was still only called once
-    mocked_bugzilla().getbug.assert_called_once()
+    mocked_bugzilla.getbug.assert_called_once()

--- a/tests/unit/test_bugzilla.py
+++ b/tests/unit/test_bugzilla.py
@@ -1,11 +1,6 @@
-"""
-Module for testing jbi/configuration.py functionality
-"""
-# pylint: disable=cannot-enumerate-pytest-fixtures
 import pytest
 
 from jbi.errors import ActionNotFoundError
-from jbi.models import BugzillaBug
 from tests.fixtures.factories import bug_factory
 
 
@@ -30,7 +25,7 @@ from tests.fixtures.factories import bug_factory
     ],
 )
 def test_jira_labels(whiteboard, expected):
-    bug = BugzillaBug(id=0, whiteboard=whiteboard)
+    bug = bug_factory(whiteboard=whiteboard)
     assert bug.get_jira_labels() == expected
 
 
@@ -52,19 +47,19 @@ def test_jira_labels(whiteboard, expected):
     ],
 )
 def test_extract_see_also(see_also, expected):
-    test_bug = BugzillaBug(id=0, see_also=see_also)
-    assert test_bug.extract_from_see_also() == expected
+    bug = bug_factory(see_also=see_also)
+    assert bug.extract_from_see_also() == expected
 
 
 def test_lookup_action(actions_example):
-    bug = BugzillaBug.parse_obj({"id": 1234, "whiteboard": "[example][DevTest]"})
+    bug = bug_factory(id=1234, whiteboard="[example][DevTest]")
     action = bug.lookup_action(actions_example)
     assert action.whiteboard_tag == "devtest"
     assert "test config" in action.description
 
 
 def test_lookup_action_missing(actions_example):
-    bug = BugzillaBug.parse_obj({"id": 1234, "whiteboard": "example DevTest"})
+    bug = bug_factory(id=1234, whiteboard="example DevTest")
     with pytest.raises(ActionNotFoundError) as exc_info:
         bug.lookup_action(actions_example)
     assert str(exc_info.value) == "example devtest"

--- a/tests/unit/test_configuration.py
+++ b/tests/unit/test_configuration.py
@@ -1,11 +1,6 @@
-"""
-Module for testing jbi/configuration.py functionality
-"""
-# pylint: disable=cannot-enumerate-pytest-fixtures
 import pytest
 
 from jbi import configuration
-from jbi.models import Actions
 
 
 def test_mock_jbi_files():
@@ -17,39 +12,3 @@ def test_mock_jbi_files():
 def test_actual_jbi_files():
     assert configuration.get_actions(jbi_config_file="config/config.nonprod.yaml")
     assert configuration.get_actions(jbi_config_file="config/config.prod.yaml")
-
-
-def test_no_actions_fails():
-    with pytest.raises(ValueError) as exc_info:
-        Actions.parse_obj([])
-    assert "ensure this value has at least 1 items" in str(exc_info.value)
-
-
-def test_unknown_module_fails():
-    with pytest.raises(ValueError) as exc_info:
-        Actions.parse_obj([{"whiteboard_tag": "x", "module": "path.to.unknown"}])
-    assert "unknown Python module `path.to.unknown`" in str(exc_info.value)
-
-
-def test_bad_module_fails():
-    with pytest.raises(ValueError) as exc_info:
-        Actions.parse_obj([{"whiteboard_tag": "x", "module": "jbi.runner"}])
-    assert "action is not properly setup" in str(exc_info.value)
-
-
-def test_duplicated_whiteboard_tag_fails():
-    action = {
-        "whiteboard_tag": "x",
-        "contact": "tbd",
-        "description": "foo",
-        "module": "tests.fixtures.noop_action",
-    }
-    with pytest.raises(ValueError) as exc_info:
-        Actions.parse_obj(
-            [
-                action,
-                {**action, "whiteboard_tag": "y"},
-                action,
-            ]
-        )
-    assert "actions have duplicated lookup tags: ['x']" in str(exc_info.value)

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -1,8 +1,8 @@
-from unittest.mock import patch
-
+import pytest
 from fastapi.encoders import jsonable_encoder
 
-from jbi.models import Action
+from jbi.models import Action, Actions
+from tests.fixtures.factories import action_factory
 
 
 def test_model_serializes():
@@ -19,3 +19,33 @@ def test_model_serializes():
     serialized_action = jsonable_encoder(action)
     assert not serialized_action.get("_caller")
     assert not serialized_action.get("caller")
+
+
+def test_no_actions_fails():
+    with pytest.raises(ValueError) as exc_info:
+        Actions.parse_obj([])
+    assert "ensure this value has at least 1 items" in str(exc_info.value)
+
+
+def test_unknown_module_fails():
+    with pytest.raises(ValueError) as exc_info:
+        Actions.parse_obj([{"whiteboard_tag": "x", "module": "path.to.unknown"}])
+    assert "unknown Python module `path.to.unknown`" in str(exc_info.value)
+
+
+def test_bad_module_fails():
+    with pytest.raises(ValueError) as exc_info:
+        Actions.parse_obj([{"whiteboard_tag": "x", "module": "jbi.runner"}])
+    assert "action is not properly setup" in str(exc_info.value)
+
+
+def test_duplicated_whiteboard_tag_fails():
+    with pytest.raises(ValueError) as exc_info:
+        Actions.parse_obj(
+            [
+                action_factory(whiteboard_tag="x"),
+                action_factory(whiteboard_tag="y"),
+                action_factory(whiteboard_tag="x"),
+            ]
+        )
+    assert "actions have duplicated lookup tags: ['x']" in str(exc_info.value)

--- a/tests/unit/test_router.py
+++ b/tests/unit/test_router.py
@@ -24,7 +24,7 @@ def test_whiteboard_tags(anon_client):
 
 
 def test_jira_projects(anon_client, mocked_jira):
-    mocked_jira().projects.return_value = [{"key": "Firefox"}, {"key": "Fenix"}]
+    mocked_jira.projects.return_value = [{"key": "Firefox"}, {"key": "Fenix"}]
 
     resp = anon_client.get("/jira_projects/")
     infos = resp.json()
@@ -66,8 +66,8 @@ def test_webhook_is_200_if_action_succeeds(
     mocked_jira,
     mocked_bugzilla,
 ):
-    mocked_bugzilla().getbug.return_value = webhook_create_example.bug
-    mocked_bugzilla().update_bugs.return_value = {
+    mocked_bugzilla.getbug.return_value = webhook_create_example.bug
+    mocked_bugzilla.update_bugs.return_value = {
         "bugs": [
             {
                 "changes": {
@@ -80,7 +80,7 @@ def test_webhook_is_200_if_action_succeeds(
             }
         ]
     }
-    mocked_jira().create_or_update_issue_remote_links.return_value = {
+    mocked_jira.create_or_update_issue_remote_links.return_value = {
         "id": 18936,
         "self": "https://mozilla.atlassian.net/rest/api/2/issue/JBI-1922/remotelink/18936",
     }
@@ -126,8 +126,8 @@ def test_read_version(anon_client):
 
 def test_read_heartbeat_all_services_fail(anon_client, mocked_jira, mocked_bugzilla):
     """/__heartbeat__ returns 503 when all the services are unavailable."""
-    mocked_bugzilla().logged_in = False
-    mocked_jira().get_server_info.return_value = None
+    mocked_bugzilla.logged_in = False
+    mocked_jira.get_server_info.return_value = None
 
     resp = anon_client.get("/__heartbeat__")
 
@@ -146,8 +146,8 @@ def test_read_heartbeat_all_services_fail(anon_client, mocked_jira, mocked_bugzi
 
 def test_read_heartbeat_jira_services_fails(anon_client, mocked_jira, mocked_bugzilla):
     """/__heartbeat__ returns 503 when one service is unavailable."""
-    mocked_bugzilla().logged_in = True
-    mocked_jira().get_server_info.return_value = None
+    mocked_bugzilla.logged_in = True
+    mocked_jira.get_server_info.return_value = None
 
     resp = anon_client.get("/__heartbeat__")
 
@@ -168,9 +168,9 @@ def test_read_heartbeat_bugzilla_services_fails(
     anon_client, mocked_jira, mocked_bugzilla
 ):
     """/__heartbeat__ returns 503 when one service is unavailable."""
-    mocked_bugzilla().logged_in = False
-    mocked_jira().get_server_info.return_value = {}
-    mocked_jira().projects.return_value = [{"key": "DevTest"}]
+    mocked_bugzilla.logged_in = False
+    mocked_jira.get_server_info.return_value = {}
+    mocked_jira.projects.return_value = [{"key": "DevTest"}]
 
     resp = anon_client.get("/__heartbeat__")
 
@@ -189,10 +189,10 @@ def test_read_heartbeat_bugzilla_services_fails(
 
 def test_read_heartbeat_success(anon_client, mocked_jira, mocked_bugzilla):
     """/__heartbeat__ returns 200 when checks succeed."""
-    mocked_bugzilla().logged_in = True
-    mocked_jira().get_server_info.return_value = {}
-    mocked_jira().projects.return_value = [{"key": "DevTest"}]
-    mocked_jira().get_permissions.return_value = {
+    mocked_bugzilla.logged_in = True
+    mocked_jira.get_server_info.return_value = {}
+    mocked_jira.projects.return_value = [{"key": "DevTest"}]
+    mocked_jira.get_permissions.return_value = {
         "permissions": {
             "ADD_COMMENTS": {"havePermission": True},
             "CREATE_ISSUES": {"havePermission": True},
@@ -218,8 +218,8 @@ def test_read_heartbeat_success(anon_client, mocked_jira, mocked_bugzilla):
 
 def test_jira_heartbeat_visible_projects(anon_client, mocked_jira, mocked_bugzilla):
     """/__heartbeat__ fails if configured projects don't match."""
-    mocked_bugzilla().logged_in = True
-    mocked_jira().get_server_info.return_value = {}
+    mocked_bugzilla.logged_in = True
+    mocked_jira.get_server_info.return_value = {}
 
     resp = anon_client.get("/__heartbeat__")
 
@@ -238,9 +238,9 @@ def test_jira_heartbeat_visible_projects(anon_client, mocked_jira, mocked_bugzil
 
 def test_jira_heartbeat_missing_permissions(anon_client, mocked_jira, mocked_bugzilla):
     """/__heartbeat__ fails if configured projects don't match."""
-    mocked_bugzilla().logged_in = True
-    mocked_jira().get_server_info.return_value = {}
-    mocked_jira().get_project_permission_scheme.return_value = {
+    mocked_bugzilla.logged_in = True
+    mocked_jira.get_server_info.return_value = {}
+    mocked_jira.get_project_permission_scheme.return_value = {
         "permissions": {
             "ADD_COMMENTS": {"havePermission": True},
             "CREATE_ISSUES": {"havePermission": True},
@@ -266,10 +266,10 @@ def test_jira_heartbeat_missing_permissions(anon_client, mocked_jira, mocked_bug
 
 def test_head_heartbeat(anon_client, mocked_jira, mocked_bugzilla):
     """/__heartbeat__ support head requests"""
-    mocked_bugzilla().logged_in = True
-    mocked_jira().get_server_info.return_value = {}
-    mocked_jira().projects.return_value = [{"key": "DevTest"}]
-    mocked_jira().get_permissions.return_value = {
+    mocked_bugzilla.logged_in = True
+    mocked_jira.get_server_info.return_value = {}
+    mocked_jira.projects.return_value = [{"key": "DevTest"}]
+    mocked_jira.get_permissions.return_value = {
         "permissions": {
             "ADD_COMMENTS": {"havePermission": True},
             "CREATE_ISSUES": {"havePermission": True},

--- a/tests/unit/test_router.py
+++ b/tests/unit/test_router.py
@@ -66,6 +66,7 @@ def test_webhook_is_200_if_action_succeeds(
     mocked_jira,
     mocked_bugzilla,
 ):
+    mocked_bugzilla().getbug.return_value = webhook_create_example.bug
     mocked_bugzilla().update_bugs.return_value = {
         "bugs": [
             {

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -13,14 +13,17 @@ from jbi.environment import Settings
 from jbi.errors import IgnoreInvalidRequestError
 from jbi.models import Action, Actions, BugzillaWebhookRequest
 from jbi.runner import execute_action
+from tests.fixtures.factories import bug_factory
 
 
 def test_request_is_ignored_because_private(
-    caplog,
     webhook_create_private_example: BugzillaWebhookRequest,
     actions_example: Actions,
     settings: Settings,
+    mocked_bugzilla,
 ):
+    bug = bug_factory(id=webhook_create_private_example.bug.id, is_private=True)
+    mocked_bugzilla().getbug.return_value = bug
     with pytest.raises(IgnoreInvalidRequestError) as exc_info:
         execute_action(
             request=webhook_create_private_example,
@@ -32,11 +35,13 @@ def test_request_is_ignored_because_private(
 
 
 def test_private_request_is_allowed(
-    caplog,
     webhook_create_private_example: BugzillaWebhookRequest,
     settings: Settings,
     actions_example,
+    mocked_bugzilla,
 ):
+    bug = bug_factory(id=webhook_create_private_example.bug.id, is_private=True)
+    mocked_bugzilla().getbug.return_value = bug
 
     actions_example["devtest"].allow_private = True
 

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -23,7 +23,7 @@ def test_request_is_ignored_because_private(
     mocked_bugzilla,
 ):
     bug = bug_factory(id=webhook_create_private_example.bug.id, is_private=True)
-    mocked_bugzilla().getbug.return_value = bug
+    mocked_bugzilla.getbug.return_value = bug
     with pytest.raises(IgnoreInvalidRequestError) as exc_info:
         execute_action(
             request=webhook_create_private_example,
@@ -41,7 +41,7 @@ def test_private_request_is_allowed(
     mocked_bugzilla,
 ):
     bug = bug_factory(id=webhook_create_private_example.bug.id, is_private=True)
-    mocked_bugzilla().getbug.return_value = bug
+    mocked_bugzilla.getbug.return_value = bug
 
     actions_example["devtest"].allow_private = True
 


### PR DESCRIPTION
This PR does several things that refactor our testing setup:
##### Decouple test objects from mocked service side effects
In some of our fixtures, we'd return an example test object, but also specify the returns of mocked side effects when that fixture was used. This made it slightly more challenging to modify test fixtures. It also wasn't obvious that the service mocking was happening when reading tests. 

Now, we set the return values of mocked services in tests. This makes tests a bit more verbose, but also makes them more explicit and obvious.

##### Add a `tests/fixtures/factories.py` module to facilitate easy test object creation

These factory functions aren't perfect, and eventually I'd like to move to using something like [pydantic-factories](https://github.com/Goldziher/pydantic-factories), but for now this is a good-enough approach to easily make different example objects in tests.

##### Move some action tests from `test_configuration.py` to `test_models.py`

Some of the Action tests in `test_configuration.py` were actually testing the Action validators, so it seemed more appropriate to have them live in `test_models.py`.