### PR TITLE
Remove GeckoView Team tag

### DIFF
--- a/config/config.prod.yaml
+++ b/config/config.prod.yaml
@@ -92,13 +92,6 @@
   parameters:
     jira_project_key: SYNC
 
-- whiteboard_tag: gv
-  contact: tbd
-  description: GeckoView Team whiteboard tag
-  enabled: true
-  parameters:
-    jira_project_key: ANDP
-
 - whiteboard_tag: mv3
   contact: tbd
   description: MV3 whiteboard tag


### PR DESCRIPTION
The `ANDP` Jira project that this tag is syncing to was created, but never used. I will talk with Jira admins elsewhere about whether we should delete the unused `ANDP` Jira project, but in the meantime, we should ~start~ stop trying to sync to it.