### PR TITLE
Ref #548, #407: filter `see_also` URLs for configured project

### DIFF
--- a/jbi/models.py
+++ b/jbi/models.py
@@ -239,7 +239,7 @@ class BugzillaBug(BaseModel):
         type_map: dict = {"enhancement": "Task", "task": "Task", "defect": "Bug"}
         return type_map.get(self.type, "Task")
 
-    def extract_from_see_also(self):
+    def extract_from_see_also(self, project_key):
         """Extract Jira Issue Key from see_also if jira url present"""
         if not self.see_also or len(self.see_also) == 0:
             return None
@@ -262,8 +262,10 @@ class BugzillaBug(BaseModel):
                 continue
 
             if any(part in JIRA_HOSTNAMES for part in host_parts):
+                # URL ending with /
                 parsed_jira_key = parsed_url.path.rstrip("/").split("/")[-1]
-                if parsed_jira_key:  # URL ending with /
+                # eg. filter for specified project SNT-1234
+                if parsed_jira_key and project_key in parsed_jira_key:
                     return parsed_jira_key
 
         return None

--- a/jbi/runner.py
+++ b/jbi/runner.py
@@ -73,7 +73,9 @@ def execute_action(
                 f"private bugs are not valid for action {action.whiteboard_tag!r}"
             )
 
-        linked_issue_key: Optional[str] = bug.extract_from_see_also()
+        linked_issue_key: Optional[str] = bug.extract_from_see_also(
+            project_key=action.jira_project_key
+        )
 
         action_context = ActionContext(
             rid=request.rid,


### PR DESCRIPTION
I think this would be a safety check for situations like in #548, when tags are modified and link switches from one project to another.

And could maybe cover #407 as a side effect. 

What do you think? 

*disclaimer: this was implemented without contemplating all possible consequences on workflows*