### PR TITLE
Allow disabling syncing whiteboard fields to Jira. Fixes #201

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -122,9 +122,9 @@
         "filename": "README.md",
         "hashed_secret": "04e78d6e804f2b59e6cb282cb9ed2c7bfd8a9737",
         "is_verified": false,
-        "line_number": 194
+        "line_number": 211
       }
     ]
   },
-  "generated_at": "2022-07-28T11:58:31Z"
+  "generated_at": "2022-08-17T08:30:43Z"
 }

--- a/README.md
+++ b/README.md
@@ -74,6 +74,9 @@ It will also set the Jira issue URL in the Bugzilla bug `see_also` field.
 - `jira_project_key`
     - string
     - The Jira project identifier
+- `sync_whiteboard_labels`
+    - boolean
+    - Whether to sync the Bugzilla status whiteboard labels to Jira. Defaults to `true`.
 
 Example configuration:
 ```yaml
@@ -83,6 +86,17 @@ Example configuration:
     module: jbi.actions.default
     parameters:
       jira_project_key: EXMPL
+```
+
+Example configuration that disables setting labels in Jira:
+```yaml
+    whiteboard_tag: example
+    contact: example@allizom.com
+    description: example configuration
+    module: jbi.actions.default
+    parameters:
+      jira_project_key: EXMPL
+      sync_whiteboard_labels: false
 ```
 
 ### Default with assignee and status action
@@ -101,6 +115,9 @@ If configured, the action supports setting the Jira issues's status when the Bug
 - `jira_project_key`
     - string
     - The Jira project identifier
+- `sync_whiteboard_labels`
+    - boolean
+    - Whether to sync the Bugzilla status whiteboard labels to Jira. Defaults to `true`.
 - `status_map` (optional)
     - mapping [str, str]
     - If defined, map the Bugzilla bug status to Jira issue status

--- a/config/config.prod.yaml
+++ b/config/config.prod.yaml
@@ -40,6 +40,7 @@
   module: jbi.actions.default_with_assignee_and_status
   parameters:
     jira_project_key: MR2
+    sync_whiteboard_labels: false
     status_map:
       ASSIGNED: In Progress
       FIXED: In Review

--- a/jbi/models.py
+++ b/jbi/models.py
@@ -266,13 +266,6 @@ class BugzillaBug(BaseModel):
         type_map: dict = {"enhancement": "Task", "task": "Task", "defect": "Bug"}
         return type_map.get(self.type, "Task")
 
-    def map_as_jira_issue(self) -> dict:
-        """Extract bug info as jira issue dictionary"""
-        return {
-            "summary": self.summary,
-            "labels": self.get_jira_labels(),
-        }
-
     def extract_from_see_also(self):
         """Extract Jira Issue Key from see_also if jira url present"""
         if not self.see_also and len(self.see_also) > 0:


### PR DESCRIPTION
For projects that make use of the Jira labels field JBI currently overwrites those labels everytime the synced bug changes. This allows disabling the syncing of the whiteboard fields.