### PR TITLE
Run service with log level INFO by default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 # Environment variables for the local development environment
 ENV=local
+LOG_LEVEL=debug
 APP_RELOAD=True
 APP_DEBUG=True
 

--- a/jbi/environment.py
+++ b/jbi/environment.py
@@ -46,7 +46,7 @@ class Settings(BaseSettings):
     bugzilla_api_key: str
 
     # Logging
-    log_level: str = "debug"
+    log_level: str = "info"
 
     # Sentry
     sentry_dsn: Optional[SentryDsn]


### PR DESCRIPTION
With the goal of aligning our portfolio on default behaviour, as promoted in https://docs.google.com/document/d/1m96FOH8Dv87m3OtjBT14C969gjhcMygZmrPpx5e7A2Y/edit?usp=sharing