### PR TITLE
Flip default config value `enabled` to `true`

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -122,9 +122,9 @@
         "filename": "README.md",
         "hashed_secret": "04e78d6e804f2b59e6cb282cb9ed2c7bfd8a9737",
         "is_verified": false,
-        "line_number": 245
+        "line_number": 243
       }
     ]
   },
-  "generated_at": "2022-10-07T13:12:35Z"
+  "generated_at": "2023-01-10T19:43:27Z"
 }

--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ Below is a full example of an action configuration:
   allow_private: false
   contact: example@allizom.com
   description: example configuration
-  enabled: true
   module: jbi.actions.default
   parameters:
     jira_project_key: EXMPL
@@ -111,7 +110,6 @@ Full configuration, that will set assignee, change the Jira issue status and res
 - whiteboard_tag: fidefe
   contact: example@allizom.com
   description: full configuration
-  enabled: true
   module: jbi.actions.default
   parameters:
     jira_project_key: FIDEFE

--- a/config/config.local.yaml
+++ b/config/config.local.yaml
@@ -3,7 +3,6 @@
 - whiteboard_tag: devtest
   contact: tbd
   description: DevTest whiteboard tag
-  enabled: true
   parameters:
     jira_project_key: DevTest
     jira_components:

--- a/config/config.nonprod.yaml
+++ b/config/config.nonprod.yaml
@@ -3,7 +3,6 @@
 - whiteboard_tag: nonprodtest
   contact: bsieber@mozilla.com
   description: Nonprod testing whiteboard tag (JBI Bin Project)
-  enabled: true
   parameters:
     jira_project_key: JB
 
@@ -11,7 +10,6 @@
   allow_private: true
   contact: dtownsend@mozilla.com
   description: Flowstate whiteboard tag
-  enabled: true
   parameters:
     jira_project_key: MR2
     steps:
@@ -70,7 +68,6 @@
 - whiteboard_tag: fxdroid
   contact: cpeterson@mozilla.com
   description: Firefox Android Team Tag
-  enabled: true
   parameters:
     jira_project_key: FXDROID
     steps:

--- a/config/config.nonprod.yaml
+++ b/config/config.nonprod.yaml
@@ -34,7 +34,6 @@
 - whiteboard_tag: fxcm
   contact: dnguyen@mozilla.com
   description: Firefox Credential Management Team whiteboard tag
-  enabled: true
   parameters:
     jira_project_key: FXCM
     steps:

--- a/config/config.prod.yaml
+++ b/config/config.prod.yaml
@@ -3,7 +3,6 @@
 - whiteboard_tag: addons
   contact: tbd
   description: Addons whiteboard tag for AMO Team
-  enabled: true
   # module: jbi.actions.default
   parameters:
     jira_project_key: WEBEXT
@@ -11,14 +10,12 @@
 - whiteboard_tag: fidedi
   contact: tbd
   description: Firefox Desktop Integration whiteboard tag
-  enabled: true
   parameters:
     jira_project_key: FIDEDI
 
 - whiteboard_tag: fidefe
   contact: gijs@mozilla.com
   description: Firefox Front End whiteboard tag
-  enabled: true
   parameters:
     jira_project_key: FIDEFE
     steps:
@@ -48,7 +45,6 @@
 - whiteboard_tag: flowstate
   contact: dtownsend@mozilla.com
   description: Flowstate whiteboard tag
-  enabled: true
   parameters:
     jira_project_key: MR2
     steps:
@@ -74,14 +70,12 @@
 - whiteboard_tag: fxatps
   contact: tbd
   description: Privacy & Security and Anti-Tracking Team whiteboard tag
-  enabled: true
   parameters:
     jira_project_key: FXATPS
 
 - whiteboard_tag: fxcm
   contact: dnguyen@mozilla.com
   description: Firefox Credential Management Team whiteboard tag
-  enabled: true
   parameters:
     jira_project_key: FXCM
     steps:
@@ -115,7 +109,6 @@
 - whiteboard_tag: fxdroid
   contact: cpeterson@mozilla.com
   description: Firefox Android Team Tag
-  enabled: true
   parameters:
     jira_project_key: FXDROID
     steps:
@@ -149,49 +142,42 @@
 - whiteboard_tag: fxsync
   contact: tbd
   description: Firefox Sync Team whiteboard tag
-  enabled: true
   parameters:
     jira_project_key: SYNC
 
 - whiteboard_tag: mv3
   contact: tbd
   description: MV3 whiteboard tag
-  enabled: true
   parameters:
     jira_project_key: WEBEXT
 
 - whiteboard_tag: nimbus
   contact: tbd
   description: Nimbus whiteboard tag
-  enabled: true
   parameters:
     jira_project_key: EXP
 
 - whiteboard_tag: prodtest
   contact: bsieber@mozilla.com
   description: Prod testing whiteboard tag (JBI Bin Project)
-  enabled: true
   parameters:
     jira_project_key: JB
 
 - whiteboard_tag: proton
   contact: tbd
   description: Proton whiteboard tag for Firefox Frontend
-  enabled: true
   parameters:
     jira_project_key: FIDEFE
 
 - whiteboard_tag: relops
   contact: tbd
   description: Release Operations Team Tag
-  enabled: true
   parameters:
     jira_project_key: RELOPS
 
 - whiteboard_tag: remote-settings
   contact: mleplatre@mozilla.com
   description: Remote Settings Server issues
-  enabled: true
   parameters:
     jira_project_key: SE
     jira_components:
@@ -200,6 +186,5 @@
 - whiteboard_tag: snt
   contact: cbellini@mozilla.com
   description: Search/NewTab Team Tag
-  enabled: true
   parameters:
     jira_project_key: SNT

--- a/jbi/models.py
+++ b/jbi/models.py
@@ -39,7 +39,7 @@ class Action(YamlModel):
     # TODO: Remove the tbd literal option when all actions have contact info # pylint: disable=fixme
     contact: EmailStr | list[EmailStr] | Literal["tbd"]
     description: str
-    enabled: bool = False
+    enabled: bool = True
     allow_private: bool = False
     parameters: dict = {}
     _caller: Optional[Callable] = PrivateAttr(default=None)

--- a/tests/fixtures/bad-config.yaml
+++ b/tests/fixtures/bad-config.yaml
@@ -3,7 +3,6 @@
 - whiteboard_tag: A
   contact: foobar
   description: test config
-  enabled: true
   module: jbi.actions.default
   parameters:
     jira_project_key: KEY


### PR DESCRIPTION
One of the available project config values is `enabled`. This value controls whether actions are run when a matching webhook is encountered. At the time of this commit, each project sets `enabled: true`. So, in this commit, we flip the default so that actions are enabled by default and can optionally be disabled by setting `enabled: false`.