### PR TITLE
Rename Jira component for Remote Settings

### DIFF
--- a/config/config.prod.yaml
+++ b/config/config.prod.yaml
@@ -259,7 +259,7 @@
   parameters:
     jira_project_key: SE
     jira_components:
-      - "Remote Settings"
+      - "remote-settings"
     steps:
       new:
         - create_issue


### PR DESCRIPTION
https://mozilla.sentry.io/issues/4248139717/?referrer=slack

Rename from `Remote Settings` to `remote-settings`. `remote-settings` seems to be the name of the remote settings [component available on the SE project](https://mozilla-hub.atlassian.net/jira/software/c/projects/SE/components).