### PR TITLE
Update to remote-link title; use URL, set icon favicon url.

### DIFF
--- a/jbi/actions/default.py
+++ b/jbi/actions/default.py
@@ -273,11 +273,13 @@ class DefaultExecutor:
             jira_key_in_response,
             extra=log_context.update(operation=Operation.LINK).dict(),
         )
+        icon_url = f"{settings.bugzilla_base_url}/favicon.ico"
         jira_response = self.jira_client.create_or_update_issue_remote_links(
             issue_key=jira_key_in_response,
             link_url=bugzilla_url,
             title=bugzilla_url,
-            icon_url=f"{settings.bugzilla_base_url}/favicon.ico",
+            icon_url=icon_url,
+            icon_title=icon_url,
         )
 
         self.update_issue(payload, bug_obj, jira_key_in_response, is_new=True)

--- a/jbi/actions/default.py
+++ b/jbi/actions/default.py
@@ -286,7 +286,7 @@ class DefaultExecutor:
         jira_response = self.jira_client.create_or_update_issue_remote_links(
             issue_key=jira_key_in_response,
             link_url=bugzilla_url,
-            title=f"Bugzilla Bug {bug_obj.id}",
+            title=bugzilla_url,
         )
 
         self.update_issue(payload, bug_obj, jira_key_in_response, is_new=True)

--- a/jbi/actions/default.py
+++ b/jbi/actions/default.py
@@ -287,6 +287,7 @@ class DefaultExecutor:
             issue_key=jira_key_in_response,
             link_url=bugzilla_url,
             title=bugzilla_url,
+            icon_url=f"{settings.bugzilla_base_url}/favicon.ico",
         )
 
         self.update_issue(payload, bug_obj, jira_key_in_response, is_new=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ fastapi = "^0.79.0"
 pydantic = {version = "^1.9.2", extras = ["dotenv", "email"]}
 uvicorn = {extras = ["standard"], version = "^0.18.2"}
 python-bugzilla = "^3.2.0"
-atlassian-python-api = { git = "https://github.com/atlassian-api/atlassian-python-api.git", rev = "82293a2ac9bfa" }
+atlassian-python-api = { git = "https://github.com/atlassian-api/atlassian-python-api.git", rev = "4e8698863e4d2" }
 dockerflow = "2022.7.0"
 Jinja2 = "^3.1.2"
 pydantic-yaml = {extras = ["pyyaml","ruamel"], version = "^0.8.0"}


### PR DESCRIPTION
#202 

After testing locally, this doesn't add the favicon--but is one step closer to what was previously expected.

The atlassian-python-api does not accept "icon" as part of the api, however if we use the Jira REST API, we should be able to add a link to a favicon. 