### PR TITLE
Fix #181: check webhooks status in heartbeat

### DIFF
--- a/jbi/models.py
+++ b/jbi/models.py
@@ -345,6 +345,26 @@ class BugzillaApiResponse(BaseModel):
     bugs: Optional[list[BugzillaBug]]
 
 
+class BugzillaWebhook(BaseModel):
+    """Bugzilla Webhook"""
+
+    id: int
+    creator: str
+    name: str
+    url: str
+    event: str
+    product: str
+    component: str
+    enabled: bool
+    errors: int
+
+
+class BugzillaWebhooksResponse(BaseModel):
+    """Bugzilla Webhooks List Response Object"""
+
+    webhooks: Optional[list[BugzillaWebhook]]
+
+
 class Context(BaseModel):
     """Generic log context throughout JBI"""
 

--- a/jbi/services/bugzilla.py
+++ b/jbi/services/bugzilla.py
@@ -146,8 +146,6 @@ def check_health() -> ServiceHealth:
     if logged_in:
         webhooks = client.list_webhooks()
         jbi_webhooks = [wh for wh in webhooks if "/bugzilla_webhook" in wh.url]
-        # See mozilla/jira-bugzilla-integration#21 whether it should
-        # be a single webhook with `product == "Any"`.
         all_webhooks_enabled = len(jbi_webhooks) > 0
         for webhook in jbi_webhooks:
             if webhook.errors > 0:

--- a/jbi/services/bugzilla.py
+++ b/jbi/services/bugzilla.py
@@ -150,6 +150,10 @@ def check_health() -> ServiceHealth:
         # be a single webhook with `product == "Any"`.
         all_webhooks_enabled = len(jbi_webhooks) > 0
         for webhook in jbi_webhooks:
+            if webhook.errors > 0:
+                logger.warning(
+                    "Webhook %s has %s error(s)", webhook.name, webhook.errors
+                )
             if not webhook.enabled:
                 all_webhooks_enabled = False
                 logger.error(

--- a/tests/unit/test_router.py
+++ b/tests/unit/test_router.py
@@ -5,7 +5,19 @@ from datetime import datetime
 from fastapi.testclient import TestClient
 
 from jbi.app import app
-from jbi.models import BugzillaWebhookRequest
+from jbi.models import BugzillaWebhook, BugzillaWebhookRequest
+
+EXAMPLE_WEBHOOK = BugzillaWebhook(
+    id=0,
+    creator="",
+    name="",
+    url="http://server/bugzilla_webhook",
+    event="create,change,comment",
+    product="Any",
+    component="Any",
+    enabled=True,
+    errors=0,
+)
 
 
 def test_read_root(anon_client):
@@ -157,28 +169,40 @@ def test_read_heartbeat_all_services_fail(anon_client, mocked_jira, mocked_bugzi
         },
         "bugzilla": {
             "up": False,
+            "all_webhooks_enabled": False,
         },
     }
 
 
 def test_read_heartbeat_jira_services_fails(anon_client, mocked_jira, mocked_bugzilla):
     """/__heartbeat__ returns 503 when one service is unavailable."""
-    mocked_bugzilla.logged_in = True
     mocked_jira.get_server_info.return_value = None
 
     resp = anon_client.get("/__heartbeat__")
 
     assert resp.status_code == 503
