### PR TITLE
Updating querystring for logging.

### DIFF
--- a/jbi/log.py
+++ b/jbi/log.py
@@ -54,7 +54,7 @@ def format_request_summary_fields(
         "path": request.url.path,
         "method": request.method,
         "lang": request.headers.get("Accept-Language"),
-        "querystring": dict(request.query_params),
+        "querystring": str(dict(request.query_params)),
         "errno": 0,
         "t": int((current_time - request_time) * 1000.0),
         "time": datetime.fromtimestamp(current_time).isoformat(),

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -19,7 +19,7 @@ def test_request_summary_is_logged(caplog):
             assert summary.name == "request.summary"
             assert summary.method == "GET"
             assert summary.path == "/"
-            assert summary.querystring == {}
+            assert summary.querystring == "{}"
 
 
 def test_errors_are_reported_to_sentry(


### PR DESCRIPTION
request.query_params is a starlette QueryParam object. 

Test // Result
- [ ] request.query_params = `"querystring": "QueryParams('enabled=false&jbi_config_file=config%2Fconfig.nonprod.yaml')"`
- [ ] str(request.query_params) = `"querystring": "enabled=true&jbi_config_file=config%2Fconfig.nonprod.yaml"`
- [ ] ~dict(request.query_params) = `{}`~
    - Results in hundreds of columns in bq log schema
- [ ] json.dumps(request.query_params) = `'<class 'TypeError'>\nTypeError('Object of type QueryParams is not JSON serializable')`
- [ ] json.dumps(dict(request.query_params)) = `"querystring": "{\"enabled\": \"false\", \"jbi_config_file\":\"config/config.nonprod.yaml\"}"`
- [x] str(dict(request.query_params)) = `"querystring": "{'enabled': 'false', 'jbi_config_file': 'config/config.nonprod.yaml'}"`

Ref:
https://mozilla-hub.atlassian.net/browse/SVCSE-707