### PR TITLE
Fix #518: add `maybe_update_components`

### DIFF
--- a/config/config.nonprod.yaml
+++ b/config/config.nonprod.yaml
@@ -182,6 +182,7 @@
       new:
         - create_issue
         - maybe_delete_duplicate
+        - maybe_update_components
         - add_link_to_bugzilla
         - add_link_to_jira
         - maybe_assign_jira_user
@@ -222,6 +223,7 @@
       new:
         - create_issue
         - maybe_delete_duplicate
+        - maybe_update_components
         - add_link_to_bugzilla
         - add_link_to_jira
         - maybe_assign_jira_user

--- a/config/config.prod.yaml
+++ b/config/config.prod.yaml
@@ -225,6 +225,18 @@
     jira_project_key: SE
     jira_components:
       - "Remote Settings"
+    steps:
+      new:
+        - create_issue
+        - maybe_delete_duplicate
+        - maybe_update_components
+        - add_link_to_bugzilla
+        - add_link_to_jira
+      existing:
+        - update_issue
+        - add_jira_comments_for_changes
+      comment:
+        - create_comment
 
 - whiteboard_tag: snt
   bugzilla_user_id: 696039
@@ -280,6 +292,7 @@
       new:
         - create_issue
         - maybe_delete_duplicate
+        - maybe_update_components
         - add_link_to_bugzilla
         - add_link_to_jira
         - maybe_assign_jira_user
@@ -321,6 +334,7 @@
       new:
         - create_issue
         - maybe_delete_duplicate
+        - maybe_update_components
         - add_link_to_bugzilla
         - add_link_to_jira
         - maybe_assign_jira_user

--- a/jbi/actions/steps.py
+++ b/jbi/actions/steps.py
@@ -31,7 +31,6 @@ def create_comment(context: ActionContext, **parameters):
 def create_issue(context: ActionContext, **parameters):
     """Create the Jira issue with the first comment as the description."""
     sync_whiteboard_labels: bool = parameters.get("sync_whiteboard_labels", True)
-    jira_components: list[str] = parameters.get("jira_components", [])
     bug = context.bug
 
     # In the payload of a bug creation, the `comment` field is `null`.
@@ -43,7 +42,6 @@ def create_issue(context: ActionContext, **parameters):
         context,
         description,
         sync_whiteboard_labels=sync_whiteboard_labels,
-        components=jira_components,
     )
     issue_key = jira_create_response.get("key")
 
@@ -198,3 +196,37 @@ def maybe_update_issue_status(context: ActionContext, **parameters):
             return context, (resp,)
 
     return context, ()
+
+
+def maybe_update_components(context: ActionContext, **parameters):
+    """
+    Update the Jira issue components
+    """
+    config_components: list[str] = parameters.get("jira_components", [])
+    candidate_components = set([context.bug.component] + config_components)
+    client = jira.get_client()
+
+    # Fetch all projects components, and match their id by name.
+    all_project_components = client.get_project_components(context.jira.project)
+    jira_components = []
+    for comp in all_project_components:
+        if comp["name"] in candidate_components:
+            jira_components.append({"id": comp["id"]})
+            candidate_components.remove(comp["name"])
+
+    if jira_components:
+        # Since we previously introspected the project components, we don't
+        # have to catch any potential 400 error response here.
+        resp = client.update_issue_field(
+            key=context.jira.issue, fields={"components": jira_components}
+        )
+
+    # Warn if some specified components are unknown
+    if candidate_components:
+        logger.warning(
+            f"Could not find components %s in project",
+            candidate_components,
+            extra=context.dict(),
+        )
+
+    return context, (resp,)

--- a/jbi/services/jira.py
+++ b/jbi/services/jira.py
@@ -211,7 +211,6 @@ def create_jira_issue(
     context: ActionContext,
     description: str,
     sync_whiteboard_labels: bool,
-    components: list[str],
 ):
     """Create a Jira issue with the specified fields and return its key."""
     bug = context.bug