-    assert resp.json() == {
-        "jira": {
-            "up": False,
-            "all_projects_are_visible": False,
-            "all_projects_have_permissions": False,
-            "all_projects_components_exist": False,
-        },
-        "bugzilla": {
-            "up": True,
-        },
+    assert resp.json()["jira"] == {
+        "up": False,
+        "all_projects_are_visible": False,
+        "all_projects_have_permissions": False,
+        "all_projects_components_exist": False,
+    }
+
+
+def test_read_heartbeat_bugzilla_webhooks_fails(
+    anon_client, mocked_jira, mocked_bugzilla
+):
+    mocked_bugzilla.logged_in = True
+    mocked_bugzilla.list_webhooks.return_value = [
+        EXAMPLE_WEBHOOK.copy(update={"enabled": False})
+    ]
+
+    resp = anon_client.get("/__heartbeat__")
+
+    assert resp.status_code == 503
+    assert resp.json()["bugzilla"] == {
+        "up": True,
+        "all_webhooks_enabled": False,
     }
 
 
@@ -193,22 +217,16 @@ def test_read_heartbeat_bugzilla_services_fails(
     resp = anon_client.get("/__heartbeat__")
 
     assert resp.status_code == 503
-    assert resp.json() == {
-        "jira": {
-            "up": True,
-            "all_projects_are_visible": True,
-            "all_projects_have_permissions": False,
-            "all_projects_components_exist": False,
-        },
-        "bugzilla": {
-            "up": False,
-        },
+    assert resp.json()["bugzilla"] == {
+        "up": False,
+        "all_webhooks_enabled": False,
     }
 
 
 def test_read_heartbeat_success(anon_client, mocked_jira, mocked_bugzilla):
     """/__heartbeat__ returns 200 when checks succeed."""
     mocked_bugzilla.logged_in = True
+    mocked_bugzilla.list_webhooks.return_value = [EXAMPLE_WEBHOOK]
     mocked_jira.get_server_info.return_value = {}
     mocked_jira.projects.return_value = [{"key": "DevTest"}]
     mocked_jira.get_project_components.return_value = [{"name": "Main"}]
@@ -233,34 +251,28 @@ def test_read_heartbeat_success(anon_client, mocked_jira, mocked_bugzilla):
         },
         "bugzilla": {
             "up": True,
+            "all_webhooks_enabled": True,
         },
     }
 
 
 def test_jira_heartbeat_visible_projects(anon_client, mocked_jira, mocked_bugzilla):
     """/__heartbeat__ fails if configured projects don't match."""
-    mocked_bugzilla.logged_in = True
     mocked_jira.get_server_info.return_value = {}
 
     resp = anon_client.get("/__heartbeat__")
 
     assert resp.status_code == 503
-    assert resp.json() == {
-        "jira": {
-            "up": True,
-            "all_projects_are_visible": False,
-            "all_projects_have_permissions": False,
-            "all_projects_components_exist": False,
-        },
-        "bugzilla": {
-            "up": True,
-        },
+    assert resp.json()["jira"] == {
+        "up": True,
+        "all_projects_are_visible": False,
+        "all_projects_have_permissions": False,
+        "all_projects_components_exist": False,
     }
 
 
 def test_jira_heartbeat_missing_permissions(anon_client, mocked_jira, mocked_bugzilla):
     """/__heartbeat__ fails if configured projects don't match."""
-    mocked_bugzilla.logged_in = True
     mocked_jira.get_server_info.return_value = {}
     mocked_jira.get_project_components.return_value = [{"name": "Main"}]
     mocked_jira.get_project_permission_scheme.return_value = {
@@ -275,21 +287,17 @@ def test_jira_heartbeat_missing_permissions(anon_client, mocked_jira, mocked_bug
     resp = anon_client.get("/__heartbeat__")
 
     assert resp.status_code == 503
-    assert resp.json() == {
-        "jira": {
-            "up": True,
-            "all_projects_are_visible": False,
-            "all_projects_have_permissions": False,
-            "all_projects_components_exist": True,
-        },
-        "bugzilla": {
-            "up": True,
-        },
+    assert resp.json()["jira"] == {
+        "up": True,
+        "all_projects_are_visible": False,
+        "all_projects_have_permissions": False,
+        "all_projects_components_exist": True,
     }
 
 
 def test_jira_heartbeat_unknown_components(anon_client, mocked_jira, mocked_bugzilla):
     mocked_bugzilla.logged_in = True
+    mocked_bugzilla.list_webhooks.return_value = [EXAMPLE_WEBHOOK]
     mocked_jira.get_server_info.return_value = {}
 
     resp = anon_client.get("/__heartbeat__")
@@ -298,9 +306,10 @@ def test_jira_heartbeat_unknown_components(anon_client, mocked_jira, mocked_bugz
     assert not resp.json()["jira"]["all_projects_components_exist"]
 
 
-def test_head_heartbeat(anon_client, mocked_jira, mocked_bugzilla):
+def test_head_heartbeat_success(anon_client, mocked_jira, mocked_bugzilla):
     """/__heartbeat__ support head requests"""
     mocked_bugzilla.logged_in = True
+    mocked_bugzilla.list_webhooks.return_value = [EXAMPLE_WEBHOOK]
     mocked_jira.get_server_info.return_value = {}
     mocked_jira.projects.return_value = [{"key": "DevTest"}]
     mocked_jira.get_project_components.return_value = [{"name": "Main"}]


### PR DESCRIPTION
Fix #181

* [x] Basic functionnality tested manually on bugzilla-dev.allizom.org
* [x] Unit tests
* [x] Decide what to do with #21 (either clean up disabled hooks or modify heartbeat logics) 
* [x] Wait for deploy of https://bugzilla.mozilla.org/show_bug.cgi?id=1800750 in PROD. See https://bugzilla.mozilla.org/__version__
