### PR TITLE
Force environment enum value representation

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -11,7 +11,7 @@ jobs:
         run: pipx install poetry
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
           cache: "poetry"
       - name: Install dependencies
         run: poetry install

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,7 +11,7 @@ jobs:
         run: pipx install poetry
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
           cache: "poetry"
       - name: Install dependencies
         run: poetry install

--- a/jbi/environment.py
+++ b/jbi/environment.py
@@ -17,6 +17,10 @@ class Environment(str, Enum):
     NONPROD = "nonprod"
     PROD = "prod"
 
+    def __str__(self):
+        # Force enum string representation to be the value instead 'Environment.NAME'
+        return str(self._value_)  # # pylint: disable=no-member
+
 
 class SentryDsn(AnyUrl):
     """Url type to validate Sentry DSN"""

--- a/tests/unit/test_configuration.py
+++ b/tests/unit/test_configuration.py
@@ -1,6 +1,8 @@
+from unittest import mock
+
 import pytest
 
-from jbi import configuration
+from jbi import configuration, environment
 
 
 def test_mock_jbi_files():
@@ -12,3 +14,17 @@ def test_mock_jbi_files():
 def test_actual_jbi_files():
     assert configuration.get_actions(jbi_config_file="config/config.nonprod.yaml")
     assert configuration.get_actions(jbi_config_file="config/config.prod.yaml")
+
+
+def test_filename_uses_env():
+    with mock.patch("jbi.configuration.Actions.parse_file") as mocked:
+        configuration.get_actions()
+    mocked.assert_called_with("config/config.local.yaml")
+
+
+def test_settings_env_is_enum_string():
+    settings = environment.Settings()
+    settings.env = environment.Environment.PROD
+
+    assert settings.env == "prod"
+    assert str(settings.env) == "prod"


### PR DESCRIPTION
4.0.4 has a bug because with Python 3.11 `str(Environment.PROD) == "Environment.PROD"`

This patch forces the string representation of the environment Enum.

Alternatively we could have used Python 3.11's `StrEnum`, but [mypy does not support it](https://github.com/python/mypy/issues/11714)
