### PR TITLE
Rename SNT to SNG (but keep old tag)

### DIFF
--- a/config/config.prod.yaml
+++ b/config/config.prod.yaml
@@ -259,7 +259,13 @@
   bugzilla_user_id: 696039
   description: Search/NewTab Team Tag
   parameters:
-    jira_project_key: SNT
+    jira_project_key: SNG
+
+- whiteboard_tag: sng
+  bugzilla_user_id: 696039
+  description: Search/NewTab Team Tag
+  parameters:
+    jira_project_key: SNG
 
 - whiteboard_tag: sp3
   bugzilla_user_id: 396948


### PR DESCRIPTION
https://mozilla.sentry.io/issues/4234643786/
First seen on 7th of June

After opening a request, got the explanation:
<img width="594" alt="Screenshot 2023-06-09 at 11 28 19" src="https://github.com/mozilla/jira-bugzilla-integration/assets/546692/be844576-791a-463f-8513-20de76b26b90">

https://mozilla-hub.atlassian.net/servicedesk/customer/portal/4/SDD-15041

-----

> I'm kind of happy this happened. It justified my intuition that project configuration had to be included in the service heartbeat. 