@@ -230,16 +229,6 @@ def create_jira_issue(
         fields["labels"] = bug.get_jira_labels()
 
     client = get_client()
-
-    if components:
-        # Fetch all projects components, and match their id by name.
-        all_project_components = client.get_project_components(context.jira.project)
-        components_id = [
-            {"id": comp["id"]}
-            for comp in all_project_components
-            if comp["name"] in components
-        ]
-        fields["components"] = components_id
 
     jira_response_create = client.create_issue(fields=fields)
 

--- a/tests/unit/services/test_jira.py
+++ b/tests/unit/services/test_jira.py
@@ -14,22 +14,6 @@ from jbi.services import jira
 def test_jira_create_issue_is_instrumented(
     mocked_responses, context_create_example, mocked_statsd
 ):
-    url = f"{get_settings().jira_base_url}rest/api/2/project/{context_create_example.jira.project}/components"
-    mocked_responses.add(
-        responses.GET,
-        url,
-        json=[
-            {
-                "id": "10000",
-                "name": "Component 1",
-            },
-            {
-                "id": "42",
-                "name": "Remote Settings",
-            },
-        ],
-    )
-
     url = f"{get_settings().jira_base_url}rest/api/2/issue"
     mocked_responses.add(
         responses.POST,
@@ -44,7 +28,6 @@ def test_jira_create_issue_is_instrumented(
         context_create_example,
         "Description",
         sync_whiteboard_labels=False,
-        components=["Remote Settings"],
     )
     jira_client = jira.get_client()
 
@@ -69,11 +52,8 @@ def test_jira_calls_log_http_errors(mocked_responses, context_create_example, ca
 
     with caplog.at_level(logging.ERROR):
         with pytest.raises(requests.HTTPError):
-            jira.create_jira_issue(
-                context_create_example,
-                "Description",
-                sync_whiteboard_labels=False,
-                components=["Remote Settings"],
+            jira.get_client().get_project_components(
+                context_create_example.jira.project
             )
 
     log_messages = [log.msg % log.args for log in caplog.records]
@@ -85,46 +65,6 @@ def test_jira_calls_log_http_errors(mocked_responses, context_create_example, ca
         log_record.body
         == '{"errorMessages": ["No project could be found with key \'X\'."], "errors": {}}'
     )
-
-
-@pytest.mark.no_mocked_jira
-def test_create_issue_with_components(mocked_responses, context_create_example):
-    url = f"{get_settings().jira_base_url}rest/api/2/project/{context_create_example.jira.project}/components"
-    mocked_responses.add(
-        responses.GET,
-        url,
-        json=[
-            {
-                "id": "10000",
-                "name": "Component 1",
-            },
-            {
-                "id": "42",
-                "name": "Remote Settings",
-            },
-        ],
-    )
-
-    url = f"{get_settings().jira_base_url}rest/api/2/issue"
-    mocked_responses.add(
-        responses.POST,
-        url,
-        json={
-            "id": "10000",
-            "key": "ED-24",
-        },
-    )
-
-    jira.create_jira_issue(
-        context_create_example,
-        "Description",
-        sync_whiteboard_labels=False,
-        components=["Remote Settings"],
-    )
-
-    posted_data = json.loads(mocked_responses.calls[-1].request.body)
-
-    assert posted_data["fields"]["components"] == [{"id": "42"}]
 
 
 @pytest.mark.no_mocked_jira


### PR DESCRIPTION
I found #518 interesting to work on, since it is related to what we are trying to achieve in #517.

I decoupled the setting of the `components` field from the `create_issue` step, and made it a dedicated "maybe step". 
If the bug component isn't part of the existing Jira project components, a warning is issued and the step does not crash (hence the `maybe_`)

I believe that this approach (removing parameters from `create_issue`) follows more what we described in our first ADR https://github.com/mozilla/jira-bugzilla-integration/blob/main/docs/adrs/001-actions-reusability.md