### PR TITLE
Fix #282: defaults user-agent to empty string in `request.summary`

### DIFF
--- a/jbi/log.py
+++ b/jbi/log.py
@@ -64,7 +64,7 @@ def format_request_summary_fields(
 
     current_time = time.time()
     return RequestSummary(
-        agent=request.headers.get("User-Agent"),
+        agent=request.headers.get("User-Agent", ""),
         path=request.url.path,
         method=request.method,
         lang=request.headers.get("Accept-Language"),

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -26,7 +26,6 @@ def test_request_summary_defaults_user_agent_to_empty_string(caplog):
     with caplog.at_level(logging.INFO):
         with TestClient(app) as anon_client:
             del anon_client.headers["User-Agent"]
-            # https://fastapi.tiangolo.com/advanced/testing-events/
             anon_client.get("/")
 
             summary = caplog.records[-1]

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -22,6 +22,18 @@ def test_request_summary_is_logged(caplog):
             assert summary.querystring == "{}"
 
 
+def test_request_summary_defaults_user_agent_to_empty_string(caplog):
+    with caplog.at_level(logging.INFO):
+        with TestClient(app) as anon_client:
+            del anon_client.headers["User-Agent"]
+            # https://fastapi.tiangolo.com/advanced/testing-events/
+            anon_client.get("/")
+
+            summary = caplog.records[-1]
+
+            assert summary.agent == ""
+
+
 def test_errors_are_reported_to_sentry(
     anon_client, webhook_create_example: BugzillaWebhookRequest
 ):


### PR DESCRIPTION
Fix #282

This error happens quite often according to Sentry
<img width="220" alt="Screenshot 2022-11-23 at 14 50 07" src="https://user-images.githubusercontent.com/546692/203563484-8de619a2-a435-4f7d-91b2-fb6154b7838a.png">
