### PR TITLE
Rename job id of linting check

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,9 +1,9 @@
-name: Run lint
+name: Run linting
 
 on: pull_request
 
 jobs:
-  run_test:
+  run_lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
https://github.com/mozilla/jira-bugzilla-integration/issues/436#issuecomment-1483387652

> One TODO I discovered in adjusting these settings was to rename the job id in `lint.yaml` from `run_test` to `run_lint`