### PR TITLE
Do not use hard-coded url in tests

### DIFF
--- a/tests/unit/actions/test_steps.py
+++ b/tests/unit/actions/test_steps.py
@@ -6,6 +6,7 @@ from unittest import mock
 import pytest
 
 from jbi.actions import default
+from jbi.environment import get_settings
 from jbi.models import ActionContext
 from jbi.services.jira import JiraCreateError
 from tests.fixtures.factories import comment_factory
@@ -55,7 +56,7 @@ def test_created_public(
     )
 
     mocked_bugzilla.update_bug.assert_called_once_with(
-        654321, see_also={"add": ["https://mozit-test.atlassian.net/browse/k"]}
+        654321, see_also={"add": [f"{get_settings().jira_base_url}browse/k"]}
     )
 
 

--- a/tests/unit/test_router.py
+++ b/tests/unit/test_router.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from fastapi.testclient import TestClient
 
 from jbi.app import app
+from jbi.environment import get_settings
 from jbi.models import BugzillaWebhookRequest
 
 
@@ -13,7 +14,7 @@ def test_read_root(anon_client):
     resp = anon_client.get("/")
     infos = resp.json()
 
-    assert "atlassian.net" in infos["configuration"]["jira_base_url"]
+    assert get_settings().jira_base_url in infos["configuration"]["jira_base_url"]
 
 
 def test_whiteboard_tags(anon_client):
@@ -72,7 +73,7 @@ def test_webhook_is_200_if_action_succeeds(
             {
                 "changes": {
                     "see_also": {
-                        "added": "https://mozilla.atlassian.net/browse/JBI-1922",
+                        "added": f"{get_settings().jira_base_url}browse/JBI-1922",
                         "removed": "",
                     }
                 },
@@ -85,7 +86,7 @@ def test_webhook_is_200_if_action_succeeds(
     }
     mocked_jira.create_or_update_issue_remote_links.return_value = {
         "id": 18936,
-        "self": "https://mozilla.atlassian.net/rest/api/2/issue/JBI-1922/remotelink/18936",
+        "self": f"{get_settings().jira_base_url}rest/api/2/issue/JBI-1922/remotelink/18936",
     }
 
     with TestClient(app) as anon_client:

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -9,7 +9,7 @@ from unittest import mock
 import pytest
 
 from jbi import Operation
-from jbi.environment import Settings
+from jbi.environment import Settings, get_settings
 from jbi.errors import IgnoreInvalidRequestError
 from jbi.models import Actions, BugzillaBug, BugzillaWebhookRequest
 from jbi.runner import execute_action
@@ -25,7 +25,7 @@ def test_bugzilla_object_is_always_fetched(
     # See https://github.com/mozilla/jira-bugzilla-integration/issues/292
     fetched_bug = bug_factory(
         id=webhook_create_example.bug.id,
-        see_also=["https://mozilla.atlassian.net/browse/JBI-234"],
+        see_also=[f"{get_settings().jira_base_url}browse/JBI-234"],
     )
     mocked_bugzilla.get_bug.return_value = fetched_bug
 


### PR DESCRIPTION
With a custom `.env` file the tests would fail. It's annoying when developing and trying things on real servers at the same time