### PR TITLE
Prefix component with product on FXP and SP3 projects

### DIFF
--- a/config/config.prod.yaml
+++ b/config/config.prod.yaml
@@ -130,6 +130,9 @@
   description: Performance Team
   parameters:
     jira_project_key: FXP
+    jira_components:
+      use_bug_component: false
+      use_bug_component_with_product_prefix: true
     steps:
       new:
         - create_issue

--- a/config/config.prod.yaml
+++ b/config/config.prod.yaml
@@ -267,6 +267,9 @@
   description: Speedometer 3
   parameters:
     jira_project_key: SP3
+    jira_components:
+      use_bug_component: false
+      use_bug_component_with_product_prefix: true
     steps:
       new:
         - create_issue


### PR DESCRIPTION
Both projects have the components field on the create/update screens. This sync is already working, but I'd like to include the product as we have some generic/shared components.