### PR TITLE
Config contact as bugzilla user id

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Below is a full example of an action configuration:
 ```yaml
 - whiteboard_tag: example
   allow_private: false
-  contact: example@allizom.com
+  bugzilla_user_id: 514230
   description: example configuration
   module: jbi.actions.default
   parameters:
@@ -36,10 +36,10 @@ A bit more about the different fields...
     - If false bugs that are not public will not be synchronized. Note that in order to synchronize
       private bugs the bugzilla user that JBI runs as must be in the security groups that are making
       the bug private.
-- `contact`
-    - an email address, a list of email addresses, or a literal "tbd" to signify that no contact is available
-    - If an issue arises with the workflow, communication will be established with these contacts
-    - Please enter the contact information for one or more stakeholders
+- `bugzilla_user_id`
+    - a bugzilla user id, a list of user ids, or a literal "tbd" to signify that no bugzilla user id is available
+    - If an issue arises with the workflow, communication will be established with these users
+    - Please enter the user information for one or more stakeholders
 - `description`
     - string
     - Please enter a description; for example, team name or project use-case.
@@ -98,7 +98,7 @@ to the Bugzilla ticket on the Jira issue.
 Minimal configuration:
 ```yaml
     whiteboard_tag: example
-    contact: example@allizom.com
+    bugzilla_user_id: 514230
     description: minimal configuration
     parameters:
       jira_project_key: EXMPL
