### PR TITLE
Add test for tag without trailing dash

### DIFF
--- a/tests/unit/test_bugzilla.py
+++ b/tests/unit/test_bugzilla.py
@@ -8,6 +8,7 @@ from tests.fixtures.factories import bug_factory
     "whiteboard,expected",
     [
         ("", ["bugzilla"]),
+        ("[tag]", ["bugzilla", "tag", "[tag]"]),
         ("[test whiteboard]", ["bugzilla", "test.whiteboard", "[test.whiteboard]"]),
         ("[test-whiteboard]", ["bugzilla", "test-whiteboard", "[test-whiteboard]"]),
         (


### PR DESCRIPTION
While debugging our STAGE instance, there was a doubt whether a tag had to have a trailing dash (eg. `[tag-]`).
This PR adds a test that asserts that it's not the case