### PR TITLE
Use text log format in local DEV

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 # Environment variables for the local development environment
 ENV=local
+LOG_FORMAT=text
 APP_RELOAD=True
 APP_DEBUG=True
 

--- a/jbi/environment.py
+++ b/jbi/environment.py
@@ -47,6 +47,7 @@ class Settings(BaseSettings):
 
     # Logging
     log_level: str = "debug"
+    log_format: str = "json"
 
     # Sentry
     sentry_dsn: Optional[SentryDsn]

--- a/jbi/log.py
+++ b/jbi/log.py
@@ -22,12 +22,18 @@ CONFIG = {
             "()": "dockerflow.logging.JsonLogFormatter",
             "logger_name": "jbi",
         },
+        "text": {
+            "format": "%(asctime)s %(levelname)-8s %(name)-15s %(message)s",
+            "datefmt": "%Y-%m-%d %H:%M:%S",
+        },
     },
     "handlers": {
         "console": {
             "level": settings.log_level.upper(),
             "class": "logging.StreamHandler",
-            "formatter": "mozlog_json",
+            "formatter": "text"
+            if settings.log_format.lower() == "text"
+            else "mozlog_json",
             "stream": sys.stdout,
         },
         "null": {


### PR DESCRIPTION
In our quality standards, we want to be able to configure the log format with the `LOG_FORMAT` env var
https://docs.google.com/document/d/1m96FOH8Dv87m3OtjBT14C969gjhcMygZmrPpx5e7A2Y/edit