### PR TITLE
Reorganize calls to Bugzilla into a dedicated class in `services.py`

### DIFF
--- a/jbi/actions/default.py
+++ b/jbi/actions/default.py
@@ -236,7 +236,7 @@ class DefaultExecutor:
 
         # In the time taken to create the Jira issue the bug may have been updated so
         # re-retrieve it to ensure we have the latest data.
-        bug_obj = self.bugzilla_client.getbug(bug_obj.id)
+        bug_obj = self.bugzilla_client.get_bug(bug_obj.id)
 
         jira_key_in_bugzilla = bug_obj.extract_from_see_also()
         _duplicate_creation_event = (

--- a/jbi/actions/default.py
+++ b/jbi/actions/default.py
@@ -94,17 +94,17 @@ class DefaultExecutor:
             )
             return False, {}
 
-        comment = payload.map_as_jira_comment()
-        if comment is None:
+        if bug_obj.comment is None:
             logger.debug(
                 "No matching comment found in payload",
                 extra=log_context.dict(),
             )
             return False, {}
 
+        formatted_comment = payload.map_as_jira_comment()
         jira_response = self.jira_client.issue_add_comment(
             issue_key=linked_issue_key,
-            comment=payload.map_as_jira_comment(),
+            comment=formatted_comment,
         )
         logger.debug(
             "Comment added to Jira issue %s",

--- a/jbi/actions/default.py
+++ b/jbi/actions/default.py
@@ -205,10 +205,8 @@ class DefaultExecutor:
             bug_obj.id,
             extra=log_context.dict(),
         )
