### PR TITLE
Make all factories fixtures

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -108,46 +108,6 @@ def context_create_example(action_context_factory) -> ActionContext:
 
 
 @pytest.fixture
-def context_update_example(
-    action_context_factory, bug_factory, jira_context_factory
-) -> ActionContext:
-    bug = bug_factory(see_also=["https://mozilla.atlassian.net/browse/JBI-234"])
-    context = action_context_factory(
-        operation=Operation.UPDATE,
-        bug=bug,
-        jira=jira_context_factory(issue=bug.extract_from_see_also()),
-    )
-    return context
-
-
-@pytest.fixture
-def context_update_status_assignee(
-    webhook_event_factory, action_context_factory, bug_factory, jira_context_factory
-) -> ActionContext:
-    bug = bug_factory(see_also=["https://mozilla.atlassian.net/browse/JBI-234"])
-    changes = [
-        {
-            "field": "status",
-            "removed": "OPEN",
-            "added": "FIXED",
-        },
-        {
-            "field": "assignee",
-            "removed": "nobody@mozilla.org",
-            "added": "mathieu@mozilla.com",
-        },
-    ]
-    event = webhook_event_factory(routing_key="bug.modify", changes=changes)
-    context = action_context_factory(
-        operation=Operation.UPDATE,
-        bug=bug,
-        event=event,
-        jira=jira_context_factory(issue=bug.extract_from_see_also()),
-    )
-    return context
-
-
-@pytest.fixture
 def context_comment_example(
     webhook_user_factory,
     bug_factory,
@@ -172,80 +132,9 @@ def context_comment_example(
 
 
 @pytest.fixture
-def context_update_resolution_example(
-    bug_factory,
-    webhook_event_factory,
-    webhook_event_change_factory,
-    action_context_factory,
-    jira_context_factory,
-) -> ActionContext:
-    bug = bug_factory(see_also=["https://mozilla.atlassian.net/browse/JBI-234"])
-    event = webhook_event_factory(
-        action="modify",
-        changes=[
-            webhook_event_change_factory(
-                field="resolution", removed="OPEN", added="FIXED"
-            ),
-        ],
-    )
-    context = action_context_factory(
-        operation=Operation.UPDATE,
-        bug=bug,
-        event=event,
-        jira=jira_context_factory(issue=bug.extract_from_see_also()),
-    )
-    return context
-
-
-@pytest.fixture
 def webhook_create_example(webhook_factory) -> BugzillaWebhookRequest:
     webhook_payload = webhook_factory()
 
-    return webhook_payload
-
-
-@pytest.fixture
-def webhook_comment_example(
-    webhook_user_factory, bug_factory, webhook_event_factory, webhook_factory
-) -> BugzillaWebhookRequest:
-    user = webhook_user_factory(login="mathieu@mozilla.org")
-    comment = BugzillaWebhookComment.parse_obj({"number": 2, "body": "hello"})
-    bug = bug_factory(
-        see_also=["https://mozilla.atlassian.net/browse/JBI-234"],
-        comment=comment,
-    )
-    event = webhook_event_factory(target="comment", user=user)
-    webhook_payload = webhook_factory(bug=bug, event=event)
-
-    return webhook_payload
-
-
-@pytest.fixture
-def webhook_private_comment_example(
-    webhook_user_factory, webhook_event_factory, bug_factory, webhook_factory
-) -> BugzillaWebhookRequest:
-    user = webhook_user_factory(login="mathieu@mozilla.org")
-    event = webhook_event_factory(target="comment", user=user)
-    bug = bug_factory(
-        comment={"id": 344, "number": 2, "is_private": True},
-        see_also=["https://mozilla.atlassian.net/browse/JBI-234"],
-    )
-    webhook_payload = webhook_factory(bug=bug, event=event)
-    return webhook_payload
-
-
-@pytest.fixture
-def webhook_change_status_assignee(
-    webhook_event_change_factory, webhook_event_factory, webhook_factory
-):
-    changes = [
-        webhook_event_change_factory(field="status", removed="OPEN", added="FIXED"),
-        webhook_event_change_factory(
-            field="assignee", removed="nobody@mozilla.org", added="mathieu@mozilla.com"
-        ),
-    ]
-    event = webhook_event_factory(routing_key="bug.modify", changes=changes)
-    webhook_payload = webhook_factory(event=event)
     return webhook_payload
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,7 +20,7 @@ from jbi.models import (
     BugzillaWebhookRequest,
 )
 from jbi.services import bugzilla, jira
-from tests.fixtures import factories
+from tests.fixtures.factories import *
 
 
 class FilteredLogCaptureFixture(pytest.LogCaptureFixture):
@@ -107,30 +107,30 @@ def mocked_responses():
 
 
 @pytest.fixture
-def context_create_example() -> ActionContext:
-    return factories.action_context_factory(
+def context_create_example(action_context_factory) -> ActionContext:
+    return action_context_factory(
         operation=Operation.CREATE,
     )
 
 
 @pytest.fixture
-def context_update_example() -> ActionContext:
-    bug = factories.bug_factory(
-        see_also=["https://mozilla.atlassian.net/browse/JBI-234"]
-    )
-    context = factories.action_context_factory(
+def context_update_example(
+    action_context_factory, bug_factory, jira_context_factory
+) -> ActionContext:
+    bug = bug_factory(see_also=["https://mozilla.atlassian.net/browse/JBI-234"])
+    context = action_context_factory(
         operation=Operation.UPDATE,
         bug=bug,
-        jira=factories.jira_context_factory(issue=bug.extract_from_see_also()),
+        jira=jira_context_factory(issue=bug.extract_from_see_also()),
     )
     return context
 
 
 @pytest.fixture
-def context_update_status_assignee() -> ActionContext:
-    bug = factories.bug_factory(
-        see_also=["https://mozilla.atlassian.net/browse/JBI-234"]
-    )
+def context_update_status_assignee(
+    webhook_event_factory, action_context_factory, bug_factory, jira_context_factory
+) -> ActionContext:
+    bug = bug_factory(see_also=["https://mozilla.atlassian.net/browse/JBI-234"])
     changes = [
         {
             "field": "status",
@@ -143,117 +143,121 @@ def context_update_status_assignee() -> ActionContext:
             "added": "mathieu@mozilla.com",
         },
     ]
-    event = factories.webhook_event_factory(routing_key="bug.modify", changes=changes)
-    context = factories.action_context_factory(
+    event = webhook_event_factory(routing_key="bug.modify", changes=changes)
+    context = action_context_factory(
         operation=Operation.UPDATE,
         bug=bug,
         event=event,
-        jira=factories.jira_context_factory(issue=bug.extract_from_see_also()),
+        jira=jira_context_factory(issue=bug.extract_from_see_also()),
     )
     return context
 
 
 @pytest.fixture
-def context_comment_example() -> ActionContext:
-    user = factories.webhook_user_factory(login="mathieu@mozilla.org")
+def context_comment_example(
+    webhook_user_factory,
+    bug_factory,
+    webhook_event_factory,
+    action_context_factory,
+    jira_context_factory,
+) -> ActionContext:
+    user = webhook_user_factory(login="mathieu@mozilla.org")
     comment = BugzillaWebhookComment.parse_obj({"number": 2, "body": "hello"})
-    bug = factories.bug_factory(
+    bug = bug_factory(
         see_also=["https://mozilla.atlassian.net/browse/JBI-234"],
         comment=comment,
     )
-    event = factories.webhook_event_factory(target="comment", user=user)
-    context = factories.action_context_factory(
+    event = webhook_event_factory(target="comment", user=user)
+    context = action_context_factory(
         operation=Operation.COMMENT,
         bug=bug,
         event=event,
-        jira=factories.jira_context_factory(issue=bug.extract_from_see_also()),
+        jira=jira_context_factory(issue=bug.extract_from_see_also()),
     )
     return context
 
 
 @pytest.fixture
-def context_update_resolution_example() -> ActionContext:
-    bug = factories.bug_factory(
-        see_also=["https://mozilla.atlassian.net/browse/JBI-234"]
-    )
-    event = factories.webhook_event_factory(
+def context_update_resolution_example(
+    bug_factory,
+    webhook_event_factory,
+    webhook_event_change_factory,
+    action_context_factory,
+    jira_context_factory,
+) -> ActionContext:
+    bug = bug_factory(see_also=["https://mozilla.atlassian.net/browse/JBI-234"])
+    event = webhook_event_factory(
         action="modify",
         changes=[
-            factories.webhook_event_change_factory(
+            webhook_event_change_factory(
                 field="resolution", removed="OPEN", added="FIXED"
             ),
         ],
     )
-    context = factories.action_context_factory(
+    context = action_context_factory(
         operation=Operation.UPDATE,
         bug=bug,
         event=event,
-        jira=factories.jira_context_factory(issue=bug.extract_from_see_also()),
+        jira=jira_context_factory(issue=bug.extract_from_see_also()),
     )
     return context
 
 
 @pytest.fixture
-def webhook_create_example() -> BugzillaWebhookRequest:
-    webhook_payload = factories.webhook_factory()
+def webhook_create_example(webhook_factory) -> BugzillaWebhookRequest:
+    webhook_payload = webhook_factory()
 
     return webhook_payload
 
 
 @pytest.fixture
-def webhook_comment_example() -> BugzillaWebhookRequest:
-    user = factories.webhook_user_factory(login="mathieu@mozilla.org")
+def webhook_comment_example(
+    webhook_user_factory, bug_factory, webhook_event_factory, webhook_factory
+) -> BugzillaWebhookRequest:
+    user = webhook_user_factory(login="mathieu@mozilla.org")
     comment = BugzillaWebhookComment.parse_obj({"number": 2, "body": "hello"})
-    bug = factories.bug_factory(
+    bug = bug_factory(
         see_also=["https://mozilla.atlassian.net/browse/JBI-234"],
         comment=comment,
     )
-    event = factories.webhook_event_factory(target="comment", user=user)
-    webhook_payload = factories.webhook_factory(bug=bug, event=event)
+    event = webhook_event_factory(target="comment", user=user)
+    webhook_payload = webhook_factory(bug=bug, event=event)
 
     return webhook_payload
 
 
 @pytest.fixture
-def webhook_private_comment_example() -> BugzillaWebhookRequest:
-    user = factories.webhook_user_factory(login="mathieu@mozilla.org")
-    event = factories.webhook_event_factory(target="comment", user=user)
-    bug = factories.bug_factory(
+def webhook_private_comment_example(
+    webhook_user_factory, webhook_event_factory, bug_factory, webhook_factory
+) -> BugzillaWebhookRequest:
+    user = webhook_user_factory(login="mathieu@mozilla.org")
+    event = webhook_event_factory(target="comment", user=user)
+    bug = bug_factory(
         comment={"id": 344, "number": 2, "is_private": True},
         see_also=["https://mozilla.atlassian.net/browse/JBI-234"],
     )
-    webhook_payload = factories.webhook_factory(bug=bug, event=event)
+    webhook_payload = webhook_factory(bug=bug, event=event)
     return webhook_payload
 
 
 @pytest.fixture
-def webhook_change_status_assignee():
+def webhook_change_status_assignee(
+    webhook_event_change_factory, webhook_event_factory, webhook_factory
+):
     changes = [
-        factories.webhook_event_change_factory(
-            field="status", removed="OPEN", added="FIXED"
-        ),
-        factories.webhook_event_change_factory(
+        webhook_event_change_factory(field="status", removed="OPEN", added="FIXED"),
+        webhook_event_change_factory(
             field="assignee", removed="nobody@mozilla.org", added="mathieu@mozilla.com"
         ),
     ]
-    event = factories.webhook_event_factory(routing_key="bug.modify", changes=changes)
-    webhook_payload = factories.webhook_factory(event=event)
+    event = webhook_event_factory(routing_key="bug.modify", changes=changes)
+    webhook_payload = webhook_factory(event=event)
     return webhook_payload
 
 
 @pytest.fixture
-def action_params_factory():
-    return factories.action_params_factory
-
-
-@pytest.fixture
-def action_factory():
-    return factories.action_factory
-
-
-@pytest.fixture
-def action_example() -> Action:
-    return factories.action_factory()
+def action_example(action_factory) -> Action:
+    return action_factory()
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,13 +12,7 @@ from jbi import Operation
 from jbi.app import app
 from jbi.configuration import get_actions
 from jbi.environment import Settings
-from jbi.models import (
-    Action,
-    ActionContext,
-    Actions,
-    BugzillaWebhookComment,
-    BugzillaWebhookRequest,
-)
+from jbi.models import ActionContext, BugzillaWebhookComment, BugzillaWebhookRequest
 from jbi.services import bugzilla, jira
 from tests.fixtures.factories import *
 
@@ -253,16 +247,6 @@ def webhook_change_status_assignee(
     event = webhook_event_factory(routing_key="bug.modify", changes=changes)
     webhook_payload = webhook_factory(event=event)
     return webhook_payload
-
-
-@pytest.fixture
-def action_example(action_factory) -> Action:
-    return action_factory()
-
-
-@pytest.fixture
-def actions_example(action_example) -> Actions:
-    return Actions.parse_obj([action_example])
 
 
 @pytest.fixture(autouse=True)

--- a/tests/fixtures/factories.py
+++ b/tests/fixtures/factories.py
@@ -38,6 +38,18 @@ def action_factory(action_params_factory):
 
 
 @pytest.fixture
+def actions_factory(action_factory):
+    def _actions_factory(**overrides):
+        actions = {
+            "__root__": [action_factory()],
+            **overrides,
+        }
+        return models.Actions.parse_obj(actions)
+
+    return _actions_factory
+
+
+@pytest.fixture
 def bug_factory():
     def _bug_factory(**overrides):
         bug = {
@@ -199,15 +211,16 @@ def bugzilla_webhook_factory():
 
 
 __all__ = [
-    "action_params_factory",
-    "action_factory",
-    "bug_factory",
-    "webhook_user_factory",
-    "webhook_event_factory",
-    "webhook_event_change_factory",
-    "webhook_factory",
-    "comment_factory",
     "action_context_factory",
-    "jira_context_factory",
+    "action_factory",
+    "action_params_factory",
+    "actions_factory",
+    "bug_factory",
     "bugzilla_webhook_factory",
+    "comment_factory",
+    "jira_context_factory",
+    "webhook_event_change_factory",
+    "webhook_event_factory",
+    "webhook_factory",
+    "webhook_user_factory",
 ]

--- a/tests/fixtures/factories.py
+++ b/tests/fixtures/factories.py
@@ -1,163 +1,213 @@
 from secrets import token_hex
 
-from jbi import Operation
-from jbi.models import (
-    Action,
-    ActionContext,
-    ActionParams,
-    BugzillaBug,
-    BugzillaComment,
-    BugzillaWebhook,
-    BugzillaWebhookEvent,
-    BugzillaWebhookEventChange,
-    BugzillaWebhookRequest,
-    BugzillaWebhookUser,
-    JiraContext,
-)
+import pytest
+
+from jbi import Operation, models
 
 
-def action_params_factory(**overrides):
-    params = {
-        "jira_project_key": "JBI",
-        "jira_components": [],
-        "labels_brackets": "no",
-        "status_map": {},
-        "resolution_map": {},
-        "issue_type_map": {"task": "Task", "defect": "Bug"},
-        **overrides,
-    }
-    return ActionParams.parse_obj(params)
-
-
-def action_factory(**overrides):
-    action = {
-        "whiteboard_tag": "devtest",
-        "bugzilla_user_id": "tbd",
-        "description": "test config",
-        "parameters": action_params_factory(),
-        **overrides,
-    }
-    return Action.parse_obj(action)
-
-
-def bug_factory(**overrides):
-    bug = {
-        "assigned_to": "nobody@mozilla.org",
-        "comment": None,
-        "component": "General",
-        "creator": "nobody@mozilla.org",
-        "flags": [],
-        "id": 654321,
-        "is_private": False,
-        "keywords": [],
-        "priority": "",
-        "product": "JBI",
-        "resolution": "",
-        "see_also": [],
-        "severity": "--",
-        "status": "NEW",
-        "summary": "JBI Test",
-        "type": "defect",
-        "whiteboard": "[devtest]",
-        **overrides,
-    }
-    return BugzillaBug.parse_obj(bug)
-
-
-def webhook_user_factory(**overrides):
-    user = {
-        "id": 123456,
-        "login": "nobody@mozilla.org",
-        "real_name": "Nobody [ :nobody ]",
-        **overrides,
-    }
-    return BugzillaWebhookUser.parse_obj(user)
-
-
-def webhook_event_factory(**overrides):
-    event = {
-        "action": "create",
-        "changes": None,
-        "routing_key": "bug.create",
-        "target": "bug",
-        "time": "2022-03-23T20:10:17.495000+00:00",
-        "user": webhook_user_factory(),
-        **overrides,
-    }
-    return BugzillaWebhookEvent.parse_obj(event)
-
-
-def webhook_event_change_factory(**overrides):
-    event = {
-        "field": "field",
-        "removed": "old value",
-        "added": "new value",
-        **overrides,
-    }
-    return BugzillaWebhookEventChange.parse_obj(event)
-
-
-def webhook_factory(**overrides):
-    webhook_event = {
-        "bug": bug_factory(),
-        "event": webhook_event_factory(),
-        "webhook_id": 34,
-        "webhook_name": "local-test",
-        **overrides,
-    }
-    return BugzillaWebhookRequest.parse_obj(webhook_event)
-
-
-def comment_factory(**overrides):
-    return BugzillaComment.parse_obj(
-        {
-            "id": 343,
-            "text": "comment text",
-            "bug_id": 654321,
-            "count": 1,
-            "is_private": True,
-            "creator": "mathieu@mozilla.org",
+@pytest.fixture
+def action_params_factory():
+    def _action_params_factory(**overrides):
+        params = {
+            "jira_project_key": "JBI",
+            "jira_components": [],
+            "labels_brackets": "no",
+            "status_map": {},
+            "resolution_map": {},
+            "issue_type_map": {"task": "Task", "defect": "Bug"},
             **overrides,
         }
-    )
+        return models.ActionParams.parse_obj(params)
+
+    return _action_params_factory
 
 
-def action_context_factory(**overrides):
-    return ActionContext.parse_obj(
-        {
-            "action": action_factory(),
-            "rid": token_hex(16),
-            "operation": Operation.IGNORE,
+@pytest.fixture
+def action_factory(action_params_factory):
+    def _action_factory(**overrides):
+        action = {
+            "whiteboard_tag": "devtest",
+            "bugzilla_user_id": "tbd",
+            "description": "test config",
+            "parameters": action_params_factory(),
+            **overrides,
+        }
+        return models.Action.parse_obj(action)
+
+    return _action_factory
+
+
+@pytest.fixture
+def bug_factory():
+    def _bug_factory(**overrides):
+        bug = {
+            "assigned_to": "nobody@mozilla.org",
+            "comment": None,
+            "component": "General",
+            "creator": "nobody@mozilla.org",
+            "flags": [],
+            "id": 654321,
+            "is_private": False,
+            "keywords": [],
+            "priority": "",
+            "product": "JBI",
+            "resolution": "",
+            "see_also": [],
+            "severity": "--",
+            "status": "NEW",
+            "summary": "JBI Test",
+            "type": "defect",
+            "whiteboard": "[devtest]",
+            **overrides,
+        }
+        return models.BugzillaBug.parse_obj(bug)
+
+    return _bug_factory
+
+
+@pytest.fixture
+def webhook_user_factory():
+    def _webhook_user_factory(**overrides):
+        user = {
+            "id": 123456,
+            "login": "nobody@mozilla.org",
+            "real_name": "Nobody [ :nobody ]",
+            **overrides,
+        }
+        return models.BugzillaWebhookUser.parse_obj(user)
+
+    return _webhook_user_factory
+
+
+@pytest.fixture
+def webhook_event_factory(webhook_user_factory):
+    def _webhook_event_factory(**overrides):
+        event = {
+            "action": "create",
+            "changes": None,
+            "routing_key": "bug.create",
+            "target": "bug",
+            "time": "2022-03-23T20:10:17.495000+00:00",
+            "user": webhook_user_factory(),
+            **overrides,
+        }
+        return models.BugzillaWebhookEvent.parse_obj(event)
+
+    return _webhook_event_factory
+
+
+@pytest.fixture
+def webhook_event_change_factory():
+    def _webhook_event_change_factory(**overrides):
+        event = {
+            "field": "field",
+            "removed": "old value",
+            "added": "new value",
+            **overrides,
+        }
+        return models.BugzillaWebhookEventChange.parse_obj(event)
+
+    return _webhook_event_change_factory
+
+
+@pytest.fixture
+def webhook_factory(bug_factory, webhook_event_factory):
+    def _webhook_factory(**overrides):
+        webhook_event = {
             "bug": bug_factory(),
             "event": webhook_event_factory(),
-            "jira": jira_context_factory(),
-            **overrides,
-        },
-    )
-
-
-def jira_context_factory(**overrides):
-    return JiraContext.parse_obj(
-        {
-            "project": "JBI",
-            "issue": None,
+            "webhook_id": 34,
+            "webhook_name": "local-test",
             **overrides,
         }
-    )
+        return models.BugzillaWebhookRequest.parse_obj(webhook_event)
+
+    return _webhook_factory
 
 
-def bugzilla_webhook_factory(**overrides):
-    return BugzillaWebhook.parse_obj(
-        {
-            "component": "General",
-            "creator": "admin@mozilla.bugs",
-            "enabled": True,
-            "errors": 0,
-            "event": "create,change,attachment,comment",
-            "id": 1,
-            "name": "Test Webhooks",
-            "product": "Firefox",
-            "url": "http://server.example.com/bugzilla_webhook",
-            **overrides,
-        }
-    )
+@pytest.fixture
+def comment_factory():
+    def _comment_factory(**overrides):
+        return models.BugzillaComment.parse_obj(
+            {
+                "id": 343,
+                "text": "comment text",
+                "bug_id": 654321,
+                "count": 1,
+                "is_private": True,
+                "creator": "mathieu@mozilla.org",
+                **overrides,
+            }
+        )
+
+    return _comment_factory
+
+
+@pytest.fixture
+def action_context_factory(
+    action_factory, bug_factory, webhook_event_factory, jira_context_factory
+):
+    def _action_context_factory(**overrides):
+        return models.ActionContext.parse_obj(
+            {
+                "action": action_factory(),
+                "rid": token_hex(16),
+                "operation": Operation.IGNORE,
+                "bug": bug_factory(),
+                "event": webhook_event_factory(),
+                "jira": jira_context_factory(),
+                **overrides,
+            },
+        )
+
+    return _action_context_factory
+
+
+@pytest.fixture
+def jira_context_factory():
+    def _jira_context_factory(**overrides):
+        return models.JiraContext.parse_obj(
+            {
+                "project": "JBI",
+                "issue": None,
+                **overrides,
+            }
+        )
+
+    return _jira_context_factory
+
+
+@pytest.fixture
+def bugzilla_webhook_factory():
+    def _bugzilla_webhook_factory(**overrides):
+        return models.BugzillaWebhook.parse_obj(
+            {
+                "component": "General",
+                "creator": "admin@mozilla.bugs",
+                "enabled": True,
+                "errors": 0,
+                "event": "create,change,attachment,comment",
+                "id": 1,
+                "name": "Test Webhooks",
+                "product": "Firefox",
+                "url": "http://server.example.com/bugzilla_webhook",
+                **overrides,
+            }
+        )
+
+    return _bugzilla_webhook_factory
+
+
+__all__ = [
+    "action_params_factory",
+    "action_factory",
+    "bug_factory",
+    "webhook_user_factory",
+    "webhook_event_factory",
+    "webhook_event_change_factory",
+    "webhook_factory",
+    "comment_factory",
+    "action_context_factory",
+    "jira_context_factory",
+    "bugzilla_webhook_factory",
+]

--- a/tests/unit/services/test_bugzilla.py
+++ b/tests/unit/services/test_bugzilla.py
@@ -5,7 +5,22 @@ import responses
 from responses import matchers
 
 from jbi.environment import get_settings
+from jbi.models import BugzillaWebhookRequest
 from jbi.services.bugzilla import BugzillaClientError, get_client
+
+
+@pytest.fixture
+def webhook_private_comment_example(
+    webhook_user_factory, webhook_event_factory, bug_factory, webhook_factory
+) -> BugzillaWebhookRequest:
+    user = webhook_user_factory(login="mathieu@mozilla.org")
+    event = webhook_event_factory(target="comment", user=user)
+    bug = bug_factory(
+        comment={"id": 344, "number": 2, "is_private": True},
+        see_also=["https://mozilla.atlassian.net/browse/JBI-234"],
+    )
+    webhook_payload = webhook_factory(bug=bug, event=event)
+    return webhook_payload
 
 
 @pytest.mark.no_mocked_bugzilla

--- a/tests/unit/services/test_jira.py
+++ b/tests/unit/services/test_jira.py
@@ -65,7 +65,7 @@ def test_jira_calls_log_http_errors(mocked_responses, context_create_example, ca
 
 
 def test_jira_retries_failing_connections_in_health_check(
-    mocked_responses, actions_example
+    mocked_responses, actions_factory
 ):
     url = f"{get_settings().jira_base_url}rest/api/2/serverInfo?doHealthCheck=True"
 
@@ -78,7 +78,7 @@ def test_jira_retries_failing_connections_in_health_check(
     )
 
     with pytest.raises(ConnectionError):
-        jira.check_health(actions_example)
+        jira.check_health(actions_factory())
 
     assert len(mocked_responses.calls) == 4
 

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -96,9 +96,9 @@ def test_product_component(product, component, expected, bug_factory):
         "[example][DevTest][example]",
     ],
 )
-def test_lookup_action_found(whiteboard, actions_example, bug_factory):
+def test_lookup_action_found(whiteboard, actions_factory, bug_factory):
     bug = bug_factory(id=1234, whiteboard=whiteboard)
-    action = bug.lookup_action(actions_example)
+    action = bug.lookup_action(actions_factory())
     assert action.whiteboard_tag == "devtest"
     assert "test config" in action.description
 
@@ -125,10 +125,10 @@ def test_lookup_action_found(whiteboard, actions_example, bug_factory):
         "[foo] devtest [bar]",
     ],
 )
-def test_lookup_action_not_found(whiteboard, actions_example, bug_factory):
+def test_lookup_action_not_found(whiteboard, actions_factory, bug_factory):
     bug = bug_factory(id=1234, whiteboard=whiteboard)
     with pytest.raises(ActionNotFoundError) as exc_info:
-        bug.lookup_action(actions_example)
+        bug.lookup_action(actions_factory())
     assert str(exc_info.value) == "devtest"
 
 

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -65,7 +65,7 @@ def test_override_step_configuration_for_single_action_type():
         (["http://mozilla.jira.com/123", "http://mozilla.jira.com/456"], "123"),
     ],
 )
-def test_extract_see_also(see_also, expected):
+def test_extract_see_also(see_also, expected, bug_factory):
     bug = bug_factory(see_also=see_also)
     assert bug.extract_from_see_also() == expected
 
@@ -79,7 +79,7 @@ def test_extract_see_also(see_also, expected):
         ("Product", "General", "Product::General"),
     ],
 )
-def test_product_component(product, component, expected):
+def test_product_component(product, component, expected, bug_factory):
     bug = bug_factory(product=product, component=component)
     assert bug.product_component == expected
 
@@ -96,7 +96,7 @@ def test_product_component(product, component, expected):
         "[example][DevTest][example]",
     ],
 )
-def test_lookup_action_found(whiteboard, actions_example):
+def test_lookup_action_found(whiteboard, actions_example, bug_factory):
     bug = bug_factory(id=1234, whiteboard=whiteboard)
     action = bug.lookup_action(actions_example)
     assert action.whiteboard_tag == "devtest"
@@ -125,7 +125,7 @@ def test_lookup_action_found(whiteboard, actions_example):
         "[foo] devtest [bar]",
     ],
 )
-def test_lookup_action_not_found(whiteboard, actions_example):
+def test_lookup_action_not_found(whiteboard, actions_example, bug_factory):
     bug = bug_factory(id=1234, whiteboard=whiteboard)
     with pytest.raises(ActionNotFoundError) as exc_info:
         bug.lookup_action(actions_example)

--- a/tests/unit/test_router.py
+++ b/tests/unit/test_router.py
@@ -59,7 +59,7 @@ def test_powered_by_jbi_filtered(exclude_middleware, anon_client):
     assert "DevTest" not in html
 
 
-def test_webhooks_details(anon_client, mocked_bugzilla):
+def test_webhooks_details(anon_client, mocked_bugzilla, bugzilla_webhook_factory):
     mocked_bugzilla.list_webhooks.return_value = [
         bugzilla_webhook_factory(),
         bugzilla_webhook_factory(errors=42, enabled=False),
@@ -198,7 +198,9 @@ def test_read_heartbeat_jira_services_fails(anon_client, mocked_jira):
     }
 
 
-def test_read_heartbeat_bugzilla_webhooks_fails(anon_client, mocked_bugzilla):
+def test_read_heartbeat_bugzilla_webhooks_fails(
+    anon_client, mocked_bugzilla, bugzilla_webhook_factory
+):
     mocked_bugzilla.logged_in.return_value = True
     mocked_bugzilla.list_webhooks.return_value = [
         bugzilla_webhook_factory(enabled=False)
@@ -213,7 +215,9 @@ def test_read_heartbeat_bugzilla_webhooks_fails(anon_client, mocked_bugzilla):
     }
 
 
-def test_heartbeat_bugzilla_reports_webhooks_errors(anon_client, mocked_bugzilla):
+def test_heartbeat_bugzilla_reports_webhooks_errors(
+    anon_client, mocked_bugzilla, bugzilla_webhook_factory
+):
     mocked_bugzilla.logged_in.return_value = True
     mocked_bugzilla.list_webhooks.return_value = [
         bugzilla_webhook_factory(id=1, errors=0, product="Remote Settings"),
@@ -244,7 +248,9 @@ def test_read_heartbeat_bugzilla_services_fails(anon_client, mocked_bugzilla):
     }
 
 
-def test_read_heartbeat_success(anon_client, mocked_jira, mocked_bugzilla):
+def test_read_heartbeat_success(
+    anon_client, mocked_jira, mocked_bugzilla, bugzilla_webhook_factory
+):
     """/__heartbeat__ returns 200 when checks succeed."""
     mocked_bugzilla.logged_in.return_value = True
     mocked_bugzilla.list_webhooks.return_value = [bugzilla_webhook_factory()]
@@ -340,7 +346,9 @@ def test_jira_heartbeat_unknown_issue_types(anon_client, mocked_jira):
     assert not resp.json()["jira"]["all_projects_issue_types_exist"]
 
 
-def test_head_heartbeat_success(anon_client, mocked_jira, mocked_bugzilla):
+def test_head_heartbeat_success(
+    anon_client, mocked_jira, mocked_bugzilla, bugzilla_webhook_factory
+):
     """/__heartbeat__ support head requests"""
     mocked_bugzilla.logged_in.return_value = True
     mocked_bugzilla.list_webhooks.return_value = [bugzilla_webhook_factory()]

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -8,8 +8,28 @@ import responses
 from jbi import Operation
 from jbi.environment import get_settings
 from jbi.errors import IgnoreInvalidRequestError
-from jbi.models import ActionContext, Actions, BugzillaWebhookRequest
+from jbi.models import ActionContext, BugzillaWebhookRequest
 from jbi.runner import Executor, execute_action
+
+
+@pytest.fixture
+def webhook_comment_example(
+    webhook_user_factory,
+    bug_factory,
+    webhook_event_factory,
+    webhook_factory,
+    comment_factory,
+) -> BugzillaWebhookRequest:
+    user = webhook_user_factory(login="mathieu@mozilla.org")
+    comment = comment_factory(number=2, body="hello")
+    bug = bug_factory(
+        see_also=["https://mozilla.atlassian.net/browse/JBI-234"],
+        comment=comment,
+    )
+    event = webhook_event_factory(target="comment", user=user)
+    webhook_payload = webhook_factory(bug=bug, event=event)
+
+    return webhook_payload
 
 
 def test_bugzilla_object_is_always_fetched(

--- a/tests/unit/test_steps.py
+++ b/tests/unit/test_steps.py
@@ -10,8 +10,6 @@ from jbi.errors import IncompleteStepError
 from jbi.models import ActionContext, JiraComponents
 from jbi.runner import Executor
 from jbi.services.jira import JiraCreateError
-from tests.conftest import action_params_factory
-from tests.fixtures.factories import comment_factory, webhook_event_change_factory
 
 ALL_STEPS = {
     "new": [
@@ -40,6 +38,7 @@ def test_created_public(
     mocked_jira,
     mocked_bugzilla,
     action_params_factory,
+    comment_factory,
 ):
     mocked_jira.create_issue.return_value = {"key": "k"}
     mocked_bugzilla.get_bug.return_value = context_create_example.bug
@@ -71,6 +70,7 @@ def test_created_with_custom_issue_type_and_fallback(
     mocked_jira,
     mocked_bugzilla,
     action_params_factory,
+    comment_factory,
 ):
     context_create_example.bug.type = "enhancement"
     mocked_jira.create_issue.return_value = {"key": "k"}
@@ -106,6 +106,7 @@ def test_created_with_custom_issue_type(
     mocked_jira,
     mocked_bugzilla,
     action_params_factory,
+    comment_factory,
 ):
     context_create_example.bug.type = "task"
     mocked_jira.create_issue.return_value = {"key": "k"}
@@ -137,7 +138,10 @@ def test_created_with_custom_issue_type(
 
 
 def test_modified_public(
-    context_update_example: ActionContext, mocked_jira, action_params_factory
+    context_update_example: ActionContext,
+    mocked_jira,
+    action_params_factory,
+    webhook_event_change_factory,
 ):
     context_update_example.event.changes = [
         webhook_event_change_factory(field="summary", removed="", added="JBI Test")
@@ -214,6 +218,7 @@ def test_create_with_no_assignee(
     mocked_jira,
     mocked_bugzilla,
     action_params_factory,
+    comment_factory,
 ):
     mocked_bugzilla.get_bug.return_value = context_create_example.bug
     mocked_bugzilla.get_comments.return_value = [
@@ -246,6 +251,7 @@ def test_create_with_assignee(
     mocked_jira,
     mocked_bugzilla,
     action_params_factory,
+    comment_factory,
 ):
     context_create_example.bug.assigned_to = "dtownsend@mozilla.com"
     # Make sure the bug fetched the second time in `create_and_link_issue()` also has the assignee.
@@ -282,7 +288,10 @@ def test_create_with_assignee(
 
 
 def test_clear_assignee(
-    context_update_example: ActionContext, mocked_jira, action_params_factory
+    context_update_example: ActionContext,
+    mocked_jira,
+    action_params_factory,
+    webhook_event_change_factory,
 ):
     context_update_example.event.action = "modify"
     context_update_example.event.changes = [
@@ -304,7 +313,10 @@ def test_clear_assignee(
 
 
 def test_set_assignee(
-    context_update_example: ActionContext, mocked_jira, action_params_factory
+    context_update_example: ActionContext,
+    mocked_jira,
+    action_params_factory,
+    webhook_event_change_factory,
 ):
     context_update_example.bug.assigned_to = "dtownsend@mozilla.com"
     context_update_example.event.action = "modify"
@@ -360,6 +372,7 @@ def test_set_assignee_failing_update(
     mocked_jira,
     capturelogs,
     action_params_factory,
+    webhook_event_change_factory,
 ):
     mocked_jira.user_find_by_user_string.return_value = []
     context_update_example.jira.issue = "key"
@@ -389,6 +402,7 @@ def test_create_with_unknown_status(
     mocked_jira,
     mocked_bugzilla,
     action_params_factory,
+    comment_factory,
 ):
     context_create_example.bug.status = "NEW"
     context_create_example.bug.resolution = ""
@@ -428,6 +442,7 @@ def test_create_with_known_status(
     mocked_jira,
     mocked_bugzilla,
     action_params_factory,
+    comment_factory,
 ):
     context_create_example.bug.status = "ASSIGNED"
     context_create_example.bug.resolution = ""
@@ -494,7 +509,10 @@ def test_change_to_unknown_status(
 
 
 def test_change_to_known_status(
-    context_update_example: ActionContext, mocked_jira, action_params_factory
+    context_update_example: ActionContext,
+    mocked_jira,
+    action_params_factory,
+    webhook_event_change_factory,
 ):
     context_update_example.bug.status = "ASSIGNED"
     context_update_example.bug.resolution = ""
@@ -521,7 +539,10 @@ def test_change_to_known_status(
 
 
 def test_change_to_known_resolution(
-    context_update_example: ActionContext, mocked_jira, action_params_factory
+    context_update_example: ActionContext,
+    mocked_jira,
+    action_params_factory,
+    webhook_event_change_factory,
 ):
     context_update_example.bug.status = "RESOLVED"
     context_update_example.bug.resolution = "FIXED"
@@ -872,7 +893,10 @@ def test_sync_whiteboard_labels_with_brackets(
 
 
 def test_sync_whiteboard_labels_update(
-    context_update_example: ActionContext, mocked_jira, action_params_factory
+    context_update_example: ActionContext,
+    mocked_jira,
+    action_params_factory,
+    webhook_event_change_factory,
 ):
     context_update_example.event.changes = [
         webhook_event_change_factory(


### PR DESCRIPTION
This PR:

- sets up all factories as pytest fixtures
- replaces the direct use of factories in tests with their fixture counterparts
- where possible, uses factories instead of patching built fixtures
For example instead of doing 

```python
foo = foo_example.bar.baz = "override"
```
do

```python
foo = foo_factory(bar=bar_factory(baz="override"))
```

While this is a little more verbose, it makes the data that's being generated more obvious and consistent between different tests.