### PR TITLE
[config] adding FXDROID config

### DIFF
--- a/config/config.nonprod.yaml
+++ b/config/config.nonprod.yaml
@@ -32,3 +32,40 @@
       ASSIGNED: In Progress
       FIXED: In Review
       REOPENED: In Progress
+
+- whiteboard_tag: fxdroid
+  contact: cpeterson@mozilla.com
+  description: Firefox Android Team Tag
+  enabled: true
+  parameters:
+    jira_project_key: FXDROID
+    steps:
+      new:
+      - create_issue
+      - maybe_delete_duplicate
+      - add_link_to_bugzilla
+      - add_link_to_jira
+      - maybe_assign_jira_user
+      - maybe_update_issue_resolution
+      - maybe_update_issue_status
+      existing:
+      - update_issue
+      - maybe_assign_jira_user
+      - maybe_update_issue_resolution
+      - maybe_update_issue_status
+    status_map:
+      UNCONFIRMED: Backlog
+      NEW: Backlog
+      ASSIGNED: In Progress
+      RESOLVED: Closed
+      REOPENED: In Progress
+      VERIFIED: Closed
+    resolution_map:
+      FIXED: Fixed
+      INVALID: Won't Do
+      WONTFIX: Won't Do
+      INACTIVE: Won't Do
+      DUPLICATE: Duplicate
+      WORKSFORME: Cannot Reproduce
+      INCOMPLETE: Won't Do
+      MOVED: Duplicate

--- a/config/config.nonprod.yaml
+++ b/config/config.nonprod.yaml
@@ -41,18 +41,18 @@
     jira_project_key: FXDROID
     steps:
       new:
-      - create_issue
-      - maybe_delete_duplicate
-      - add_link_to_bugzilla
-      - add_link_to_jira
-      - maybe_assign_jira_user
-      - maybe_update_issue_resolution
-      - maybe_update_issue_status
+        - create_issue
+        - maybe_delete_duplicate
+        - add_link_to_bugzilla
+        - add_link_to_jira
+        - maybe_assign_jira_user
+        - maybe_update_issue_resolution
+        - maybe_update_issue_status
       existing:
-      - update_issue
-      - maybe_assign_jira_user
-      - maybe_update_issue_resolution
-      - maybe_update_issue_status
+        - update_issue
+        - maybe_assign_jira_user
+        - maybe_update_issue_resolution
+        - maybe_update_issue_status
     status_map:
       UNCONFIRMED: Backlog
       NEW: Backlog

--- a/config/config.prod.yaml
+++ b/config/config.prod.yaml
@@ -85,6 +85,43 @@
   parameters:
     jira_project_key: FXCM
 
+- whiteboard_tag: fxdroid
+  contact: cpeterson@mozilla.com
+  description: Firefox Android Team Tag
+  enabled: true
+  parameters:
+    jira_project_key: FXDROID
+    steps:
+      new:
+      - create_issue
+      - maybe_delete_duplicate
+      - add_link_to_bugzilla
+      - add_link_to_jira
+      - maybe_assign_jira_user
+      - maybe_update_issue_resolution
+      - maybe_update_issue_status
+      existing:
+      - update_issue
+      - maybe_assign_jira_user
+      - maybe_update_issue_resolution
+      - maybe_update_issue_status
+    status_map:
+      UNCONFIRMED: Backlog
+      NEW: Backlog
+      ASSIGNED: In Progress
+      RESOLVED: Closed
+      REOPENED: In Progress
+      VERIFIED: Closed
+    resolution_map:
+      FIXED: Fixed
+      INVALID: Won't Do
+      WONTFIX: Won't Do
+      INACTIVE: Won't Do
+      DUPLICATE: Duplicate
+      WORKSFORME: Cannot Reproduce
+      INCOMPLETE: Won't Do
+      MOVED: Duplicate
+
 - whiteboard_tag: fxsync
   contact: tbd
   description: Firefox Sync Team whiteboard tag

--- a/config/config.prod.yaml
+++ b/config/config.prod.yaml
@@ -93,18 +93,18 @@
     jira_project_key: FXDROID
     steps:
       new:
-      - create_issue
-      - maybe_delete_duplicate
-      - add_link_to_bugzilla
-      - add_link_to_jira
-      - maybe_assign_jira_user
-      - maybe_update_issue_resolution
-      - maybe_update_issue_status
+        - create_issue
+        - maybe_delete_duplicate
+        - add_link_to_bugzilla
+        - add_link_to_jira
+        - maybe_assign_jira_user
+        - maybe_update_issue_resolution
+        - maybe_update_issue_status
       existing:
-      - update_issue
-      - maybe_assign_jira_user
-      - maybe_update_issue_resolution
-      - maybe_update_issue_status
+        - update_issue
+        - maybe_assign_jira_user
+        - maybe_update_issue_resolution
+        - maybe_update_issue_status
     status_map:
       UNCONFIRMED: Backlog
       NEW: Backlog


### PR DESCRIPTION
#301 

- jira project is here: https://mozit-test.atlassian.net/jira/software/c/projects/FXDROID/boards/515

_The expected behavior should be testable once this merges with main; the [fxdroid] tag in the bmo nonporod environment should then be working here:
https://bugzilla-dev.allizom.org_