### PR TITLE
Use `get_project` to retrieve project issue types

### DIFF
--- a/jbi/services/jira.py
+++ b/jbi/services/jira.py
@@ -85,7 +85,7 @@ class JiraClient(Jira):
     set_issue_status = instrumented_method(Jira.set_issue_status)
     issue_add_comment = instrumented_method(Jira.issue_add_comment)
     create_issue = instrumented_method(Jira.create_issue)
-    issue_createmeta_issuetypes = instrumented_method(Jira.issue_createmeta_issuetypes)
+    get_project = instrumented_method(Jira.get_project)
 
 
 @lru_cache(maxsize=1)
@@ -228,8 +228,8 @@ def _all_project_issue_types_exist(actions: Actions):
     }
     success = True
     for project, specified_issue_types in issue_types_by_project.items():
-        all_issue_types = get_client().issue_createmeta_issuetypes(project)
-        all_issue_types_names = set(it["name"] for it in all_issue_types)
+        response = get_client().get_project(project)
+        all_issue_types_names = set(it["name"] for it in response["issueTypes"])
         unknown = set(specified_issue_types) - all_issue_types_names
         if unknown:
             logger.error(

--- a/tests/unit/test_router.py
+++ b/tests/unit/test_router.py
@@ -259,10 +259,12 @@ def test_read_heartbeat_success(anon_client, mocked_jira, mocked_bugzilla):
             "DELETE_ISSUES": {"havePermission": True},
         },
     }
-    mocked_jira.issue_createmeta_issuetypes.return_value = [
-        {"name": "Task"},
-        {"name": "Bug"},
-    ]
+    mocked_jira.get_project.return_value = {
+        "issueTypes": [
+            {"name": "Task"},
+            {"name": "Bug"},
+        ]
+    }
 
     resp = anon_client.get("/__heartbeat__")
 
@@ -324,10 +326,12 @@ def test_jira_heartbeat_unknown_components(anon_client, mocked_jira):
 
 def test_jira_heartbeat_unknown_issue_types(anon_client, mocked_jira):
     mocked_jira.get_server_info.return_value = {}
-    mocked_jira.issue_createmeta_issuetypes.return_value = [
-        {"name": "Task"},
-        # missing Bug
-    ]
+    mocked_jira.get_project.return_value = {
+        "issueTypes": [
+            {"name": "Task"},
+            # missing "Bug"
+        ]
+    }
 
     resp = anon_client.get("/__heartbeat__")
 
@@ -351,10 +355,12 @@ def test_head_heartbeat_success(anon_client, mocked_jira, mocked_bugzilla):
             "DELETE_ISSUES": {"havePermission": True},
         },
     }
-    mocked_jira.issue_createmeta_issuetypes.return_value = [
-        {"name": "Task"},
-        {"name": "Bug"},
-    ]
+    mocked_jira.get_project.return_value = {
+        "issueTypes": [
+            {"name": "Task"},
+            {"name": "Bug"},
+        ]
+    }
 
     resp = anon_client.head("/__heartbeat__")
 


### PR DESCRIPTION
I was unable to successfully use `GET /rest/api/2/issuetype/project` ([docs](https://developer.atlassian.com/cloud/jira/platform/rest/v2/api-group-issue-types/#api-rest-api-2-issuetype-project-get)) or `issue/createmeta/{}/issuetypes` to find issue types for a project. For the later URL, I didn't even see the endpoint [documented](https://developer.atlassian.com/cloud/jira/platform/rest/v2/api-group-issues/#api-rest-api-2-issue-createmeta-get) in the Cloud REST API documentation. Maybe it only works for `Server` (i.e. not `Cloud`) instances? ([Server docs](https://developer.atlassian.com/server/jira/platform/jira-rest-api-examples/#discovering-issue-type-data
))

I _was_ able to successfully view available issue types through the `GET /rest/api/2/project/{projectIdOrKey}` endpoint ([docs](https://developer.atlassian.com/cloud/jira/platform/rest/v2/api-group-projects/#api-rest-api-2-project-projectidorkey-get)).

