### PR TITLE
Update app.py info

### DIFF
--- a/jbi/app.py
+++ b/jbi/app.py
@@ -33,7 +33,7 @@ sentry_sdk.init(
 
 app = FastAPI(
     title="Jira Bugzilla Integration (JBI)",
-    description="JBI v2 Platform",
+    description="Platform providing default and customized synchronization for bugzilla bugs.",
     version=version_info["version"],
     debug=settings.app_debug,
 )


### PR DESCRIPTION
This info displays on [the site](https://jbi.services.mozilla.com/):
<img width="476" alt="Screen Shot 2022-10-19 at 10 58 26 AM" src="https://user-images.githubusercontent.com/53873986/196768787-7dd2bc76-488b-400c-9fc2-846b78b1a917.png">

version: v4.0.2
description: "v2" 

For consistency, the idea of versioning in JBI should be removed throughout the code; _we plan to use Git Tags for versioning moving forward._ 