### PR TITLE
Fix #415: ignore events when Jira issue is not readable by bot

### DIFF
--- a/jbi/runner.py
+++ b/jbi/runner.py
@@ -17,7 +17,7 @@ from jbi.models import (
     JiraContext,
     RunnerContext,
 )
-from jbi.services import bugzilla
+from jbi.services import bugzilla, jira
 
 logger = logging.getLogger(__name__)
 
@@ -89,6 +89,12 @@ def execute_action(
                 action_context = action_context.update(operation=Operation.CREATE)
 
         else:
+            # Check that issue exists (and is readable)
+            if not jira.get_issue(action_context, action_context.jira.issue):
+                raise IgnoreInvalidRequestError(
+                    f"ignore unreadable issue {action_context.jira.issue}"
+                )
+
             if event.target == "bug":
                 changed_fields = event.changed_fields() or []
                 action_context = action_context.update(

--- a/jbi/services/jira.py
+++ b/jbi/services/jira.py
@@ -203,6 +203,19 @@ def _all_projects_components_exist(actions: Actions):
     return success
 
 
+def get_issue(context: ActionContext, issue_key):
+    """Return the Jira issue fields or `None` if not found."""
+    try:
+        return get_client().get_issue(issue_key)
+    except requests_exceptions.HTTPError as exc:
+        if exc.response.status_code != 404:
+            raise
+        logger.error(
+            "Could not read issue %s: %s", issue_key, exc, extra=context.dict()
+        )
+        return None
+
+
 class JiraCreateError(Exception):
     """Error raised on Jira issue creation."""
 


### PR DESCRIPTION
When the linked Jira issue is not readable, we log and ignore the event