### PR TITLE
Remove class inheritance between default and default with status and assignee (ref #77)

### DIFF
--- a/tests/unit/actions/test_default.py
+++ b/tests/unit/actions/test_default.py
@@ -42,7 +42,7 @@ def test_default_returns_callable_with_data(
     )
 
     assert handled
-    assert details["jira_response"] == sentinel
+    assert details["responses"][-1] == sentinel
 
 
 def test_created_public(


### PR DESCRIPTION
By removing the inheritance between the two actions, we pave the way for #77 and the resulting create/update/update workflows, although they have some duplicate bits, can be read from top to bottom.