-        comment_list = self.bugzilla_client.get_comments(idlist=[bug_obj.id])
-        description = comment_list["bugs"][str(bug_obj.id)]["comments"][0]["text"][
-            :JIRA_DESCRIPTION_CHAR_LIMIT
-        ]
+        comment_list = self.bugzilla_client.get_comments(bug_obj.id)
+        description = comment_list[0].text[:JIRA_DESCRIPTION_CHAR_LIMIT]
 
         fields = {
             **self.jira_fields(bug_obj),  # type: ignore

--- a/jbi/models.py
+++ b/jbi/models.py
@@ -315,13 +315,6 @@ class BugzillaBug(BaseModel):
 class BugzillaWebhookRequest(BaseModel):
     """Bugzilla Webhook Request Object"""
 
-    class Config:
-        """pydantic model config"""
-
-        keep_untouched = (
-            functools.cached_property,
-        )  # https://github.com/samuelcolvin/pydantic/issues/1241
-
     webhook_id: int
     webhook_name: str
     event: BugzillaWebhookEvent

--- a/jbi/models.py
+++ b/jbi/models.py
@@ -331,8 +331,6 @@ class BugzillaWebhookRequest(BaseModel):
         """Extract comment from Webhook Event"""
         commenter: BugzillaWebhookUser = self.event.user
         comment: BugzillaWebhookComment = self.bug.comment
-        if comment is None:
-            return None
         return f"*({commenter.login})* commented: \n{{quote}}{comment.body}{{quote}}"
 
     def map_as_jira_description(self):

--- a/jbi/models.py
+++ b/jbi/models.py
@@ -333,13 +333,6 @@ class BugzillaWebhookRequest(BaseModel):
         comment: BugzillaWebhookComment = self.bug.comment
         return f"*({commenter.login})* commented: \n{{quote}}{comment.body}{{quote}}"
 
-    def map_as_jira_description(self):
-        """Extract description as comment from Webhook Event"""
-        comment: BugzillaWebhookComment = self.bug.comment
-        comment_body: str = comment.body
-        body = f"*(description)*: \n{{quote}}{comment_body}{{quote}}"
-        return body
-
     def map_as_comments(
         self,
         status_log_enabled: bool = True,

--- a/jbi/models.py
+++ b/jbi/models.py
@@ -371,6 +371,15 @@ class BugzillaWebhookRequest(BaseModel):
         return [json.dumps(comment, indent=4) for comment in comments]
 
 
+class BugzillaComment(BaseModel):
+    """Bugzilla Comment"""
+
+    id: int
+    text: str
+    is_private: bool
+    creator: str
+
+
 class BugzillaApiResponse(BaseModel):
     """Bugzilla Response Object"""
 

--- a/jbi/runner.py
+++ b/jbi/runner.py
@@ -41,7 +41,7 @@ def execute_action(
         try:
             if request.bug.is_private:
                 request = request.copy(
-                    update={"bug": get_bugzilla().getbug(request.bug.id)}
+                    update={"bug": get_bugzilla().get_bug(request.bug.id)}
                 )
         except Exception as err:
             logger.exception("Failed to get bug: %s", err, extra=log_context.dict())

--- a/jbi/services.py
+++ b/jbi/services.py
@@ -99,7 +99,7 @@ class BugzillaClient:
         """Return `true` if credentials are valid"""
         return self._client.logged_in
 
-    def getbug(self, bugid) -> BugzillaBug:
+    def get_bug(self, bugid) -> BugzillaBug:
         """Return the Bugzilla object with all attributes"""
         response = self._client.getbug(bugid).__dict__
         bug = BugzillaBug.parse_obj(response)
@@ -129,7 +129,7 @@ def get_bugzilla():
         settings.bugzilla_base_url, api_key=str(settings.bugzilla_api_key)
     )
     instrumented_methods = (
-        "getbug",
+        "get_bug",
         "get_comments",
         "update_bugs",
     )

--- a/jbi/services.py
+++ b/jbi/services.py
@@ -9,6 +9,7 @@ import backoff
 import bugzilla as rh_bugzilla
 from atlassian import Jira, errors
 from statsd.defaults.env import statsd
+from pydantic import parse_obj_as
 
 from jbi import environment
 from jbi.models import BugzillaBug, BugzillaComment
@@ -115,7 +116,7 @@ class BugzillaClient:
         """Return the list of comments for the specified bug ID"""
         response = self._client.get_comments(idlist=[bugid])
         comments = response["bugs"][str(bugid)]["comments"]
-        return [BugzillaComment.parse_obj(comment) for comment in comments]
+        return parse_obj_as(list[BugzillaComment], comments)
 
     def update_bug(self, bugid, **attrs):
         """Update the specified bug with the specified attributes"""

--- a/jbi/services.py
+++ b/jbi/services.py
@@ -131,7 +131,7 @@ def get_bugzilla():
     instrumented_methods = (
         "get_bug",
         "get_comments",
-        "update_bugs",
+        "update_bug",
     )
     return InstrumentedClient(
         wrapped=bugzilla_client,

--- a/jbi/services.py
+++ b/jbi/services.py
@@ -8,8 +8,8 @@ from typing import TYPE_CHECKING
 import backoff
 import bugzilla as rh_bugzilla
 from atlassian import Jira, errors
-from statsd.defaults.env import statsd
 from pydantic import parse_obj_as
+from statsd.defaults.env import statsd
 
 from jbi import environment
 from jbi.models import BugzillaBug, BugzillaComment
@@ -108,6 +108,7 @@ class BugzillaClient:
         if bug.comment and bug.comment.is_private:
             comment_list = self.get_comments(bugid)
             matching_comments = [c for c in comment_list if c.id == bug.comment.id]
+            # If no matching entry is found, set `bug.comment` to `None`.
             found = matching_comments[0] if matching_comments else None
             bug = bug.copy(update={"comment": found})
         return bug

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,9 +32,12 @@ def settings():
 
 
 @pytest.fixture(autouse=True)
-def mocked_bugzilla():
-    with mock.patch("jbi.services.rh_bugzilla.Bugzilla") as mocked_bz:
-        yield mocked_bz()
+def mocked_bugzilla(request):
+    if "no_mocked_bugzilla" in request.keywords:
+        yield None
+    else:
+        with mock.patch("jbi.services.BugzillaClient") as mocked_bz:
+            yield mocked_bz()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/fixtures/factories.py
+++ b/tests/fixtures/factories.py
@@ -1,6 +1,7 @@
 from jbi.models import (
     Action,
     BugzillaBug,
+    BugzillaComment,
     BugzillaWebhookEvent,
     BugzillaWebhookRequest,
     BugzillaWebhookUser,
@@ -77,12 +78,14 @@ def webhook_factory(**overrides):
 
 
 def comment_factory(**overrides):
-    return {
-        "id": 343,
-        "text": "comment text",
-        "bug_id": 654321,
-        "count": 1,
-        "is_private": True,
-        "creator": "mathieu@mozilla.org",
-        **overrides,
-    }
+    return BugzillaComment.parse_obj(
+        {
+            "id": 343,
+            "text": "comment text",
+            "bug_id": 654321,
+            "count": 1,
+            "is_private": True,
+            "creator": "mathieu@mozilla.org",
+            **overrides,
+        }
+    )

--- a/tests/unit/actions/test_default.py
+++ b/tests/unit/actions/test_default.py
@@ -31,7 +31,7 @@ def test_default_returns_callable_with_data(
 ):
     sentinel = mock.sentinel
     mocked_jira.create_or_update_issue_remote_links.return_value = sentinel
-    mocked_bugzilla.getbug.return_value = webhook_create_example.bug
+    mocked_bugzilla.get_bug.return_value = webhook_create_example.bug
     callable_object = default.init(jira_project_key="")
 
     handled, details = callable_object(payload=webhook_create_example)
@@ -43,7 +43,7 @@ def test_default_returns_callable_with_data(
 def test_created_public(
     webhook_create_example: BugzillaWebhookRequest, mocked_jira, mocked_bugzilla
 ):
-    mocked_bugzilla.getbug.return_value = webhook_create_example.bug
+    mocked_bugzilla.get_bug.return_value = webhook_create_example.bug
     mocked_bugzilla.get_comments.return_value = [
         comment_factory(text="Initial comment")
     ]
@@ -117,7 +117,7 @@ def test_jira_returns_an_error(
 def test_disabled_label_field(
     webhook_create_example: BugzillaWebhookRequest, mocked_jira, mocked_bugzilla
 ):
-    mocked_bugzilla.getbug.return_value = webhook_create_example.bug
+    mocked_bugzilla.get_bug.return_value = webhook_create_example.bug
     mocked_bugzilla.get_comments.return_value = [
         comment_factory(text="Initial comment")
     ]

--- a/tests/unit/actions/test_default.py
+++ b/tests/unit/actions/test_default.py
@@ -44,9 +44,9 @@ def test_created_public(
     webhook_create_example: BugzillaWebhookRequest, mocked_jira, mocked_bugzilla
 ):
     mocked_bugzilla.getbug.return_value = webhook_create_example.bug
-    mocked_bugzilla.get_comments.return_value = {
-        "bugs": {"654321": {"comments": [{"text": "Initial comment"}]}}
-    }
+    mocked_bugzilla.get_comments.return_value = [
+        comment_factory(text="Initial comment")
+    ]
     callable_object = default.init(jira_project_key="JBI")
 
     callable_object(payload=webhook_create_example)
@@ -118,9 +118,9 @@ def test_disabled_label_field(
     webhook_create_example: BugzillaWebhookRequest, mocked_jira, mocked_bugzilla
 ):
     mocked_bugzilla.getbug.return_value = webhook_create_example.bug
-    mocked_bugzilla.get_comments.return_value = {
-        "bugs": {"654321": {"comments": [{"text": "Initial comment"}]}}
-    }
+    mocked_bugzilla.get_comments.return_value = [
+        comment_factory(text="Initial comment")
+    ]
     callable_object = default.init(jira_project_key="JBI", sync_whiteboard_labels=False)
 
     callable_object(payload=webhook_create_example)

--- a/tests/unit/actions/test_default.py
+++ b/tests/unit/actions/test_default.py
@@ -62,32 +62,6 @@ def test_created_public(
     )
 
 
-def test_created_private(
-    webhook_create_private_example: BugzillaWebhookRequest, mocked_jira, mocked_bugzilla
-):
-    fetched_private_bug = bug_factory(
-        id=webhook_create_private_example.bug.id,
-        is_private=webhook_create_private_example.bug.is_private,
-    )
-    mocked_bugzilla.getbug.return_value = fetched_private_bug
-    mocked_bugzilla.get_comments.return_value = {
-        "bugs": {"654321": {"comments": [{"text": "Initial comment"}]}}
-    }
-    callable_object = default.init(jira_project_key="JBI")
-
-    callable_object(payload=webhook_create_private_example)
-
-    mocked_jira.create_issue.assert_called_once_with(
-        fields={
-            "summary": "JBI Test",
-            "labels": ["bugzilla", "devtest", "[devtest]"],
-            "issuetype": {"name": "Bug"},
-            "description": "Initial comment",
-            "project": {"key": "JBI"},
-        },
-    )
-
-
 def test_modified_public(webhook_modify_example: BugzillaWebhookRequest, mocked_jira):
     assert webhook_modify_example.bug
     callable_object = default.init(jira_project_key="")
@@ -95,25 +69,6 @@ def test_modified_public(webhook_modify_example: BugzillaWebhookRequest, mocked_
     callable_object(payload=webhook_modify_example)
 
     assert webhook_modify_example.bug.extract_from_see_also(), "see_also is not empty"
-
-    mocked_jira.update_issue_field.assert_called_once_with(
-        key="JBI-234",
-        fields={"summary": "JBI Test", "labels": ["bugzilla", "devtest", "[devtest]"]},
-    )
-
-
-def test_modified_private(
-    webhook_modify_private_example: BugzillaWebhookRequest, mocked_jira, mocked_bugzilla
-):
-    fetched_private_bug = bug_factory(
-        id=webhook_modify_private_example.bug.id,
-        is_private=webhook_modify_private_example.bug.is_private,
-        see_also=["https://mozilla.atlassian.net/browse/JBI-234"],
-    )
-    mocked_bugzilla.getbug.return_value = fetched_private_bug
-    callable_object = default.init(jira_project_key="")
-
-    callable_object(payload=webhook_modify_private_example)
 
     mocked_jira.update_issue_field.assert_called_once_with(
         key="JBI-234",
@@ -131,51 +86,6 @@ def test_added_comment(webhook_comment_example: BugzillaWebhookRequest, mocked_j
         issue_key="JBI-234",
         comment="*(mathieu@mozilla.org)* commented: \n{quote}hello{quote}",
     )
-
-
-def test_added_private_comment(
-    webhook_private_comment_example, mocked_jira, mocked_bugzilla
-):
-    # given
-    comments = [
-        comment_factory(id=343, text="not this one", count=1),
-        comment_factory(id=344, text="hello", count=2),
-        comment_factory(id=345, text="not this one", count=3),
-    ]
-
-    mocked_bugzilla.get_comments.return_value = {
-        "bugs": {"654321": {"comments": comments}},
-        "comments": {},
-    }
-
-    callable_object = default.init(jira_project_key="")
-
-    # when the default action receives a webhook with a private comment (number 2)
-    callable_object(payload=webhook_private_comment_example)
-
-    # then
-    mocked_jira.issue_add_comment.assert_called_once_with(
-        issue_key="JBI-234",
-        comment="*(mathieu@mozilla.org)* commented: \n{quote}hello{quote}",
-    )
-
-
-def test_added_missing_private_comment(
-    webhook_private_comment_example: BugzillaWebhookRequest,
-    mocked_jira,
-    mocked_bugzilla,
-):
-
-    callable_object = default.init(jira_project_key="")
-    mocked_bugzilla.get_comments.return_value = {
-        "bugs": {str(webhook_private_comment_example.bug.id): {"comments": []}},
-        "comments": {},
-    }
-
-    handled, _ = callable_object(payload=webhook_private_comment_example)
-
-    mocked_jira.issue_add_comment.assert_not_called()
-    assert not handled
 
 
 def test_added_comment_without_linked_issue(

--- a/tests/unit/actions/test_default_with_assignee_and_status.py
+++ b/tests/unit/actions/test_default_with_assignee_and_status.py
@@ -3,7 +3,7 @@ from tests.fixtures.factories import comment_factory
 
 
 def test_create_with_no_assignee(webhook_create_example, mocked_jira, mocked_bugzilla):
-    mocked_bugzilla.getbug.return_value = webhook_create_example.bug
+    mocked_bugzilla.get_bug.return_value = webhook_create_example.bug
     mocked_bugzilla.get_comments.return_value = [
         comment_factory(text="Initial comment")
     ]
@@ -29,7 +29,7 @@ def test_create_with_no_assignee(webhook_create_example, mocked_jira, mocked_bug
 def test_create_with_assignee(webhook_create_example, mocked_jira, mocked_bugzilla):
     webhook_create_example.bug.assigned_to = "dtownsend@mozilla.com"
     # Make sure the bug fetched the second time in `create_and_link_issue()` also has the assignee.
-    mocked_bugzilla.getbug.return_value = webhook_create_example.bug
+    mocked_bugzilla.get_bug.return_value = webhook_create_example.bug
     mocked_jira.create_issue.return_value = {"key": "JBI-534"}
     mocked_jira.user_find_by_user_string.return_value = [{"accountId": "6254"}]
     mocked_bugzilla.get_comments.return_value = [
@@ -120,7 +120,7 @@ def test_create_with_unknown_status(
 ):
     webhook_create_example.bug.status = "NEW"
     webhook_create_example.bug.resolution = ""
-    mocked_bugzilla.getbug.return_value = webhook_create_example.bug
+    mocked_bugzilla.get_bug.return_value = webhook_create_example.bug
     mocked_bugzilla.get_comments.return_value = [
         comment_factory(text="Initial comment")
     ]
@@ -153,7 +153,7 @@ def test_create_with_known_status(webhook_create_example, mocked_jira, mocked_bu
     webhook_create_example.bug.status = "ASSIGNED"
     webhook_create_example.bug.resolution = ""
     # Make sure the bug fetched the second time in `create_and_link_issue()` also has the status.
-    mocked_bugzilla.getbug.return_value = webhook_create_example.bug
+    mocked_bugzilla.get_bug.return_value = webhook_create_example.bug
     mocked_bugzilla.get_comments.return_value = [
         comment_factory(text="Initial comment")
     ]

--- a/tests/unit/actions/test_default_with_assignee_and_status.py
+++ b/tests/unit/actions/test_default_with_assignee_and_status.py
@@ -27,6 +27,7 @@ def test_create_with_no_assignee(webhook_create_example, mocked_jira, mocked_bug
 
 def test_create_with_assignee(webhook_create_example, mocked_jira, mocked_bugzilla):
     webhook_create_example.bug.assigned_to = "dtownsend@mozilla.com"
+    # Make sure the bug fetched the second time in `create_and_link_issue()` also has the assignee.
     mocked_bugzilla.getbug.return_value = webhook_create_example.bug
     mocked_jira.create_issue.return_value = {"key": "JBI-534"}
     mocked_jira.user_find_by_user_string.return_value = [{"accountId": "6254"}]
@@ -150,13 +151,12 @@ def test_create_with_unknown_status(
 def test_create_with_known_status(webhook_create_example, mocked_jira, mocked_bugzilla):
     webhook_create_example.bug.status = "ASSIGNED"
     webhook_create_example.bug.resolution = ""
-
-    mocked_jira.create_issue.return_value = {"key": "JBI-534"}
-
+    # Make sure the bug fetched the second time in `create_and_link_issue()` also has the status.
     mocked_bugzilla.getbug.return_value = webhook_create_example.bug
     mocked_bugzilla.get_comments.return_value = {
         "bugs": {"654321": {"comments": [{"text": "Initial comment"}]}}
     }
+    mocked_jira.create_issue.return_value = {"key": "JBI-534"}
 
     callable_object = action.init(
         jira_project_key="JBI",

--- a/tests/unit/actions/test_default_with_assignee_and_status.py
+++ b/tests/unit/actions/test_default_with_assignee_and_status.py
@@ -1,11 +1,12 @@
 from jbi.actions import default_with_assignee_and_status as action
+from tests.fixtures.factories import comment_factory
 
 
 def test_create_with_no_assignee(webhook_create_example, mocked_jira, mocked_bugzilla):
     mocked_bugzilla.getbug.return_value = webhook_create_example.bug
-    mocked_bugzilla.get_comments.return_value = {
-        "bugs": {"654321": {"comments": [{"text": "Initial comment"}]}}
-    }
+    mocked_bugzilla.get_comments.return_value = [
+        comment_factory(text="Initial comment")
+    ]
     mocked_jira.create_issue.return_value = {"key": "new-id"}
     callable_object = action.init(jira_project_key="JBI")
     handled, _ = callable_object(payload=webhook_create_example)
@@ -31,9 +32,9 @@ def test_create_with_assignee(webhook_create_example, mocked_jira, mocked_bugzil
     mocked_bugzilla.getbug.return_value = webhook_create_example.bug
     mocked_jira.create_issue.return_value = {"key": "JBI-534"}
     mocked_jira.user_find_by_user_string.return_value = [{"accountId": "6254"}]
-    mocked_bugzilla.get_comments.return_value = {
-        "bugs": {"654321": {"comments": [{"text": "Initial comment"}]}}
-    }
+    mocked_bugzilla.get_comments.return_value = [
+        comment_factory(text="Initial comment")
+    ]
 
     callable_object = action.init(jira_project_key="JBI")
     callable_object(payload=webhook_create_example)
@@ -120,9 +121,9 @@ def test_create_with_unknown_status(
     webhook_create_example.bug.status = "NEW"
     webhook_create_example.bug.resolution = ""
     mocked_bugzilla.getbug.return_value = webhook_create_example.bug
-    mocked_bugzilla.get_comments.return_value = {
-        "bugs": {"654321": {"comments": [{"text": "Initial comment"}]}}
-    }
+    mocked_bugzilla.get_comments.return_value = [
+        comment_factory(text="Initial comment")
+    ]
     mocked_jira.create_issue.return_value = {"key": "new-id"}
 
     callable_object = action.init(
@@ -153,9 +154,9 @@ def test_create_with_known_status(webhook_create_example, mocked_jira, mocked_bu
     webhook_create_example.bug.resolution = ""
     # Make sure the bug fetched the second time in `create_and_link_issue()` also has the status.
     mocked_bugzilla.getbug.return_value = webhook_create_example.bug
-    mocked_bugzilla.get_comments.return_value = {
-        "bugs": {"654321": {"comments": [{"text": "Initial comment"}]}}
-    }
+    mocked_bugzilla.get_comments.return_value = [
+        comment_factory(text="Initial comment")
+    ]
     mocked_jira.create_issue.return_value = {"key": "JBI-534"}
 
     callable_object = action.init(

--- a/tests/unit/test_bugzilla.py
+++ b/tests/unit/test_bugzilla.py
@@ -100,35 +100,3 @@ def test_payload_changes_list_in_routing_key(webhook_change_status_assignee):
         "assigned_to",
         "status",
     ]
-
-
-def test_payload_bugzilla_object_public(mocked_bugzilla, webhook_modify_example):
-    bug_obj = webhook_modify_example.bugzilla_object
-    mocked_bugzilla.getbug.assert_not_called()
-    assert bug_obj.product == "JBI"
-    assert bug_obj.status == "NEW"
-    assert webhook_modify_example.bug == bug_obj
-
-
-def test_bugzilla_object_private(mocked_bugzilla, webhook_modify_private_example):
-    # given
-    fetched_private_bug = bug_factory(
-        id=webhook_modify_private_example.bug.id,
-        is_private=webhook_modify_private_example.bug.is_private,
-        see_also=["https://mozilla.atlassian.net/browse/JBI-234"],
-    )
-    mocked_bugzilla.getbug.return_value = fetched_private_bug
-
-    # when a private bug's bugzilla_object property is accessed
-    webhook_modify_private_example.bugzilla_object
-    # then
-    mocked_bugzilla.getbug.assert_called_once_with(
-        webhook_modify_private_example.bug.id
-    )
-    assert fetched_private_bug.product == "JBI"
-    assert fetched_private_bug.status == "NEW"
-
-    # when it is accessed again
-    fetched_private_bug = webhook_modify_private_example.bugzilla_object
-    # getbug was still only called once
-    mocked_bugzilla.getbug.assert_called_once()

--- a/tests/unit/test_bugzilla.py
+++ b/tests/unit/test_bugzilla.py
@@ -66,11 +66,6 @@ def test_lookup_action_missing(actions_example):
     assert str(exc_info.value) == "example devtest"
 
 
-def test_map_jira_description(webhook_comment_example):
-    desc = webhook_comment_example.map_as_jira_description()
-    assert desc == "*(description)*: \n{quote}hello{quote}"
-
-
 def test_map_as_comments(webhook_change_status_assignee):
     mapped = webhook_change_status_assignee.map_as_comments(
         status_log_enabled=True, assignee_log_enabled=True

--- a/tests/unit/test_router.py
+++ b/tests/unit/test_router.py
@@ -67,7 +67,7 @@ def test_webhook_is_200_if_action_succeeds(
     mocked_bugzilla,
 ):
     mocked_bugzilla.getbug.return_value = webhook_create_example.bug
-    mocked_bugzilla.update_bugs.return_value = {
+    mocked_bugzilla.update_bug.return_value = {
         "bugs": [
             {
                 "changes": {

--- a/tests/unit/test_router.py
+++ b/tests/unit/test_router.py
@@ -66,7 +66,7 @@ def test_webhook_is_200_if_action_succeeds(
     mocked_jira,
     mocked_bugzilla,
 ):
-    mocked_bugzilla.getbug.return_value = webhook_create_example.bug
+    mocked_bugzilla.get_bug.return_value = webhook_create_example.bug
     mocked_bugzilla.update_bug.return_value = {
         "bugs": [
             {

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -23,7 +23,7 @@ def test_request_is_ignored_because_private(
     mocked_bugzilla,
 ):
     bug = bug_factory(id=webhook_create_private_example.bug.id, is_private=True)
-    mocked_bugzilla.getbug.return_value = bug
+    mocked_bugzilla.get_bug.return_value = bug
     with pytest.raises(IgnoreInvalidRequestError) as exc_info:
         execute_action(
             request=webhook_create_private_example,
@@ -41,7 +41,7 @@ def test_private_request_is_allowed(
     mocked_bugzilla,
 ):
     bug = bug_factory(id=webhook_create_private_example.bug.id, is_private=True)
-    mocked_bugzilla.getbug.return_value = bug
+    mocked_bugzilla.get_bug.return_value = bug
 
     actions_example["devtest"].allow_private = True
 
@@ -228,7 +228,7 @@ def test_bugzilla_object_is_fetched_when_private(
         is_private=webhook_modify_private_example.bug.is_private,
         see_also=["https://mozilla.atlassian.net/browse/JBI-234"],
     )
-    mocked_bugzilla.getbug.return_value = fetched_private_bug
+    mocked_bugzilla.get_bug.return_value = fetched_private_bug
     actions_example["devtest"].allow_private = True
 
     # when the runner executes a private bug
@@ -239,6 +239,6 @@ def test_bugzilla_object_is_fetched_when_private(
     )
 
     # then
-    mocked_bugzilla.getbug.assert_called_once_with(
+    mocked_bugzilla.get_bug.assert_called_once_with(
         webhook_modify_private_example.bug.id
     )

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -215,3 +215,30 @@ def test_counter_is_incremented_on_processed_requests(
             settings=settings,
         )
     mocked.incr.assert_called_with("jbi.bugzilla.processed.count")
+
+
+def test_bugzilla_object_is_fetched_when_private(
+    mocked_bugzilla,
+    webhook_modify_private_example,
+    actions_example: Actions,
+    settings: Settings,
+):
+    fetched_private_bug = bug_factory(
+        id=webhook_modify_private_example.bug.id,
+        is_private=webhook_modify_private_example.bug.is_private,
+        see_also=["https://mozilla.atlassian.net/browse/JBI-234"],
+    )
+    mocked_bugzilla.getbug.return_value = fetched_private_bug
+    actions_example["devtest"].allow_private = True
+
+    # when the runner executes a private bug
+    execute_action(
+        request=webhook_modify_private_example,
+        actions=actions_example,
+        settings=settings,
+    )
+
+    # then
+    mocked_bugzilla.getbug.assert_called_once_with(
+        webhook_modify_private_example.bug.id
+    )

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -37,28 +37,46 @@ def test_timer_is_used_on_bugzilla_getcomments():
     mocked.timer.assert_called_with("jbi.bugzilla.methods.get_comments.timer")
 
 
+@pytest.mark.no_mocked_bugzilla
 def test_bugzilla_methods_are_retried_if_raising():
-    with mock.patch(
-        "jbi.services.rh_bugzilla.Bugzilla.return_value.get_comments"
-    ) as mocked:
-        mocked.side_effect = (bugzilla.BugzillaError("boom"), [mock.sentinel])
+    with mock.patch("jbi.services.rh_bugzilla.Bugzilla") as mocked_bugzilla:
+        mocked_bugzilla().get_comments.side_effect = [
+            bugzilla.BugzillaError("boom"),
+            {"bugs": {"42": {"comments": []}}},
+        ]
         bugzilla_client = get_bugzilla()
 
         # Not raising
-        bugzilla_client.get_comments([])
+        bugzilla_client.get_comments(42)
 
-    assert mocked.call_count == 2
+    assert mocked_bugzilla().get_comments.call_count == 2
 
 
+@pytest.mark.no_mocked_bugzilla
 def test_bugzilla_get_bug_comment(webhook_private_comment_example):
     # given
     with mock.patch("jbi.services.rh_bugzilla.Bugzilla") as mocked_bugzilla:
         mocked_bugzilla().getbug.return_value = webhook_private_comment_example.bug
 
         comments = [
-            comment_factory(id=343, text="not this one", count=1),
-            comment_factory(id=344, text="hello", count=2),
-            comment_factory(id=345, text="not this one", count=3),
+            {
+                "id": 343,
+                "text": "not this one",
+                "is_private": False,
+                "creator": "mathieu@mozilla.org",
+            },
+            {
+                "id": 344,
+                "text": "hello",
+                "is_private": False,
+                "creator": "mathieu@mozilla.org",
+            },
+            {
+                "id": 345,
+                "text": "not this one",
+                "is_private": False,
+                "creator": "mathieu@mozilla.org",
+            },
         ]
         mocked_bugzilla().get_comments.return_value = {
             "bugs": {
@@ -70,10 +88,11 @@ def test_bugzilla_get_bug_comment(webhook_private_comment_example):
         expanded = get_bugzilla().getbug(webhook_private_comment_example.bug.id)
 
     # then
-    assert expanded.comment["creator"] == "mathieu@mozilla.org"
-    assert expanded.comment["text"] == "hello"
+    assert expanded.comment.creator == "mathieu@mozilla.org"
+    assert expanded.comment.text == "hello"
 
 
+@pytest.mark.no_mocked_bugzilla
 def test_bugzilla_missing_private_comment(
     webhook_private_comment_example,
 ):

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -85,7 +85,7 @@ def test_bugzilla_get_bug_comment(webhook_private_comment_example):
             "comments": {},
         }
 
-        expanded = get_bugzilla().getbug(webhook_private_comment_example.bug.id)
+        expanded = get_bugzilla().get_bug(webhook_private_comment_example.bug.id)
 
     # then
     assert expanded.comment.creator == "mathieu@mozilla.org"
@@ -104,6 +104,6 @@ def test_bugzilla_missing_private_comment(
             "comments": {},
         }
 
-        expanded = get_bugzilla().getbug(webhook_private_comment_example.bug.id)
+        expanded = get_bugzilla().get_bug(webhook_private_comment_example.bug.id)
 
     assert not expanded.comment


### PR DESCRIPTION
* [x] Refactor
* [x] Remove useless assignments in tests
* [x] Remove notion of private bugs in tests (now responsibility of runner)
* [x] Wait for #219 to clean up cases where `payload.bug` can be `None`