### PR TITLE
Ref #479: disable synchronization of labels on dataquality/dataplatform

### DIFF
--- a/config/config.nonprod.yaml
+++ b/config/config.nonprod.yaml
@@ -207,6 +207,7 @@
       WORKSFORME: Done
       INCOMPLETE: Done
       MOVED: Done
+    sync_whiteboard_labels: false
 
 - whiteboard_tag: dataquality
   bugzilla_user_id: tbd
@@ -244,3 +245,4 @@
       WORKSFORME: Done
       INCOMPLETE: Done
       MOVED: Done
+    sync_whiteboard_labels: false

--- a/config/config.prod.yaml
+++ b/config/config.prod.yaml
@@ -290,6 +290,7 @@
         - maybe_update_issue_status
       comment:
         - create_comment
+    sync_whiteboard_labels: false
 
 
 - whiteboard_tag: dataquality
@@ -313,3 +314,4 @@
         - maybe_update_issue_status
       comment:
         - create_comment
+    sync_whiteboard_labels: false


### PR DESCRIPTION
Error reported in Sentry https://mozilla.sentry.io/issues/3571741650/?project=6364263

`"labels":"Field 'labels' cannot be set. It is not on the appropriate screen, or unknown."`

Related #294 