@@ -108,7 +108,7 @@ Full configuration, that will set assignee, change the Jira issue status and res
 
 ```yaml
 - whiteboard_tag: fidefe
-  contact: example@allizom.com
+  bugzilla_user_id: 514230
   description: full configuration
   module: jbi.actions.default
   parameters:
@@ -256,7 +256,7 @@ GET /whiteboard_tags/
 {
     "addons": {
         "whiteboard_tag": "addons",
-        "contact": "example@allizom.com",
+        "bugzilla_user_id": "514230",
         "description": "Addons whiteboard tag for AMO Team",
         "enabled": true,
         "module": "jbi.actions.default",

--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ GET /whiteboard_tags/
 {
     "addons": {
         "whiteboard_tag": "addons",
-        "bugzilla_user_id": "514230",
+        "bugzilla_user_id": 514230,
         "description": "Addons whiteboard tag for AMO Team",
         "enabled": true,
         "module": "jbi.actions.default",

--- a/config/config.local.yaml
+++ b/config/config.local.yaml
@@ -1,7 +1,7 @@
 ---
 # Action Config
 - whiteboard_tag: devtest
-  contact: tbd
+  bugzilla_user_id: tbd
   description: DevTest whiteboard tag
   parameters:
     jira_project_key: DevTest

--- a/config/config.nonprod.yaml
+++ b/config/config.nonprod.yaml
@@ -1,14 +1,14 @@
 ---
 # Action Config
 - whiteboard_tag: nonprodtest
-  contact: 644672
+  bugzilla_user_id: 644672
   description: Nonprod testing whiteboard tag (JBI Bin Project)
   parameters:
     jira_project_key: JB
 
 - whiteboard_tag: flowstate
   allow_private: true
-  contact: 91159
+  bugzilla_user_id: 91159
   description: Flowstate whiteboard tag
   parameters:
     jira_project_key: JB
@@ -32,7 +32,7 @@
       REOPENED: In Progress
 
 - whiteboard_tag: fxcm
-  contact: tbd
+  bugzilla_user_id: tbd
   description: Firefox Credential Management Team whiteboard tag
   parameters:
     jira_project_key: JB
@@ -65,7 +65,7 @@
       MOVED: Done
 
 - whiteboard_tag: fxdroid
-  contact: 430528
+  bugzilla_user_id: 430528
   description: Firefox Android Team Tag
   parameters:
     jira_project_key: JB
@@ -98,7 +98,7 @@
       MOVED: Closed
 
 - whiteboard_tag: fxp
-  contact: 396948
+  bugzilla_user_id: 396948
   description: Performance Team
   parameters:
     jira_project_key: JB
@@ -135,7 +135,7 @@
       MOVED: Done
 
 - whiteboard_tag: sp3
-  contact: 396948
+  bugzilla_user_id: 396948
   description: Speedometer 3
   parameters:
     jira_project_key: JB

--- a/config/config.nonprod.yaml
+++ b/config/config.nonprod.yaml
@@ -1,14 +1,14 @@
 ---
 # Action Config
 - whiteboard_tag: nonprodtest
-  contact: bsieber@mozilla.com
+  contact: 644672
   description: Nonprod testing whiteboard tag (JBI Bin Project)
   parameters:
     jira_project_key: JB
 
 - whiteboard_tag: flowstate
   allow_private: true
-  contact: dtownsend@mozilla.com
+  contact: 91159
   description: Flowstate whiteboard tag
   parameters:
     jira_project_key: JB
@@ -32,7 +32,7 @@
       REOPENED: In Progress
 
 - whiteboard_tag: fxcm
-  contact: dnguyen@mozilla.com
+  contact: tbd
   description: Firefox Credential Management Team whiteboard tag
   parameters:
     jira_project_key: JB
@@ -65,7 +65,7 @@
       MOVED: Done
 
 - whiteboard_tag: fxdroid
-  contact: cpeterson@mozilla.com
+  contact: 430528
   description: Firefox Android Team Tag
   parameters:
     jira_project_key: JB
@@ -135,7 +135,7 @@
       MOVED: Done
 
 - whiteboard_tag: sp3
-  contact: dhunt@mozilla.com
+  contact: 396948
   description: Speedometer 3
   parameters:
     jira_project_key: JB

--- a/config/config.nonprod.yaml
+++ b/config/config.nonprod.yaml
@@ -98,7 +98,7 @@
       MOVED: Closed
 
 - whiteboard_tag: fxp
-  contact: tbd
+  contact: 396948
   description: Performance Team
   parameters:
     jira_project_key: JB

--- a/config/config.nonprod.yaml
+++ b/config/config.nonprod.yaml
@@ -98,7 +98,7 @@
       MOVED: Closed
 
 - whiteboard_tag: fxp
-  contact: perf-pmo@mozilla.com
+  contact: tbd
   description: Performance Team
   parameters:
     jira_project_key: JB

--- a/config/config.prod.yaml
+++ b/config/config.prod.yaml
@@ -140,7 +140,7 @@
       MOVED: Closed
 
 - whiteboard_tag: fxp
-  contact: perf-pmo@mozilla.com
+  contact: tbd
   description: Performance Team
   parameters:
     jira_project_key: FXP

--- a/config/config.prod.yaml
+++ b/config/config.prod.yaml
@@ -140,7 +140,7 @@
       MOVED: Closed
 
 - whiteboard_tag: fxp
-  contact: tbd
+  contact: 396948
   description: Performance Team
   parameters:
     jira_project_key: FXP

--- a/config/config.prod.yaml
+++ b/config/config.prod.yaml
@@ -1,20 +1,20 @@
 ---
 # Action Config
 - whiteboard_tag: addons
-  contact: tbd
+  bugzilla_user_id: tbd
   description: Addons whiteboard tag for AMO Team
   # module: jbi.actions.default
   parameters:
     jira_project_key: WEBEXT
 
 - whiteboard_tag: fidedi
-  contact: tbd
+  bugzilla_user_id: tbd
   description: Firefox Desktop Integration whiteboard tag
   parameters:
     jira_project_key: FIDEDI
 
 - whiteboard_tag: fidefe
-  contact: 159069
+  bugzilla_user_id: 159069
   description: Firefox Front End whiteboard tag
   parameters:
     jira_project_key: FIDEFE
@@ -43,7 +43,7 @@
       REOPENED: In Progress
 
 - whiteboard_tag: flowstate
-  contact: 91159
+  bugzilla_user_id: 91159
   description: Flowstate whiteboard tag
   parameters:
     jira_project_key: MR2
@@ -68,13 +68,13 @@
       REOPENED: In Progress
 
 - whiteboard_tag: fxatps
-  contact: tbd
+  bugzilla_user_id: tbd
   description: Privacy & Security and Anti-Tracking Team whiteboard tag
   parameters:
     jira_project_key: FXATPS
 
 - whiteboard_tag: fxcm
-  contact: 713707
+  bugzilla_user_id: 713707
   description: Firefox Credential Management Team whiteboard tag
   parameters:
     jira_project_key: FXCM
@@ -107,7 +107,7 @@
       MOVED: Done
 
 - whiteboard_tag: fxdroid
-  contact: 430528
+  bugzilla_user_id: 430528
   description: Firefox Android Team Tag
   parameters:
     jira_project_key: FXDROID
@@ -140,7 +140,7 @@
       MOVED: Closed
 
 - whiteboard_tag: fxp
-  contact: 396948
+  bugzilla_user_id: 396948
   description: Performance Team
   parameters:
     jira_project_key: FXP
@@ -177,49 +177,49 @@
       MOVED: Done
 
 - whiteboard_tag: fxsync
-  contact: 624105
+  bugzilla_user_id: 624105
   description: Firefox Sync Team whiteboard tag
   parameters:
     jira_project_key: SYNC
 
 - whiteboard_tag: disco
-  contact: 624105
+  bugzilla_user_id: 624105
   description: DISCO whiteboard tag
   parameters:
     jira_project_key: DISCO
 
 - whiteboard_tag: mv3
-  contact: tbd
+  bugzilla_user_id: tbd
   description: MV3 whiteboard tag
   parameters:
     jira_project_key: WEBEXT
 
 - whiteboard_tag: nimbus
-  contact: 624105
+  bugzilla_user_id: 624105
   description: Nimbus whiteboard tag
   parameters:
     jira_project_key: EXP
 
 - whiteboard_tag: prodtest
-  contact: 644672
+  bugzilla_user_id: 644672
   description: Prod testing whiteboard tag (JBI Bin Project)
   parameters:
     jira_project_key: JB
 
 - whiteboard_tag: proton
-  contact: tbd
+  bugzilla_user_id: tbd
   description: Proton whiteboard tag for Firefox Frontend
   parameters:
     jira_project_key: FIDEFE
 
 - whiteboard_tag: relops
-  contact: tbd
+  bugzilla_user_id: tbd
   description: Release Operations Team Tag
   parameters:
     jira_project_key: RELOPS
 
 - whiteboard_tag: remote-settings
-  contact: 576226
+  bugzilla_user_id: 576226
   description: Remote Settings Server issues
   parameters:
     jira_project_key: SE
@@ -227,13 +227,13 @@
       - "Remote Settings"
 
 - whiteboard_tag: snt
-  contact: 696039
+  bugzilla_user_id: 696039
   description: Search/NewTab Team Tag
   parameters:
     jira_project_key: SNT
 
 - whiteboard_tag: sp3
-  contact: 396948
+  bugzilla_user_id: 396948
   description: Speedometer 3
   parameters:
     jira_project_key: SP3

--- a/config/config.prod.yaml
+++ b/config/config.prod.yaml
@@ -183,7 +183,7 @@
     jira_project_key: SYNC
 
 - whiteboard_tag: disco
-  contact: tbd
+  contact: 624105
   description: DISCO whiteboard tag
   parameters:
     jira_project_key: DISCO

--- a/config/config.prod.yaml
+++ b/config/config.prod.yaml
@@ -14,7 +14,7 @@
     jira_project_key: FIDEDI
 
 - whiteboard_tag: fidefe
-  contact: gijs@mozilla.com
+  contact: 159069
   description: Firefox Front End whiteboard tag
   parameters:
     jira_project_key: FIDEFE
@@ -43,7 +43,7 @@
       REOPENED: In Progress
 
 - whiteboard_tag: flowstate
-  contact: dtownsend@mozilla.com
+  contact: 91159
   description: Flowstate whiteboard tag
   parameters:
     jira_project_key: MR2
@@ -74,7 +74,7 @@
     jira_project_key: FXATPS
 
 - whiteboard_tag: fxcm
-  contact: dnguyen@mozilla.com
+  contact: 713707
   description: Firefox Credential Management Team whiteboard tag
   parameters:
     jira_project_key: FXCM
@@ -107,7 +107,7 @@
       MOVED: Done
 
 - whiteboard_tag: fxdroid
-  contact: cpeterson@mozilla.com
+  contact: 430528
   description: Firefox Android Team Tag
   parameters:
     jira_project_key: FXDROID
@@ -177,7 +177,7 @@
       MOVED: Done
 
 - whiteboard_tag: fxsync
-  contact: tbd
+  contact: 624105
   description: Firefox Sync Team whiteboard tag
   parameters:
     jira_project_key: SYNC
@@ -195,13 +195,13 @@
     jira_project_key: WEBEXT
 
 - whiteboard_tag: nimbus
-  contact: tbd
+  contact: 624105
   description: Nimbus whiteboard tag
   parameters:
     jira_project_key: EXP
 
 - whiteboard_tag: prodtest
-  contact: bsieber@mozilla.com
+  contact: 644672
   description: Prod testing whiteboard tag (JBI Bin Project)
   parameters:
     jira_project_key: JB
@@ -219,7 +219,7 @@
     jira_project_key: RELOPS
 
 - whiteboard_tag: remote-settings
-  contact: mleplatre@mozilla.com
+  contact: 576226
   description: Remote Settings Server issues
   parameters:
     jira_project_key: SE
@@ -227,13 +227,13 @@
       - "Remote Settings"
 
 - whiteboard_tag: snt
-  contact: cbellini@mozilla.com
+  contact: 696039
   description: Search/NewTab Team Tag
   parameters:
     jira_project_key: SNT
 
 - whiteboard_tag: sp3
-  contact: dhunt@mozilla.com
+  contact: 396948
   description: Speedometer 3
   parameters:
     jira_project_key: SP3

--- a/jbi/models.py
+++ b/jbi/models.py
@@ -11,15 +11,7 @@ from types import ModuleType
 from typing import Any, Callable, Literal, Mapping, Optional, TypedDict
 from urllib.parse import ParseResult, urlparse
 
-from pydantic import (
-    BaseModel,
-    EmailStr,
-    Extra,
-    Field,
-    PrivateAttr,
-    root_validator,
-    validator,
-)
+from pydantic import BaseModel, Extra, Field, PrivateAttr, root_validator, validator
 from pydantic_yaml import YamlModel
 
 from jbi import Operation
@@ -37,7 +29,7 @@ class Action(YamlModel):
     whiteboard_tag: str
     module: str = "jbi.actions.default"
     # TODO: Remove the tbd literal option when all actions have contact info # pylint: disable=fixme
-    contact: EmailStr | list[EmailStr] | Literal["tbd"]
+    contact: int | list[int] | Literal["tbd"]
     description: str
     enabled: bool = True
     allow_private: bool = False

--- a/jbi/models.py
+++ b/jbi/models.py
@@ -28,8 +28,8 @@ class Action(YamlModel):
 
     whiteboard_tag: str
     module: str = "jbi.actions.default"
-    # TODO: Remove the tbd literal option when all actions have contact info # pylint: disable=fixme
-    contact: int | list[int] | Literal["tbd"]
+    # TODO: Remove the tbd literal option when all actions have bugzilla_user_id info # pylint: disable=fixme
+    bugzilla_user_id: int | list[int] | Literal["tbd"]
     description: str
     enabled: bool = True
     allow_private: bool = False
@@ -121,7 +121,7 @@ class Actions(YamlModel):
         """
         Inspect the list of actions:
          - Validate that lookup tags are uniques
-         - If the action's contact is "tbd", emit a warning.
+         - If the action's bugzilla_user_id is "tbd", emit a warning.
         """
         tags = [action.whiteboard_tag.lower() for action in actions]
         duplicated_tags = [t for i, t in enumerate(tags) if t in tags[:i]]
@@ -129,9 +129,9 @@ class Actions(YamlModel):
             raise ValueError(f"actions have duplicated lookup tags: {duplicated_tags}")
 
         for action in actions:
-            if action.contact == "tbd":
+            if action.bugzilla_user_id == "tbd":
                 warnings.warn(
-                    f"Provide contact data for `{action.whiteboard_tag}` action."
+                    f"Provide bugzilla_user_id data for `{action.whiteboard_tag}` action."
                 )
 
         return actions

--- a/jbi/models.py
+++ b/jbi/models.py
@@ -28,7 +28,6 @@ class Action(YamlModel):
 
     whiteboard_tag: str
     module: str = "jbi.actions.default"
-    # TODO: Remove the tbd literal option when all actions have bugzilla_user_id info # pylint: disable=fixme
     bugzilla_user_id: int | list[int] | Literal["tbd"]
     description: str
     enabled: bool = True

--- a/tests/fixtures/bad-config.yaml
+++ b/tests/fixtures/bad-config.yaml
@@ -1,7 +1,7 @@
 ---
 # Action Config
 - whiteboard_tag: A
-  contact: foobar
+  bugzilla_user_id: foobar
   description: test config
   module: jbi.actions.default
   parameters:

--- a/tests/fixtures/factories.py
+++ b/tests/fixtures/factories.py
@@ -16,7 +16,7 @@ from jbi.models import (
 def action_factory(**overrides):
     action = {
         "whiteboard_tag": "devtest",
-        "contact": "tbd",
+        "bugzilla_user_id": "tbd",
         "description": "test config",
         "module": "tests.fixtures.noop_action",
         "parameters": {

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -10,7 +10,7 @@ def test_model_serializes():
     action = Action.parse_obj(
         {
             "whiteboard_tag": "devtest",
-            "bugzilla_user_id": "123456",
+            "bugzilla_user_id": 123456,
             "description": "test config",
             "module": "tests.fixtures.bugzilla_action",
         }
@@ -19,6 +19,37 @@ def test_model_serializes():
     serialized_action = jsonable_encoder(action)
     assert not serialized_action.get("_caller")
     assert not serialized_action.get("caller")
+
+
+def test_model_with_user_list_serializes():
+    """Regression test to assert that action with initialized Bugzilla client serializes (with user id list)"""
+    action = Action.parse_obj(
+        {
+            "whiteboard_tag": "devtest",
+            "bugzilla_user_id": [123456, 654321, 000000, 111111],
+            "description": "test config",
+            "module": "tests.fixtures.bugzilla_action",
+        }
+    )
+    action.caller(bug=None, event=None)
+    serialized_action = jsonable_encoder(action)
+    assert not serialized_action.get("_caller")
+    assert not serialized_action.get("caller")
+
+    def test_model_with_user_list_of_one_serializes():
+        """Regression test to assert that action with initialized Bugzilla client serializes (with user id in list)"""
+        action = Action.parse_obj(
+            {
+                "whiteboard_tag": "devtest",
+                "bugzilla_user_id": [123456],
+                "description": "test config",
+                "module": "tests.fixtures.bugzilla_action",
+            }
+        )
+        action.caller(bug=None, event=None)
+        serialized_action = jsonable_encoder(action)
+        assert not serialized_action.get("_caller")
+        assert not serialized_action.get("caller")
 
 
 def test_no_actions_fails():

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -10,7 +10,7 @@ def test_model_serializes():
     action = Action.parse_obj(
         {
             "whiteboard_tag": "devtest",
-            "contact": "person@example.com",
+            "contact": "123456",
             "description": "test config",
             "module": "tests.fixtures.bugzilla_action",
         }

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -10,7 +10,7 @@ def test_model_serializes():
     action = Action.parse_obj(
         {
             "whiteboard_tag": "devtest",
-            "contact": "123456",
+            "bugzilla_user_id": "123456",
             "description": "test config",
             "module": "tests.fixtures.bugzilla_action",
         }


### PR DESCRIPTION
To resolve: #58 

Found the user_id's by using the following url: https://bugzilla.mozilla.org/user_profile?login=<email>

...and looking at the Network calls to see the associated user-id.