### PR TITLE
Convert `InstrumentedClient` class to decorator

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,6 +31,12 @@ from tests.fixtures.factories import (
 )
 
 
+@pytest.fixture(autouse=True)
+def mocked_statsd():
+    with mock.patch("jbi.services.common.statsd") as _mocked_statsd:
+        yield _mocked_statsd
+
+
 @pytest.fixture
 def anon_client():
     """A test client with no authorization."""
@@ -66,7 +72,7 @@ def mocked_jira(request):
         yield None
         jira.get_client.cache_clear()
     else:
-        with mock.patch("jbi.services.jira.Jira") as mocked_jira:
+        with mock.patch("jbi.services.jira.JiraClient") as mocked_jira:
             yield mocked_jira()
             jira.get_client.cache_clear()
 

--- a/tests/unit/services/test_jira.py
+++ b/tests/unit/services/test_jira.py
@@ -1,5 +1,4 @@
 import json
-from unittest import mock
 
 import pytest
 import responses
@@ -8,22 +7,48 @@ from jbi.environment import get_settings
 from jbi.services import jira
 
 
-def test_counter_is_incremented_on_jira_create_issue():
+@pytest.mark.no_mocked_jira
+def test_jira_create_issue_is_instrumented(
+    mocked_responses, context_create_example, mocked_statsd
+):
+    url = f"{get_settings().jira_base_url}rest/api/2/project/{context_create_example.jira.project}/components"
+    mocked_responses.add(
+        responses.GET,
+        url,
+        json=[
+            {
+                "id": "10000",
+                "name": "Component 1",
+            },
+            {
+                "id": "42",
+                "name": "Remote Settings",
+            },
+        ],
+    )
+
+    url = f"{get_settings().jira_base_url}rest/api/2/issue"
+    mocked_responses.add(
+        responses.POST,
+        url,
+        json={
+            "id": "10000",
+            "key": "ED-24",
+        },
+    )
+
+    jira.create_jira_issue(
+        context_create_example,
+        "Description",
+        sync_whiteboard_labels=False,
+        components=["Remote Settings"],
+    )
     jira_client = jira.get_client()
 
-    with mock.patch("jbi.services.common.statsd") as mocked:
-        jira_client.create_issue({})
+    jira_client.create_issue({})
 
-    mocked.incr.assert_called_with("jbi.jira.methods.create_issue.count")
-
-
-def test_timer_is_used_on_jira_create_issue():
-    jira_client = jira.get_client()
-
-    with mock.patch("jbi.services.common.statsd") as mocked:
-        jira_client.create_issue({})
-
-    mocked.timer.assert_called_with("jbi.jira.methods.create_issue.timer")
+    mocked_statsd.incr.assert_called_with("jbi.jira.methods.create_issue.count")
+    mocked_statsd.timer.assert_called_with("jbi.jira.methods.create_issue.timer")
 
 
 @pytest.mark.no_mocked_jira


### PR DESCRIPTION
This makes it so that we're dealing with client objects directly, rather than an `InstrumentedClient`. This makes things like autocomplete, docstrings, and typing work a bit better.


Before:
<img width="849" alt="Screenshot 2023-05-08 at 2 51 05 PM" src="https://user-images.githubusercontent.com/20747904/236913707-e36ffa20-66dc-4a74-9fb2-26102a230792.png">
<img width="976" alt="Screenshot 2023-05-08 at 2 48 26 PM" src="https://user-images.githubusercontent.com/20747904/236913750-c84e75d0-23db-473c-9191-9adbed5fe620.png">

After:
<img width="808" alt="Screenshot 2023-05-08 at 2 50 49 PM" src="https://user-images.githubusercontent.com/20747904/236913821-62f61404-6218-4613-b8f3-41aa610fdc14.png">
<img width="923" alt="Screenshot 2023-05-08 at 2 49 45 PM" src="https://user-images.githubusercontent.com/20747904/236913825-e80d6437-b841-41ad-8c98-01999526bdeb.png">
