### PR TITLE
Update pyproject.toml; python minimum version: 3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["@mozilla/jbi-core"]
 license = "MPL"
 
 [tool.poetry.dependencies]
-python = ">=3.8, <3.11"
+python = ">=3.10 <3.11"
 fastapi = "^0.79.0"
 pydantic = {version = "^1.9.2", extras = ["dotenv", "email"]}
 uvicorn = {extras = ["standard"], version = "^0.18.2"}


### PR DESCRIPTION
We're using python 3.10 functionality here: https://github.com/mozilla/jira-bugzilla-integration/pull/199

Please update your local poetry instances! Thanks.