### PR TITLE
Rename components parameters to jira_components (follow-up #256)

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ to the Bugzilla ticket on the Jira issue.
     - mapping [str, list[str]]
     - If defined, the specified steps are executed. The group of steps listed under `new` are executed when a Bugzilla event occurs on a ticket that is unknown to Jira. The steps under `existing`, when the Bugzilla ticket is already linked to a Jira issue. The steps under `comment` when a comment is posted on a linked Bugzilla ticket.
     If one of these groups is not specified, the default steps will be used.
-- `components` (optional)
+- `jira_components` (optional)
    - list [str]
    - If defined, the created issues will be assigned the specified components.
 - `sync_whiteboard_labels` (optional)

--- a/config/config.local.yaml
+++ b/config/config.local.yaml
@@ -6,5 +6,5 @@
   enabled: true
   parameters:
     jira_project_key: DevTest
-    components:
+    jira_components:
       - "Main"

--- a/jbi/actions/steps.py
+++ b/jbi/actions/steps.py
@@ -31,7 +31,7 @@ def create_comment(context: ActionContext, **parameters):
 def create_issue(context: ActionContext, **parameters):
     """Create the Jira issue with the first comment as the description."""
     sync_whiteboard_labels: bool = parameters.get("sync_whiteboard_labels", True)
-    components: list[str] = parameters.get("components", [])
+    jira_components: list[str] = parameters.get("jira_components", [])
     bug = context.bug
 
     # In the payload of a bug creation, the `comment` field is `null`.
@@ -43,7 +43,7 @@ def create_issue(context: ActionContext, **parameters):
         context,
         description,
         sync_whiteboard_labels=sync_whiteboard_labels,
-        components=components,
+        components=jira_components,
     )
     issue_key = jira_create_response.get("key")
 

--- a/jbi/services/jira.py
+++ b/jbi/services/jira.py
@@ -148,9 +148,9 @@ def _validate_permissions(all_projects_perms):
 
 def _all_projects_components_exist(actions: Actions):
     components_by_project = {
-        action.parameters["jira_project_key"]: action.parameters["components"]
+        action.parameters["jira_project_key"]: action.parameters["jira_components"]
         for action in actions
-        if "components" in action.parameters
+        if "jira_components" in action.parameters
     }
     success = True
     for project, specified_components in components_by_project.items():


### PR DESCRIPTION
Since we have the parameter `jira_project_key`, I think it makes more sense for `components` to be `jira_components` See #256 