### PR TITLE
Status mapping for DENG issues

### DIFF
--- a/config/config.prod.yaml
+++ b/config/config.prod.yaml
@@ -292,6 +292,21 @@
         - maybe_update_issue_status
       comment:
         - create_comment
+    status_map:
+      UNCONFIRMED: Backlog
+      NEW: Backlog
+      ASSIGNED: In Progress
+      REOPENED: In Progress
+      RESOLVED: Done
+      VERIFIED: Done
+      FIXED: Done
+      INVALID: Done
+      WONTFIX: Done
+      INACTIVE: Done
+      DUPLICATE: Done
+      WORKSFORME: Done
+      INCOMPLETE: Done
+      MOVED: Done
     sync_whiteboard_labels: false
 
 
@@ -318,4 +333,19 @@
         - maybe_update_issue_status
       comment:
         - create_comment
+    status_map:
+      UNCONFIRMED: To Do
+      NEW: To Do
+      ASSIGNED: In Progress
+      REOPENED: In Progress
+      RESOLVED: Done
+      VERIFIED: Done
+      FIXED: Done
+      INVALID: Done
+      WONTFIX: Done
+      INACTIVE: Done
+      DUPLICATE: Done
+      WORKSFORME: Done
+      INCOMPLETE: Done
+      MOVED: Done
     sync_whiteboard_labels: false


### PR DESCRIPTION
The `status_map` got removed as part of https://github.com/mozilla/jira-bugzilla-integration/pull/494 for debugging purposes. Now that the issues are syncing correctly can we add back the mapping?