### PR TITLE
Iss 301 status and resolution map

### DIFF
--- a/config/config.nonprod.yaml
+++ b/config/config.nonprod.yaml
@@ -55,6 +55,14 @@
       UNCONFIRMED: Backlog
       NEW: Backlog
       ASSIGNED: In Progress
-      RESOLVED: Done
       REOPENED: In Progress
+      RESOLVED: Done
       VERIFIED: Done
+      FIXED: Done
+      INVALID: Done
+      WONTFIX: Done
+      INACTIVE: Done
+      DUPLICATE: Done
+      WORKSFORME: Done
+      INCOMPLETE: Done
+      MOVED: Done

--- a/config/config.prod.yaml
+++ b/config/config.prod.yaml
@@ -107,9 +107,17 @@
       UNCONFIRMED: Backlog
       NEW: Backlog
       ASSIGNED: In Progress
-      RESOLVED: Done
       REOPENED: In Progress
+      RESOLVED: Done
       VERIFIED: Done
+      FIXED: Done
+      INVALID: Done
+      WONTFIX: Done
+      INACTIVE: Done
+      DUPLICATE: Done
+      WORKSFORME: Done
+      INCOMPLETE: Done
+      MOVED: Done
 
 - whiteboard_tag: fxsync
   contact: tbd


### PR DESCRIPTION
Relevant code:
https://github.com/mozilla/jira-bugzilla-integration/blob/a28e06fb7403ad85e6cb7868fc7048a2d2e6ee8f/jbi/actions/steps.py#L177

When resolution was not "None" this would take precedence over status changes due to the above line. 

Adding the available bugzilla resolutions as "Done" for the status to be migrated to Jira. 

Alternatively we could likely swap the ordering for the effect that I was originally expecting; however this feature might be used in FIDEFE and other locations.

Not sure if this is an "issue" but I don't think it should hold this PR up.