### PR TITLE
Fix errors observed after v4.4.0 release

### DIFF
--- a/jbi/actions/default.py
+++ b/jbi/actions/default.py
@@ -7,7 +7,7 @@ is created or updated, its `operation` attribute will be `Operation.CREATE` or `
 and when a comment is posted, it will be set to `Operation.COMMENT`.
 """
 import logging
-from typing import Optional
+from typing import Callable, Optional
 
 from jbi import ActionResult, Operation
 from jbi.actions import steps as steps_module
@@ -86,7 +86,7 @@ def init(
 class Executor:
     """Callable class that encapsulates the default action."""
 
-    def __init__(self, steps, **parameters):
+    def __init__(self, steps: dict[Operation, list[Callable]], **parameters):
         """Initialize Executor Object"""
         self.steps = steps
         self.parameters = parameters

--- a/jbi/actions/steps.py
+++ b/jbi/actions/steps.py
@@ -5,7 +5,7 @@ Each step takes an `ActionContext` and a list of arbitrary parameters.
 """
 
 import logging
-from typing import Optional
+from typing import Iterable, Optional
 
 from requests import exceptions as requests_exceptions
 
@@ -154,6 +154,8 @@ def maybe_update_issue_resolution(
     https://support.atlassian.com/jira-cloud-administration/docs/what-are-issue-statuses-priorities-and-resolutions/
     """
     resolution_map: dict[str, str] = parameters.get("resolution_map", {})
+    if not isinstance(resolution_map, dict):
+        raise TypeError("The 'resolution_map' parameter must be a dictionary.")
     jira_resolution = resolution_map.get(context.bug.resolution or "")
     if jira_resolution is None:
         logger.debug(
@@ -181,9 +183,12 @@ def maybe_update_issue_status(context: ActionContext, **parameters):
     Update the Jira issue resolution
     https://support.atlassian.com/jira-cloud-administration/docs/what-are-issue-statuses-priorities-and-resolutions/
     """
-    resolution_map: dict[str, str] = parameters.get("status_map", {})
+    status_map = parameters.get("status_map", {})
+    if not isinstance(status_map, dict):
+        raise TypeError("The 'status_map' parameter must be a dictionary.")
+
     bz_status = context.bug.resolution or context.bug.status
-    jira_status = resolution_map.get(bz_status or "")
+    jira_status = status_map.get(bz_status or "")
 
     if jira_status is None:
         logger.debug(
@@ -212,7 +217,9 @@ def maybe_update_components(context: ActionContext, **parameters):
     """
     Update the Jira issue components
     """
-    config_components: list[str] = parameters.get("jira_components", [])
+    config_components = parameters.get("jira_components", [])
+    if not isinstance(config_components, Iterable):
+        raise TypeError("The 'jira_components' parameter must be an iterable.")
     candidate_components = set(config_components)
     if context.bug.component:
         candidate_components.add(context.bug.component)

--- a/jbi/models.py
+++ b/jbi/models.py
@@ -68,15 +68,17 @@ class Action(YamlModel):
             action_parameters: Optional[dict[str, Any]] = values["parameters"]
             action_module: ModuleType = importlib.import_module(module)
             if not action_module:
-                raise TypeError("Module is not found.")
+                raise TypeError(f"Module '{module}' is not found.")
             if not hasattr(action_module, "init"):
-                raise TypeError("Module is missing `init` method.")
+                raise TypeError(f"Module '{module}' is missing `init` method.")
 
             signature(action_module.init).bind(**action_parameters)  # type: ignore
         except ImportError as exception:
             raise ValueError(f"unknown Python module `{module}`.") from exception
         except (TypeError, AttributeError) as exception:
-            raise ValueError(f"action is not properly setup.{exception}") from exception
+            raise ValueError(
+                f"action '{module}' is not properly setup. {exception}"
+            ) from exception
         return values
 
 

--- a/jbi/models.py
+++ b/jbi/models.py
@@ -9,7 +9,7 @@ import re
 import warnings
 from inspect import signature
 from types import ModuleType
-from typing import Callable, Literal, Mapping, Optional, TypedDict
+from typing import Any, Callable, Literal, Mapping, Optional, TypedDict
 from urllib.parse import ParseResult, urlparse
 
 from pydantic import BaseModel, Extra, Field, PrivateAttr, root_validator, validator
@@ -23,19 +23,6 @@ logger = logging.getLogger(__name__)
 JIRA_HOSTNAMES = ("jira", "atlassian")
 
 
-class ActionParameters(BaseModel):
-    """Action parameters"""
-
-    # For runner
-    jira_project_key: str
-    steps: Optional[dict[str, list[str]]] = None
-    # For steps
-    status_map: Optional[dict[str, str]] = None
-    resolution_map: Optional[dict[str, str]] = None
-    jira_components: Optional[list[str]] = None
-    sync_whiteboard_labels: bool = True
-
-
 class Action(YamlModel):
     """
     Action is the inner model for each action in the configuration file"""
@@ -46,21 +33,21 @@ class Action(YamlModel):
     description: str
     enabled: bool = True
     allow_private: bool = False
-    parameters: ActionParameters
+    parameters: dict = {}
     _caller: Optional[Callable] = PrivateAttr(default=None)
     _required_jira_permissions: set[str] = PrivateAttr(default=None)
 
     @property
     def jira_project_key(self):
         """Return the configured project key."""
-        return self.parameters.jira_project_key
+        return self.parameters["jira_project_key"]
 
     @property
     def caller(self) -> Callable:
         """Return the initialized callable for this action."""
         if self._caller is None:
             action_module: ModuleType = importlib.import_module(self.module)
-            initialized: Callable = action_module.init(**self.parameters.dict())  # type: ignore
+            initialized: Callable = action_module.init(**self.parameters)  # type: ignore
             self._caller = initialized
         return self._caller
 
@@ -78,23 +65,18 @@ class Action(YamlModel):
         """Validate action: exists, has init function, and has expected params"""
         try:
             module: str = values["module"]  # type: ignore
-            try:
-                action_parameters = values["parameters"].dict()
-            except KeyError:
-                action_parameters = {}
+            action_parameters: Optional[dict[str, Any]] = values["parameters"]
             action_module: ModuleType = importlib.import_module(module)
             if not action_module:
                 raise TypeError("Module is not found.")
             if not hasattr(action_module, "init"):
                 raise TypeError("Module is missing `init` method.")
 
-            signature(action_module.init).bind(**action_parameters)
+            signature(action_module.init).bind(**action_parameters)  # type: ignore
         except ImportError as exception:
             raise ValueError(f"unknown Python module `{module}`.") from exception
         except (TypeError, AttributeError) as exception:
-            raise ValueError(
-                f"action '{module}' is not properly setup. {exception}"
-            ) from exception
+            raise ValueError(f"action is not properly setup.{exception}") from exception
         return values
 
 
@@ -126,7 +108,11 @@ class Actions(YamlModel):
     @functools.cached_property
     def configured_jira_projects_keys(self) -> set[str]:
         """Return the list of Jira project keys from all configured actions"""
-        return {action.jira_project_key for action in self.__root__}
+        return {
+            action.jira_project_key
+            for action in self.__root__
+            if "jira_project_key" in action.parameters
+        }
 
     @validator("__root__")
     def validate_actions(  # pylint: disable=no-self-argument

--- a/jbi/models.py
+++ b/jbi/models.py
@@ -113,7 +113,7 @@ class Actions(YamlModel):
         return {
             action.jira_project_key
             for action in self.__root__
-            if "jira_project_key" in action.parameters
+            if action.parameters.get("jira_project_key")
         }
 
     @validator("__root__")

--- a/jbi/runner.py
+++ b/jbi/runner.py
@@ -81,7 +81,7 @@ def execute_action(
             event=event,
             operation=Operation.IGNORE,
             jira=JiraContext(project=action.jira_project_key, issue=linked_issue_key),
-            extra={k: str(v) for k, v in action.parameters.dict().items()},
+            extra={k: str(v) for k, v in action.parameters.items()},
         )
 
         if action_context.jira.issue is None:

--- a/jbi/services/jira.py
+++ b/jbi/services/jira.py
@@ -131,7 +131,7 @@ def _fetch_project_permissions(actions):
     required_perms_by_project = {
         action.parameters["jira_project_key"]: action.required_jira_permissions
         for action in actions
-        if "jira_project_key" in action.parameters
+        if action.parameters.get("jira_project_key")
     }
     client = get_client()
     all_projects_perms = {}
@@ -186,7 +186,7 @@ def _all_projects_components_exist(actions: Actions):
     components_by_project = {
         action.parameters["jira_project_key"]: action.parameters["jira_components"]
         for action in actions
-        if "jira_components" in action.parameters
+        if action.parameters.get("jira_components")
     }
     success = True
     for project, specified_components in components_by_project.items():

--- a/jbi/services/jira.py
+++ b/jbi/services/jira.py
@@ -129,8 +129,9 @@ def _all_projects_permissions(actions: Actions):
 def _fetch_project_permissions(actions):
     """Fetches permissions for the configured projects"""
     required_perms_by_project = {
-        action.parameters.jira_project_key: action.required_jira_permissions
+        action.parameters["jira_project_key"]: action.required_jira_permissions
         for action in actions
+        if "jira_project_key" in action.parameters
     }
     client = get_client()
     all_projects_perms = {}
@@ -183,8 +184,9 @@ def _validate_permissions(all_projects_perms):
 
 def _all_projects_components_exist(actions: Actions):
     components_by_project = {
-        action.parameters.jira_project_key: action.parameters.jira_components
+        action.parameters["jira_project_key"]: action.parameters["jira_components"]
         for action in actions
+        if "jira_components" in action.parameters
     }
     success = True
     for project, specified_components in components_by_project.items():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -229,7 +229,7 @@ def webhook_modify_private_example() -> BugzillaWebhookRequest:
 
 
 @pytest.fixture
-def action_factory() -> Action:
+def action_factory():
     return factories.action_factory
 
 

--- a/tests/fixtures/bugzilla_action.py
+++ b/tests/fixtures/bugzilla_action.py
@@ -3,5 +3,5 @@ class FakeBugzillaAction:
         return {"bug": bug, "event": event}
 
 
-def init(**kwargs):
+def init():
     return FakeBugzillaAction()

--- a/tests/fixtures/bugzilla_action.py
+++ b/tests/fixtures/bugzilla_action.py
@@ -1,7 +1,0 @@
-class FakeBugzillaAction:
-    def __call__(self, bug, event):
-        return {"bug": bug, "event": event}
-
-
-def init():
-    return FakeBugzillaAction()

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -66,8 +66,10 @@ def test_unknown_module_fails():
 
 def test_bad_module_fails():
     with pytest.raises(ValueError) as exc_info:
+        # use a module that exists in the source, but isn't properly set up as
+        # a valid action module
         Actions.parse_obj([{"whiteboard_tag": "x", "module": "jbi.runner"}])
-    assert "action is not properly setup" in str(exc_info.value)
+    assert "action 'jbi.runner' is not properly setup" in str(exc_info.value)
 
 
 def test_duplicated_whiteboard_tag_fails():

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -1,55 +1,33 @@
+import pydantic
 import pytest
 from fastapi.encoders import jsonable_encoder
 
-from jbi.models import Action, Actions
-from tests.fixtures.factories import action_factory
+from jbi import Operation
+from jbi.models import Actions
+from tests.fixtures.factories import action_context_factory
 
 
-def test_model_serializes():
-    """Regression test to assert that action with initialized Bugzilla client serializes"""
-    action = Action.parse_obj(
-        {
-            "whiteboard_tag": "devtest",
-            "bugzilla_user_id": 123456,
-            "description": "test config",
-            "module": "tests.fixtures.bugzilla_action",
-        }
+def test_default_action_serializes(action_factory):
+    action = action_factory(
+        module="jbi.actions.default",
+        parameters={"jira_project_key": "ABC", "steps": {"new": []}},
     )
-    action.caller(bug=None, event=None)
+    action.caller(action_context_factory(operation=Operation.CREATE))
     serialized_action = jsonable_encoder(action)
     assert not serialized_action.get("_caller")
     assert not serialized_action.get("caller")
 
 
-def test_model_with_user_list_serializes():
-    """Regression test to assert that action with initialized Bugzilla client serializes (with user id list)"""
-    action = Action.parse_obj(
-        {
-            "whiteboard_tag": "devtest",
-            "bugzilla_user_id": [123456, 654321, 000000, 111111],
-            "description": "test config",
-            "module": "tests.fixtures.bugzilla_action",
-        }
-    )
-    action.caller(bug=None, event=None)
-    serialized_action = jsonable_encoder(action)
-    assert not serialized_action.get("_caller")
-    assert not serialized_action.get("caller")
+@pytest.mark.parametrize("value", [123456, [123456], [12345, 67890], "tbd"])
+def test_valid_bugzilla_user_ids(action_factory, value):
+    action = action_factory(bugzilla_user_id=value)
+    assert action.bugzilla_user_id == value
 
-    def test_model_with_user_list_of_one_serializes():
-        """Regression test to assert that action with initialized Bugzilla client serializes (with user id in list)"""
-        action = Action.parse_obj(
-            {
-                "whiteboard_tag": "devtest",
-                "bugzilla_user_id": [123456],
-                "description": "test config",
-                "module": "tests.fixtures.bugzilla_action",
-            }
-        )
-        action.caller(bug=None, event=None)
-        serialized_action = jsonable_encoder(action)
-        assert not serialized_action.get("_caller")
-        assert not serialized_action.get("caller")
+
+@pytest.mark.parametrize("value", [None, "foobar@example.com"])
+def test_invalid_bugzilla_user_ids(action_factory, value):
+    with pytest.raises(pydantic.ValidationError):
+        action = action_factory(bugzilla_user_id=value)
 
 
 def test_no_actions_fails():
@@ -72,7 +50,7 @@ def test_bad_module_fails():
     assert "action 'jbi.runner' is not properly setup" in str(exc_info.value)
 
 
-def test_duplicated_whiteboard_tag_fails():
+def test_duplicated_whiteboard_tag_fails(action_factory):
     with pytest.raises(ValueError) as exc_info:
         Actions.parse_obj(
             [

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -1,7 +1,7 @@
 import pytest
 from fastapi.encoders import jsonable_encoder
 
-from jbi.models import Action, ActionParameters, Actions
+from jbi.models import Action, Actions
 from tests.fixtures.factories import action_factory
 
 
@@ -13,7 +13,6 @@ def test_model_serializes():
             "bugzilla_user_id": 123456,
             "description": "test config",
             "module": "tests.fixtures.bugzilla_action",
-            "parameters": ActionParameters(jira_project_key="fooo"),
         }
     )
     action.caller(bug=None, event=None)
@@ -30,7 +29,6 @@ def test_model_with_user_list_serializes():
             "bugzilla_user_id": [123456, 654321, 000000, 111111],
             "description": "test config",
             "module": "tests.fixtures.bugzilla_action",
-            "parameters": ActionParameters(jira_project_key="fooo"),
         }
     )
     action.caller(bug=None, event=None)
@@ -46,7 +44,6 @@ def test_model_with_user_list_serializes():
                 "bugzilla_user_id": [123456],
                 "description": "test config",
                 "module": "tests.fixtures.bugzilla_action",
-                "parameters": ActionParameters(jira_project_key="fooo"),
             }
         )
         action.caller(bug=None, event=None)
@@ -70,7 +67,7 @@ def test_unknown_module_fails():
 def test_bad_module_fails():
     with pytest.raises(ValueError) as exc_info:
         Actions.parse_obj([{"whiteboard_tag": "x", "module": "jbi.runner"}])
-    assert "action 'jbi.runner' is not properly setup" in str(exc_info.value)
+    assert "action is not properly setup" in str(exc_info.value)
 
 
 def test_duplicated_whiteboard_tag_fails():


### PR DESCRIPTION
In https://github.com/mozilla/jira-bugzilla-integration/commit/c178e304b0858bba15c6a60c15ddbd46fb7cf327, we added typing for action parameters, which made it more "ergonomic" to access params and know their types.

However, this lead to [some](https://mozilla.sentry.io/issues/4208127241/?project=6364263&query=is%3Aunresolved&referrer=issue-stream&stream_index=1) [issues](https://mozilla.sentry.io/issues/4208116624/?project=6364263&query=is%3Aunresolved&referrer=issue-stream&stream_index=0)  in some functions where we'd `get()` params, providing a default if the key wasn't in the params dict.

Here is a subset of `ActionParameters`:

```python
    status_map: Optional[dict[str, str]] = None
    resolution_map: Optional[dict[str, str]] = None
    jira_components: Optional[list[str]] = None
