### PR TITLE
Return 4XX response if no bug is provided (fixes #418)

### DIFF
--- a/jbi/models.py
+++ b/jbi/models.py
@@ -317,7 +317,7 @@ class BugzillaWebhookRequest(BaseModel):
     webhook_id: int
     webhook_name: str
     event: BugzillaWebhookEvent
-    bug: Optional[BugzillaBug]
+    bug: BugzillaBug
 
     def map_as_jira_comment(self):
         """Extract comment from Webhook Event"""
@@ -379,8 +379,6 @@ class BugzillaWebhookRequest(BaseModel):
     @functools.cached_property
     def bugzilla_object(self) -> BugzillaBug:
         """Returns the bugzilla bug object, querying the API as needed for private bugs"""
-        if not self.bug:
-            raise ValueError("missing bug reference")
         if not self.bug.is_private:
             return self.bug
         return self.getbug_as_bugzilla_object()

--- a/jbi/runner.py
+++ b/jbi/runner.py
@@ -27,9 +27,7 @@ def execute_action(
     The value returned by the action call is returned.
     """
     log_context = {
-        "bug": {
-            "id": request.bug.id if request.bug else None,
-        },
+        "bug": request.bug.dict(),
         "request": request.dict(),
     }
     try:
@@ -37,8 +35,6 @@ def execute_action(
             "Handling incoming request",
             extra={"operation": Operation.HANDLE, **log_context},
         )
-        if not request.bug:
-            raise IgnoreInvalidRequestError("no bug data received")
 
         try:
             bug_obj: BugzillaBug = request.bugzilla_object

--- a/tests/unit/test_router.py
+++ b/tests/unit/test_router.py
@@ -111,6 +111,17 @@ def test_webhook_is_200_if_action_raises_IgnoreInvalidRequestError(
         )
 
 
+def test_webhook_is_422_if_bug_information_missing(webhook_create_example):
+    webhook_create_example.bug = None
+
+    with TestClient(app) as anon_client:
+        response = anon_client.post(
+            "/bugzilla_webhook", data=webhook_create_example.json()
+        )
+        assert response.status_code == 422
+        assert response.json()["detail"][0]["msg"] == "none is not an allowed value"
+
+
 def test_read_version(anon_client):
     """__version__ returns the contents of version.json."""
     here = os.path.dirname(__file__)

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -56,22 +56,6 @@ def test_private_request_is_allowed(
     assert payload.bug.id == 654321
 
 
-def test_request_is_ignored_because_no_bug(
-    webhook_create_example: BugzillaWebhookRequest,
-    actions_example: Actions,
-    settings: Settings,
-):
-    webhook_create_example.bug = None
-
-    with pytest.raises(IgnoreInvalidRequestError) as exc_info:
-        execute_action(
-            request=webhook_create_example,
-            actions=actions_example,
-            settings=settings,
-        )
-    assert str(exc_info.value) == "no bug data received"
-
-
 def test_request_is_ignored_because_no_action(
     webhook_create_example: BugzillaWebhookRequest,
     actions_example: Actions,


### PR DESCRIPTION
I have checked logs, and we haven't logged `no bug data received` a single time in the last 7 days. So, I would conclude that this is not a case we want to support (eg. return a gentle 200 if no bug provided).

<img width="592" alt="Screenshot 2022-08-25 at 12 11 35" src="https://user-images.githubusercontent.com/546692/186638252-786f9bef-9892-4f54-96be-d9f2088035da.png">

Unlike `no action matching bug whiteboard tags` for example...

<img width="949" alt="Screenshot 2022-08-25 at 11 56 32" src="https://user-images.githubusercontent.com/546692/186635881-5d852560-d792-478b-bc13-07b0d5bdebf9.png">
