### PR TITLE
Start migrating source code to strict typing

### DIFF
--- a/jbi/app.py
+++ b/jbi/app.py
@@ -4,9 +4,10 @@ Core FastAPI app (setup, middleware)
 import logging
 import time
 from pathlib import Path
+from typing import Awaitable, Callable
 
 import sentry_sdk
-from fastapi import FastAPI, Request
+from fastapi import FastAPI, Request, Response
 from fastapi.staticfiles import StaticFiles
 from sentry_sdk.integrations.fastapi import FastApiIntegration
 from sentry_sdk.integrations.starlette import StarletteIntegration
@@ -41,7 +42,9 @@ app.mount("/static", StaticFiles(directory=SRC_DIR / "static"), name="static")
 
 
 @app.middleware("http")
-async def request_summary(request: Request, call_next):
+async def request_summary(
+    request: Request, call_next: Callable[[Request], Awaitable[Response]]
+) -> Response:
     """Middleware to log request info"""
     summary_logger = logging.getLogger("request.summary")
     request_time = time.time()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,24 @@ warn_return_any = true
 module = ["ruamel", "bugzilla", "atlassian", "statsd.defaults.env"]
 ignore_missing_imports = true
 
+[[tool.mypy.overrides]]
+module = [
+    "jbi.app"
+]
+disallow_any_generics = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_defs = true
+disallow_incomplete_defs = true
+check_untyped_defs = true
+disallow_untyped_decorators = true
+no_implicit_optional = true
+warn_unused_ignores = true
+warn_return_any = true
+no_implicit_reexport = true
+strict_equality = true
+strict_concatenate = true
+
 [tool.coverage]
 # https://github.com/nedbat/coveragepy
     [tool.coverage.run]


### PR DESCRIPTION
In this commit, we start the process of migrating the project to being strictly typed with mypy.

To do this, we use mypy config to enable all strict type rules that apply to the module level (some strict rules can't be applied at the module level). We also specify a list of modules to apply those rules against. The goal will be to gradually add more modules to the list until we've added all of the modules, at which point we will check the entire source directory with `strict` enabled.