```

And here's a snippet where one of the errors popped up:
```python
resolution_map: dict[str, str] = parameters.get("resolution_map", {})
jira_resolution = resolution_map.get(context.bug.resolution or "")
```
In this case, we expect to set `resolution_map` to `{}` if it isn't set in the config. But based on how the Pydantic model behaves, if `resolution_map` is unset in the config, it gets set to `resolution_map=None` in the Pydantic model, so we set `resolution_map` to `None`.

Here's where the other error popped up:

```python
    components_by_project = {
        action.parameters.jira_project_key: action.parameters.jira_components
        for action in actions
    }
    success = True
    for project, specified_components in components_by_project.items():
        all_project_components = get_client().get_project_components(project)
        all_components_names = set(comp["name"] for comp in all_project_components)
        unknown = set(specified_components) - all_components_names
```

In this case, we still need a guard to filter out actions where `parameters.jira_components` is `None`, because we can't make a `set` out of None.

For now, my strategy was to revert the PR where we added this `ActionParameters` object and add some regression test cases.

While I was here, I took the opportunity to fix some other issues I saw.

Also, now that I'm looking again at #523, `ActionParameters` might be going in a direction that's different than was intended as far as how "free" users are to supply entirely custom actions and parameters. I'll open this discussion in a new issue, but it might warrant an ADR if we want to narrow action parameters to only certain fields / types.
