### PR TITLE
Add DENG config for data infra working group

### DIFF
--- a/config/config.nonprod.yaml
+++ b/config/config.nonprod.yaml
@@ -171,7 +171,7 @@
       INCOMPLETE: Done
       MOVED: Done
 
-- whiteboard_tag: data-platform-infra-wg
+- whiteboard_tag: dataplatform
   bugzilla_user_id: tbd
   description: Data Platform Infrastructure
   parameters:
@@ -210,7 +210,7 @@
       INCOMPLETE: Done
       MOVED: Done
 
-- whiteboard_tag: data-quality
+- whiteboard_tag: dataquality
   bugzilla_user_id: tbd
   description: Data Quality
   parameters:

--- a/config/config.nonprod.yaml
+++ b/config/config.nonprod.yaml
@@ -175,7 +175,7 @@
   bugzilla_user_id: tbd
   description: Data Platform Infrastructure
   parameters:
-    jira_project_key: DENG
+    jira_project_key: JB
     jira_components:
       - "Data Platform Infrastructure"
     steps:
@@ -214,7 +214,7 @@
   bugzilla_user_id: tbd
   description: Data Quality
   parameters:
-    jira_project_key: DENG
+    jira_project_key: JB
     jira_components:
       - "Data Quality"
     steps:

--- a/config/config.nonprod.yaml
+++ b/config/config.nonprod.yaml
@@ -170,3 +170,81 @@
       WORKSFORME: Done
       INCOMPLETE: Done
       MOVED: Done
+
+- whiteboard_tag: data-platform-infra-wg
+  bugzilla_user_id: tbd
+  description: Data Platform Infrastructure
+  parameters:
+    jira_project_key: DENG
+    jira_components:
+      - "Data Platform Infrastructure"
+    steps:
+      new:
+        - create_issue
+        - maybe_delete_duplicate
+        - add_link_to_bugzilla
+        - add_link_to_jira
+        - maybe_assign_jira_user
+        - maybe_update_issue_resolution
+        - maybe_update_issue_status
+      existing:
+        - update_issue
+        - maybe_assign_jira_user
+        - maybe_update_issue_resolution
+        - maybe_update_issue_status
+      comment:
+        - create_comment
+    status_map:
+      UNCONFIRMED: Backlog
+      NEW: Backlog
+      ASSIGNED: In Progress
+      REOPENED: In Progress
+      RESOLVED: Done
+      VERIFIED: Done
+      FIXED: Done
+      INVALID: Done
+      WONTFIX: Done
+      INACTIVE: Done
+      DUPLICATE: Done
+      WORKSFORME: Done
+      INCOMPLETE: Done
+      MOVED: Done
+
+- whiteboard_tag: data-quality
+  bugzilla_user_id: tbd
+  description: Data Quality
+  parameters:
+    jira_project_key: DENG
+    jira_components:
+      - "Data Quality"
+    steps:
+      new:
+        - create_issue
+        - maybe_delete_duplicate
+        - add_link_to_bugzilla
+        - add_link_to_jira
+        - maybe_assign_jira_user
+        - maybe_update_issue_resolution
+        - maybe_update_issue_status
+      existing:
+        - update_issue
+        - maybe_assign_jira_user
+        - maybe_update_issue_resolution
+        - maybe_update_issue_status
+      comment:
+        - create_comment
+    status_map:
+      UNCONFIRMED: To Do
+      NEW: To Do
+      ASSIGNED: In Progress
+      REOPENED: In Progress
+      RESOLVED: Done
+      VERIFIED: Done
+      FIXED: Done
+      INVALID: Done
+      WONTFIX: Done
+      INACTIVE: Done
+      DUPLICATE: Done
+      WORKSFORME: Done
+      INCOMPLETE: Done
+      MOVED: Done

--- a/config/config.prod.yaml
+++ b/config/config.prod.yaml
@@ -269,7 +269,7 @@
       INCOMPLETE: Done
       MOVED: Done
 
-- whiteboard_tag: data-platform-infra-wg
+- whiteboard_tag: dataplatform
   bugzilla_user_id: tbd
   description: Data Platform Infrastructure
   parameters:
@@ -308,7 +308,7 @@
       INCOMPLETE: Done
       MOVED: Done
 
-- whiteboard_tag: data-quality
+- whiteboard_tag: dataquality
   bugzilla_user_id: tbd
   description: Data Quality
   parameters:

--- a/config/config.prod.yaml
+++ b/config/config.prod.yaml
@@ -268,3 +268,81 @@
       WORKSFORME: Done
       INCOMPLETE: Done
       MOVED: Done
+
+- whiteboard_tag: data-platform-infra-wg
+  bugzilla_user_id: tbd
+  description: Data Platform Infrastructure
+  parameters:
+    jira_project_key: DENG
+    jira_components:
+      - "Data Platform Infrastructure"
+    steps:
+      new:
+        - create_issue
+        - maybe_delete_duplicate
+        - add_link_to_bugzilla
+        - add_link_to_jira
+        - maybe_assign_jira_user
+        - maybe_update_issue_resolution
+        - maybe_update_issue_status
+      existing:
+        - update_issue
+        - maybe_assign_jira_user
+        - maybe_update_issue_resolution
+        - maybe_update_issue_status
+      comment:
+        - create_comment
+    status_map:
+      UNCONFIRMED: Backlog
+      NEW: Backlog
+      ASSIGNED: In Progress
+      REOPENED: In Progress
+      RESOLVED: Done
+      VERIFIED: Done
+      FIXED: Done
+      INVALID: Done
+      WONTFIX: Done
+      INACTIVE: Done
+      DUPLICATE: Done
+      WORKSFORME: Done
+      INCOMPLETE: Done
+      MOVED: Done
+
+- whiteboard_tag: data-quality
+  bugzilla_user_id: tbd
+  description: Data Quality
+  parameters:
+    jira_project_key: DENG
+    jira_components:
+      - "Data Quality"
+    steps:
+      new:
+        - create_issue
+        - maybe_delete_duplicate
+        - add_link_to_bugzilla
+        - add_link_to_jira
+        - maybe_assign_jira_user
+        - maybe_update_issue_resolution
+        - maybe_update_issue_status
+      existing:
+        - update_issue
+        - maybe_assign_jira_user
+        - maybe_update_issue_resolution
+        - maybe_update_issue_status
+      comment:
+        - create_comment
+    status_map:
+      UNCONFIRMED: To Do
+      NEW: To Do
+      ASSIGNED: In Progress
+      REOPENED: In Progress
+      RESOLVED: Done
+      VERIFIED: Done
+      FIXED: Done
+      INVALID: Done
+      WONTFIX: Done
+      INACTIVE: Done
+      DUPLICATE: Done
+      WORKSFORME: Done
+      INCOMPLETE: Done
+      MOVED: Done


### PR DESCRIPTION
This is adding a config to sync `[data-platform-infra-wg]` and `[data-quality]` issues from Bugzilla to the DENG Jira project. We don't have a specific bugzilla user that should be associated with new tickets, so I just set it to `tbd`.

cc @rafrombrc