### PR TITLE
Reduce coupling between services and steps modules

### DIFF
--- a/jbi/router.py
+++ b/jbi/router.py
@@ -15,14 +15,14 @@ from jbi.models import Actions, BugzillaWebhookRequest
 from jbi.runner import IgnoreInvalidRequestError, execute_action
 from jbi.services import bugzilla, jira
 
-_settings = Annotated[Settings, Depends(get_settings)]
-_actions = Annotated[Actions, Depends(get_actions)]
-_version = Annotated[dict, Depends(get_version)]
+SettingsDep = Annotated[Settings, Depends(get_settings)]
+ActionsDep = Annotated[Actions, Depends(get_actions)]
+VersionDep = Annotated[dict, Depends(get_version)]
 router = APIRouter()
 
 
 @router.get("/", include_in_schema=False)
-def root(request: Request, settings: _settings):
+def root(request: Request, settings: SettingsDep):
     """Expose key configuration"""
     return {
         "title": request.app.title,
@@ -38,7 +38,7 @@ def root(request: Request, settings: _settings):
 
 @router.get("/__heartbeat__")
 @router.head("/__heartbeat__")
-def heartbeat(response: Response, actions: _actions):
+def heartbeat(response: Response, actions: ActionsDep):
     """Return status of backing services, as required by Dockerflow."""
     health_map = {
         "bugzilla": bugzilla.check_health(),
@@ -60,7 +60,7 @@ def lbheartbeat():
 
 
 @router.get("/__version__")
-def version(version_json: _version):
+def version(version_json: VersionDep):
     """Return version.json, as required by Dockerflow."""
     return version_json
 
@@ -68,7 +68,7 @@ def version(version_json: _version):
 @router.post("/bugzilla_webhook")
 def bugzilla_webhook(
     request: Request,
-    actions: _actions,
+    actions: ActionsDep,
     webhook_request: BugzillaWebhookRequest = Body(..., embed=False),
 ):
     """API endpoint that Bugzilla Webhook Events request"""
@@ -82,7 +82,7 @@ def bugzilla_webhook(
 
 @router.get("/whiteboard_tags/")
 def get_whiteboard_tags(
-    actions: _actions,
+    actions: ActionsDep,
     whiteboard_tag: Optional[str] = None,
 ):
     """API for viewing whiteboard_tags and associated data"""
@@ -111,7 +111,7 @@ templates = Jinja2Templates(directory=SRC_DIR / "templates")
 @router.get("/powered_by_jbi/", response_class=HTMLResponse)
 def powered_by_jbi(
     request: Request,
-    actions: _actions,
+    actions: ActionsDep,
     enabled: Optional[bool] = None,
 ):
     """API for `Powered By` endpoint"""

--- a/jbi/runner.py
+++ b/jbi/runner.py
@@ -178,7 +178,9 @@ def execute_action(
 
         else:
             # Check that issue exists (and is readable)
-            if not jira.get_issue(action_context, action_context.jira.issue):
+            if not jira.get_service().get_issue(
+                action_context, action_context.jira.issue
+            ):
                 raise IgnoreInvalidRequestError(
                     f"ignore unreadable issue {action_context.jira.issue}"
                 )

--- a/jbi/runner.py
+++ b/jbi/runner.py
@@ -141,7 +141,7 @@ def execute_action(
             extra=runner_context.dict(),
         )
         try:
-            bug = bugzilla.get_client().get_bug(
+            bug = bugzilla.get_service().client.get_bug(
                 bug.id
             )  # refresh bug data; this removes webhook specific info--but avoids duplications
             bug.comment = webhook_comment  # inject webhook data back into bug

--- a/jbi/services/bugzilla.py
+++ b/jbi/services/bugzilla.py
@@ -200,6 +200,11 @@ class BugzillaService:
         updated_bug.comment = bug.comment
         return updated_bug
 
+    def list_webhooks(self):
+        """List the currently configured webhooks, including their status."""
+
+        return self.client.list_webhooks()
+
 
 @lru_cache(maxsize=1)
 def get_service():

--- a/jbi/services/bugzilla.py
+++ b/jbi/services/bugzilla.py
@@ -180,6 +180,26 @@ class BugzillaService:
         )
         return self.client.update_bug(bug.id, see_also={"add": [jira_url]})
 
+    def get_description(self, bug_id: int):
+        """Fetch a bug's description
+
+        A Bug's description does not appear in the payload of a bug. Instead, it is "comment 0"
+        """
+
+        comment_list = self.client.get_comments(bug_id)
+        comment_body = comment_list[0].text if comment_list else ""
+        return str(comment_body)
+
+    def refresh_bug_data(self, bug: BugzillaBug):
+        """Re-fetch a bug to ensure we have the most up-to-date data"""
+
+        updated_bug = self.client.get_bug(bug.id)
+        # When bugs come in as webhook payloads, they have a "comment"
+        # attribute, but this field isn't available when we get a bug by ID.
+        # So, we make sure to add the comment back if it was present on the bug.
+        updated_bug.comment = bug.comment
+        return updated_bug
+
 
 @lru_cache(maxsize=1)
 def get_service():

--- a/jbi/services/jira.py
+++ b/jbi/services/jira.py
@@ -57,13 +57,17 @@ instrumented_method = instrument(
 )
 
 
+class JiraCreateError(Exception):
+    """Error raised on Jira issue creation."""
+
+
 class JiraClient(Jira):
     """Adapted Atlassian Jira client that logs errors and wraps methods
     in our instrumentation decorator.
     """
 
     def raise_for_status(self, *args, **kwargs):
-        """Catch and log HTTP errors responses of the Jira client.
+        """Catch and log HTTP errors responses of the Jira self.client.
 
         Without this the actual requests and responses are not exposed when an error
         occurs, which makes troubleshooting tedious.
@@ -95,361 +99,353 @@ class JiraClient(Jira):
     get_project = instrumented_method(Jira.get_project)
 
 
+class JiraService:
+    """Used by action workflows to perform action-specific Jira tasks"""
+
+    def __init__(self, client) -> None:
+        self.client = client
+
+    def fetch_visible_projects(self) -> list[dict]:
+        """Return list of projects that are visible with the configured Jira credentials"""
+
+        projects: list[dict] = self.client.projects(included_archived=None)
+        return projects
+
+    def check_health(self, actions: Actions) -> ServiceHealth:
+        """Check health for Jira Service"""
+
+        server_info = self.client.get_server_info(True)
+        is_up = server_info is not None
+        health: ServiceHealth = {
+            "up": is_up,
+            "all_projects_are_visible": is_up and self._all_projects_visible(actions),
+            "all_projects_have_permissions": self._all_projects_permissions(actions),
+            "all_projects_components_exist": is_up
+            and self._all_projects_components_exist(actions),
+            "all_projects_issue_types_exist": is_up
+            and self._all_project_issue_types_exist(actions),
+        }
+        return health
+
+    def _all_projects_visible(self, actions: Actions) -> bool:
+        visible_projects = {project["key"] for project in self.fetch_visible_projects()}
+        missing_projects = actions.configured_jira_projects_keys - visible_projects
+        if missing_projects:
+            logger.error(
+                "Jira projects %s are not visible with configured credentials",
+                missing_projects,
+            )
+        return not missing_projects
+
+    def _all_projects_permissions(self, actions: Actions):
+        """Fetches and validates that required permissions exist for the configured projects"""
+        all_projects_perms = self._fetch_project_permissions(actions)
+        return self._validate_permissions(all_projects_perms)
+
+    def _fetch_project_permissions(self, actions: Actions):
+        """Fetches permissions for the configured projects"""
+
+        all_projects_perms = {}
+        # Query permissions for all configured projects in parallel threads.
+        with concurrent.futures.ThreadPoolExecutor(max_workers=4) as executor:
+            futures_to_projects = {
+                executor.submit(
+                    self.client.get_permissions,
+                    project_key=project_key,
+                    permissions=",".join(JIRA_REQUIRED_PERMISSIONS),
+                ): project_key
+                for project_key in actions.configured_jira_projects_keys
+            }
+            # Obtain futures' results unordered.
+            for future in concurrent.futures.as_completed(futures_to_projects):
+                project_key = futures_to_projects[future]
+                response = future.result()
+                all_projects_perms[project_key] = response["permissions"]
+        return all_projects_perms
+
+    def _validate_permissions(self, all_projects_perms):
+        """Validates permissions for the configured projects"""
+        misconfigured = []
+        for project_key, obtained_perms in all_projects_perms.items():
+            missing_required_perms = JIRA_REQUIRED_PERMISSIONS - set(
+                obtained_perms.keys()
+            )
+            not_given = set(
+                entry["key"]
+                for entry in obtained_perms.values()
+                if not entry["havePermission"]
+            )
+            if missing_permissions := missing_required_perms.union(not_given):
+                misconfigured.append((project_key, missing_permissions))
+        for project_key, missing in misconfigured:
+            logger.error(
+                "Configured credentials don't have permissions %s on Jira project %s",
+                ",".join(missing),
+                project_key,
+                extra={
+                    "jira": {
+                        "project": project_key,
+                    }
+                },
+            )
+        return not misconfigured
+
+    def _all_projects_components_exist(self, actions: Actions):
+        components_by_project = {
+            action.parameters.jira_project_key: action.parameters.jira_components.set_custom_components
+            for action in actions
+        }
+        success = True
+        for project, specified_components in components_by_project.items():
+            all_project_components = self.client.get_project_components(project)
+            all_components_names = set(comp["name"] for comp in all_project_components)
+            unknown = set(specified_components) - all_components_names
+            if unknown:
+                logger.error(
+                    "Jira project %s does not have components %s",
+                    project,
+                    unknown,
+                )
+                success = False
+
+        return success
+
+    def _all_project_issue_types_exist(self, actions: Actions):
+        issue_types_by_project = {
+            action.parameters.jira_project_key: set(
+                action.parameters.issue_type_map.values()
+            )
+            for action in actions
+        }
+        success = True
+        for project, specified_issue_types in issue_types_by_project.items():
+            response = self.client.get_project(project)
+            all_issue_types_names = set(it["name"] for it in response["issueTypes"])
+            unknown = set(specified_issue_types) - all_issue_types_names
+            if unknown:
+                logger.error(
+                    "Jira project %s does not have issue type %s", project, unknown
+                )
+                success = False
+        return success
+
+    def get_issue(self, context: ActionContext, issue_key):
+        """Return the Jira issue fields or `None` if not found."""
+        try:
+            return self.client.get_issue(issue_key)
+        except requests_exceptions.HTTPError as exc:
+            if exc.response.status_code != 404:
+                raise
+            logger.error(
+                "Could not read issue %s: %s", issue_key, exc, extra=context.dict()
+            )
+            return None
+
+    def create_jira_issue(
+        self, context: ActionContext, description: str, issue_type: str
+    ):
+        """Create a Jira issue with basic fields in the project and return its key."""
+        bug = context.bug
+        logger.debug(
+            "Create new Jira issue for Bug %s",
+            bug.id,
+            extra=context.dict(),
+        )
+        fields: dict[str, Any] = {
+            "summary": bug.summary,
+            "issuetype": {"name": issue_type},
+            "description": description[:JIRA_DESCRIPTION_CHAR_LIMIT],
+            "project": {"key": context.jira.project},
+        }
+
+        jira_response_create = self.client.create_issue(fields=fields)
+
+        # Jira response can be of the form: List or Dictionary
+        if isinstance(jira_response_create, list):
+            # if a list is returned, get the first item
+            jira_response_create = jira_response_create[0]
+
+        if isinstance(jira_response_create, dict):
+            # if a dict is returned or the first item in a list, confirm there are no errors
+            errs = ",".join(jira_response_create.get("errors", []))
+            msgs = ",".join(jira_response_create.get("errorMessages", []))
+            if errs or msgs:
+                raise JiraCreateError(errs + msgs)
+
+        return jira_response_create
+
+    def add_jira_comment(self, context: ActionContext):
+        """Publish a comment on the specified Jira issue"""
+        context = context.update(operation=Operation.COMMENT)
+        commenter = context.event.user.login if context.event.user else "unknown"
+        comment = context.bug.comment
+        assert comment  # See jbi.steps.create_comment()
+
+        issue_key = context.jira.issue
+        formatted_comment = (
+            f"*({commenter})* commented: \n{{quote}}{comment.body}{{quote}}"
+        )
+        jira_response = self.client.issue_add_comment(
+            issue_key=issue_key,
+            comment=formatted_comment,
+        )
+        logger.debug(
+            "User comment added to Jira issue %s",
+            issue_key,
+            extra=context.dict(),
+        )
+        return jira_response
+
+    def add_jira_comments_for_changes(self, context: ActionContext):
+        """Add comments on the specified Jira issue for each change of the event"""
+        bug = context.bug
+        event = context.event
+        issue_key = context.jira.issue
+
+        comments: list = []
+        user = event.user.login if event.user else "unknown"
+        for change in event.changes or []:
+            if change.field in ["status", "resolution"]:
+                comments.append(
+                    {
+                        "modified by": user,
+                        "resolution": bug.resolution,
+                        "status": bug.status,
+                    }
+                )
+            if change.field in ["assigned_to", "assignee"]:
+                comments.append({"assignee": bug.assigned_to})
+
+        jira_response_comments = []
+        for i, comment in enumerate(comments):
+            logger.debug(
+                "Create comment #%s on Jira issue %s",
+                i + 1,
+                issue_key,
+                extra=context.update(operation=Operation.COMMENT).dict(),
+            )
+            jira_response = self.client.issue_add_comment(
+                issue_key=issue_key, comment=json.dumps(comment, indent=4)
+            )
+            jira_response_comments.append(jira_response)
+
+        return jira_response_comments
+
+    def delete_jira_issue_if_duplicate(
+        self, context: ActionContext, latest_bug: BugzillaBug
+    ):
+        """Rollback the Jira issue creation if there is already a linked Jira issue
+        on the Bugzilla ticket"""
+        issue_key = context.jira.issue
+        jira_key_in_bugzilla = latest_bug.extract_from_see_also()
+        _duplicate_creation_event = (
+            jira_key_in_bugzilla is not None and issue_key != jira_key_in_bugzilla
+        )
+        if not _duplicate_creation_event:
+            return None
+
+        logger.warning(
+            "Delete duplicated Jira issue %s from Bug %s",
+            issue_key,
+            context.bug.id,
+            extra=context.update(operation=Operation.DELETE).dict(),
+        )
+        jira_response_delete = self.client.delete_issue(issue_id_or_key=issue_key)
+        return jira_response_delete
+
+    def add_link_to_bugzilla(self, context: ActionContext):
+        """Add link to Bugzilla ticket in Jira issue"""
+        bug = context.bug
+        issue_key = context.jira.issue
+        bugzilla_url = f"{settings.bugzilla_base_url}/show_bug.cgi?id={bug.id}"
+        logger.debug(
+            "Link %r on Jira issue %s",
+            bugzilla_url,
+            issue_key,
+            extra=context.update(operation=Operation.LINK).dict(),
+        )
+        icon_url = f"{settings.bugzilla_base_url}/favicon.ico"
+        return self.client.create_or_update_issue_remote_links(
+            issue_key=issue_key,
+            link_url=bugzilla_url,
+            title=bugzilla_url,
+            icon_url=icon_url,
+            icon_title=icon_url,
+        )
+
+    def clear_assignee(self, context: ActionContext):
+        """Clear the assignee of the specified Jira issue."""
+        issue_key = context.jira.issue
+        logger.debug("Clearing assignee", extra=context.dict())
+        return self.client.update_issue_field(key=issue_key, fields={"assignee": None})
+
+    def find_jira_user(self, context: ActionContext, email: str):
+        """Lookup Jira users, raise an error if not exactly one found."""
+        logger.debug("Find Jira user with email %s", email, extra=context.dict())
+        users = self.client.user_find_by_user_string(query=email)
+        if len(users) != 1:
+            raise ValueError(f"User {email} not found")
+        return users[0]
+
+    def assign_jira_user(self, context: ActionContext, email: str):
+        """Set the assignee of the specified Jira issue, raise if fails."""
+        issue_key = context.jira.issue
+        assert issue_key  # Until we have more fine-grained typing of contexts
+
+        jira_user = self.find_jira_user(context, email)
+        jira_user_id = jira_user["accountId"]
+        try:
+            # There doesn't appear to be an easy way to verify that
+            # this user can be assigned to this issue, so just try
+            # and do it.
+            return self.client.update_issue_field(
+                key=issue_key,
+                fields={"assignee": {"accountId": jira_user_id}},
+            )
+        except (requests_exceptions.HTTPError, IOError) as exc:
+            raise ValueError(
+                f"Could not assign {jira_user_id} to issue {issue_key}"
+            ) from exc
+
+    def update_issue_status(self, context: ActionContext, jira_status: str):
+        """Update the status of the Jira issue"""
+        issue_key = context.jira.issue
+        assert issue_key  # Until we have more fine-grained typing of contexts
+
+        logger.debug(
+            "Updating Jira status to %s",
+            jira_status,
+            extra=context.dict(),
+        )
+        return self.client.set_issue_status(
+            issue_key,
+            jira_status,
+        )
+
+    def update_issue_resolution(self, context: ActionContext, jira_resolution: str):
+        """Update the resolution of the Jira issue."""
+        issue_key = context.jira.issue
+        assert issue_key  # Until we have more fine-grained typing of contexts
+
+        logger.debug(
+            "Updating Jira resolution to %s",
+            jira_resolution,
+            extra=context.dict(),
+        )
+        return self.client.update_issue_field(
+            key=issue_key,
+            fields={"resolution": jira_resolution},
+        )
+
+
 @lru_cache(maxsize=1)
-def get_client():
+def get_service():
     """Get atlassian Jira Service"""
-    return JiraClient(
+    client = JiraClient(
         url=settings.jira_base_url,
         username=settings.jira_username,
         password=settings.jira_api_key,  # package calls this param 'password' but actually expects an api key
         cloud=True,  # we run against an instance of Jira cloud
     )
 
-
-def fetch_visible_projects() -> list[dict]:
-    """Return list of projects that are visible with the configured Jira credentials"""
-    client = get_client()
-    projects: list[dict] = client.projects(included_archived=None)
-    return projects
-
-
-def check_health(actions: Actions) -> ServiceHealth:
-    """Check health for Jira Service"""
-    client = get_client()
-    server_info = client.get_server_info(True)
-    is_up = server_info is not None
-    health: ServiceHealth = {
-        "up": is_up,
-        "all_projects_are_visible": is_up and _all_projects_visible(actions),
-        "all_projects_have_permissions": _all_projects_permissions(actions),
-        "all_projects_components_exist": is_up
-        and _all_projects_components_exist(actions),
-        "all_projects_issue_types_exist": is_up
-        and _all_project_issue_types_exist(actions),
-    }
-    return health
-
-
-def _all_projects_visible(actions: Actions) -> bool:
-    visible_projects = {project["key"] for project in fetch_visible_projects()}
-    missing_projects = actions.configured_jira_projects_keys - visible_projects
-    if missing_projects:
-        logger.error(
-            "Jira projects %s are not visible with configured credentials",
-            missing_projects,
-        )
-    return not missing_projects
-
-
-def _all_projects_permissions(actions: Actions):
-    """Fetches and validates that required permissions exist for the configured projects"""
-    all_projects_perms = _fetch_project_permissions(actions)
-    return _validate_permissions(all_projects_perms)
-
-
-def _fetch_project_permissions(actions: Actions):
-    """Fetches permissions for the configured projects"""
-    client = get_client()
-    all_projects_perms = {}
-    # Query permissions for all configured projects in parallel threads.
-    with concurrent.futures.ThreadPoolExecutor(max_workers=4) as executor:
-        futures_to_projects = {
-            executor.submit(
-                client.get_permissions,
-                project_key=project_key,
-                permissions=",".join(JIRA_REQUIRED_PERMISSIONS),
-            ): project_key
-            for project_key in actions.configured_jira_projects_keys
-        }
-        # Obtain futures' results unordered.
-        for future in concurrent.futures.as_completed(futures_to_projects):
-            project_key = futures_to_projects[future]
-            response = future.result()
-            all_projects_perms[project_key] = response["permissions"]
-    return all_projects_perms
-
-
-def _validate_permissions(all_projects_perms):
-    """Validates permissions for the configured projects"""
-    misconfigured = []
-    for project_key, obtained_perms in all_projects_perms.items():
-        missing_required_perms = JIRA_REQUIRED_PERMISSIONS - set(obtained_perms.keys())
-        not_given = set(
-            entry["key"]
-            for entry in obtained_perms.values()
-            if not entry["havePermission"]
-        )
-        if missing_permissions := missing_required_perms.union(not_given):
-            misconfigured.append((project_key, missing_permissions))
-    for project_key, missing in misconfigured:
-        logger.error(
-            "Configured credentials don't have permissions %s on Jira project %s",
-            ",".join(missing),
-            project_key,
-            extra={
-                "jira": {
-                    "project": project_key,
-                }
-            },
-        )
-    return not misconfigured
-
-
-def _all_projects_components_exist(actions: Actions):
-    components_by_project = {
-        action.parameters.jira_project_key: action.parameters.jira_components.set_custom_components
-        for action in actions
-    }
-    success = True
-    for project, specified_components in components_by_project.items():
-        all_project_components = get_client().get_project_components(project)
-        all_components_names = set(comp["name"] for comp in all_project_components)
-        unknown = set(specified_components) - all_components_names
-        if unknown:
-            logger.error(
-                "Jira project %s does not have components %s",
-                project,
-                unknown,
-            )
-            success = False
-
-    return success
-
-
-def _all_project_issue_types_exist(actions: Actions):
-    issue_types_by_project = {
-        action.parameters.jira_project_key: set(
-            action.parameters.issue_type_map.values()
-        )
-        for action in actions
-    }
-    success = True
-    for project, specified_issue_types in issue_types_by_project.items():
-        response = get_client().get_project(project)
-        all_issue_types_names = set(it["name"] for it in response["issueTypes"])
-        unknown = set(specified_issue_types) - all_issue_types_names
-        if unknown:
-            logger.error(
-                "Jira project %s does not have issue type %s", project, unknown
-            )
-            success = False
-    return success
-
-
-def get_issue(context: ActionContext, issue_key):
-    """Return the Jira issue fields or `None` if not found."""
-    try:
-        return get_client().get_issue(issue_key)
-    except requests_exceptions.HTTPError as exc:
-        if exc.response.status_code != 404:
-            raise
-        logger.error(
-            "Could not read issue %s: %s", issue_key, exc, extra=context.dict()
-        )
-        return None
-
-
-class JiraCreateError(Exception):
-    """Error raised on Jira issue creation."""
-
-
-def create_jira_issue(context: ActionContext, description: str, issue_type: str):
-    """Create a Jira issue with basic fields in the project and return its key."""
-    bug = context.bug
-    logger.debug(
-        "Create new Jira issue for Bug %s",
-        bug.id,
-        extra=context.dict(),
-    )
-    fields: dict[str, Any] = {
-        "summary": bug.summary,
-        "issuetype": {"name": issue_type},
-        "description": description[:JIRA_DESCRIPTION_CHAR_LIMIT],
-        "project": {"key": context.jira.project},
-    }
-
-    client = get_client()
-
-    jira_response_create = client.create_issue(fields=fields)
-
-    # Jira response can be of the form: List or Dictionary
-    if isinstance(jira_response_create, list):
-        # if a list is returned, get the first item
-        jira_response_create = jira_response_create[0]
-
-    if isinstance(jira_response_create, dict):
-        # if a dict is returned or the first item in a list, confirm there are no errors
-        errs = ",".join(jira_response_create.get("errors", []))
-        msgs = ",".join(jira_response_create.get("errorMessages", []))
-        if errs or msgs:
-            raise JiraCreateError(errs + msgs)
-
-    return jira_response_create
-
-
-def add_jira_comment(context: ActionContext):
-    """Publish a comment on the specified Jira issue"""
-    context = context.update(operation=Operation.COMMENT)
-    commenter = context.event.user.login if context.event.user else "unknown"
-    comment = context.bug.comment
-    assert comment  # See jbi.steps.create_comment()
-
-    issue_key = context.jira.issue
-    formatted_comment = f"*({commenter})* commented: \n{{quote}}{comment.body}{{quote}}"
-    jira_response = get_client().issue_add_comment(
-        issue_key=issue_key,
-        comment=formatted_comment,
-    )
-    logger.debug(
-        "User comment added to Jira issue %s",
-        issue_key,
-        extra=context.dict(),
-    )
-    return jira_response
-
-
-def add_jira_comments_for_changes(context: ActionContext):
-    """Add comments on the specified Jira issue for each change of the event"""
-    bug = context.bug
-    event = context.event
-    issue_key = context.jira.issue
-
-    comments: list = []
-    user = event.user.login if event.user else "unknown"
-    for change in event.changes or []:
-        if change.field in ["status", "resolution"]:
-            comments.append(
-                {
-                    "modified by": user,
-                    "resolution": bug.resolution,
-                    "status": bug.status,
-                }
-            )
-        if change.field in ["assigned_to", "assignee"]:
-            comments.append({"assignee": bug.assigned_to})
-
-    jira_response_comments = []
-    for i, comment in enumerate(comments):
-        logger.debug(
-            "Create comment #%s on Jira issue %s",
-            i + 1,
-            issue_key,
-            extra=context.update(operation=Operation.COMMENT).dict(),
-        )
-        jira_response = get_client().issue_add_comment(
-            issue_key=issue_key, comment=json.dumps(comment, indent=4)
-        )
-        jira_response_comments.append(jira_response)
-
-    return jira_response_comments
-
-
-def delete_jira_issue_if_duplicate(context: ActionContext, latest_bug: BugzillaBug):
-    """Rollback the Jira issue creation if there is already a linked Jira issue
-    on the Bugzilla ticket"""
-    issue_key = context.jira.issue
-    jira_key_in_bugzilla = latest_bug.extract_from_see_also()
-    _duplicate_creation_event = (
-        jira_key_in_bugzilla is not None and issue_key != jira_key_in_bugzilla
-    )
-    if not _duplicate_creation_event:
-        return None
-
-    logger.warning(
-        "Delete duplicated Jira issue %s from Bug %s",
-        issue_key,
-        context.bug.id,
-        extra=context.update(operation=Operation.DELETE).dict(),
-    )
-    jira_response_delete = get_client().delete_issue(issue_id_or_key=issue_key)
-    return jira_response_delete
-
-
-def add_link_to_bugzilla(context: ActionContext):
-    """Add link to Bugzilla ticket in Jira issue"""
-    bug = context.bug
-    issue_key = context.jira.issue
-    bugzilla_url = f"{settings.bugzilla_base_url}/show_bug.cgi?id={bug.id}"
-    logger.debug(
-        "Link %r on Jira issue %s",
-        bugzilla_url,
-        issue_key,
-        extra=context.update(operation=Operation.LINK).dict(),
-    )
-    icon_url = f"{settings.bugzilla_base_url}/favicon.ico"
-    return get_client().create_or_update_issue_remote_links(
-        issue_key=issue_key,
-        link_url=bugzilla_url,
-        title=bugzilla_url,
-        icon_url=icon_url,
-        icon_title=icon_url,
-    )
-
-
-def clear_assignee(context: ActionContext):
-    """Clear the assignee of the specified Jira issue."""
-    issue_key = context.jira.issue
-    logger.debug("Clearing assignee", extra=context.dict())
-    return get_client().update_issue_field(key=issue_key, fields={"assignee": None})
-
-
-def find_jira_user(context: ActionContext, email: str):
-    """Lookup Jira users, raise an error if not exactly one found."""
-    logger.debug("Find Jira user with email %s", email, extra=context.dict())
-    users = get_client().user_find_by_user_string(query=email)
-    if len(users) != 1:
-        raise ValueError(f"User {email} not found")
-    return users[0]
-
-
-def assign_jira_user(context: ActionContext, email: str):
-    """Set the assignee of the specified Jira issue, raise if fails."""
-    issue_key = context.jira.issue
-    assert issue_key  # Until we have more fine-grained typing of contexts
-
-    jira_user = find_jira_user(context, email)
-    jira_user_id = jira_user["accountId"]
-    try:
-        # There doesn't appear to be an easy way to verify that
-        # this user can be assigned to this issue, so just try
-        # and do it.
-        return get_client().update_issue_field(
-            key=issue_key,
-            fields={"assignee": {"accountId": jira_user_id}},
-        )
-    except (requests_exceptions.HTTPError, IOError) as exc:
-        raise ValueError(
-            f"Could not assign {jira_user_id} to issue {issue_key}"
-        ) from exc
-
-
-def update_issue_status(context: ActionContext, jira_status: str):
-    """Update the status of the Jira issue"""
-    issue_key = context.jira.issue
-    assert issue_key  # Until we have more fine-grained typing of contexts
-
-    logger.debug(
-        "Updating Jira status to %s",
-        jira_status,
-        extra=context.dict(),
-    )
-    return get_client().set_issue_status(
-        issue_key,
-        jira_status,
-    )
-
-
-def update_issue_resolution(context: ActionContext, jira_resolution: str):
-    """Update the resolution of the Jira issue."""
-    issue_key = context.jira.issue
-    assert issue_key  # Until we have more fine-grained typing of contexts
-
-    logger.debug(
-        "Updating Jira resolution to %s",
-        jira_resolution,
-        extra=context.dict(),
-    )
-    return get_client().update_issue_field(
-        key=issue_key,
-        fields={"resolution": jira_resolution},
-    )
+    return JiraService(client=client)

--- a/jbi/services/jira.py
+++ b/jbi/services/jira.py
@@ -1,7 +1,10 @@
 """Contains a Jira REST client and functions comprised of common operations
 with that REST client
 """
-
+# This import is needed (as of Pyhon 3.11) to enable type checking with modules
+# imported under `TYPE_CHECKING`
+# https://docs.python.org/3/whatsnew/3.7.html#pep-563-postponed-evaluation-of-annotations
+# https://docs.python.org/3/whatsnew/3.11.html#pep-563-may-not-be-the-future
 from __future__ import annotations
 
 import concurrent.futures
@@ -20,6 +23,7 @@ from jbi.models import ActionContext, BugzillaBug
 
 from .common import ServiceHealth, instrument
 
+# https://docs.python.org/3.11/library/typing.html#typing.TYPE_CHECKING
 if TYPE_CHECKING:
     from jbi.models import Actions
 

--- a/jbi/services/jira.py
+++ b/jbi/services/jira.py
@@ -422,6 +422,24 @@ class JiraService:
             jira_status,
         )
 
+    def update_issue_summary(self, context: ActionContext):
+        """Update's an issue's summary with the description of an incoming bug"""
+
+        bug = context.bug
+        issue_key = context.jira.issue
+        logger.debug(
+            "Update summary of Jira issue %s for Bug %s",
+            issue_key,
+            bug.id,
+            extra=context.dict(),
+        )
+        truncated_summary = (bug.summary or "")[:JIRA_DESCRIPTION_CHAR_LIMIT]
+        fields: dict[str, str] = {
+            "summary": truncated_summary,
+        }
+        jira_response = self.client.update_issue_field(key=issue_key, fields=fields)
+        return jira_response
+
     def update_issue_resolution(self, context: ActionContext, jira_resolution: str):
         """Update the resolution of the Jira issue."""
         issue_key = context.jira.issue

--- a/jbi/steps.py
+++ b/jbi/steps.py
@@ -87,25 +87,10 @@ def maybe_delete_duplicate(context: ActionContext, parameters: ActionParams):
 def update_issue_summary(context: ActionContext, parameters: ActionParams):
     """Update the Jira issue's summary if the linked bug is modified."""
 
-    bug = context.bug
-    issue_key = context.jira.issue
-
     if "summary" not in context.event.changed_fields():
         return context
 
-    logger.debug(
-        "Update summary of Jira issue %s for Bug %s",
-        issue_key,
-        bug.id,
-        extra=context.dict(),
-    )
-    truncated_summary = (bug.summary or "")[: jira.JIRA_DESCRIPTION_CHAR_LIMIT]
-    fields: dict[str, str] = {
-        "summary": truncated_summary,
-    }
-    jira_response_update = jira.get_service().client.update_issue_field(
-        key=issue_key, fields=fields
-    )
+    jira_response_update = jira.get_service().update_issue_summary(context)
     context = context.append_responses(jira_response_update)
     return context
 

--- a/jbi/steps.py
+++ b/jbi/steps.py
@@ -3,6 +3,11 @@ Collection of reusable action steps.
 
 Each step takes an `ActionContext` and a list of arbitrary parameters.
 """
+
+# This import is needed (as of Pyhon 3.11) to enable type checking with modules
+# imported under `TYPE_CHECKING`
+# https://docs.python.org/3/whatsnew/3.7.html#pep-563-postponed-evaluation-of-annotations
+# https://docs.python.org/3/whatsnew/3.11.html#pep-563-may-not-be-the-future
 from __future__ import annotations
 
 import logging
@@ -13,6 +18,7 @@ from requests import exceptions as requests_exceptions
 from jbi import Operation
 from jbi.errors import IncompleteStepError
 
+# https://docs.python.org/3.11/library/typing.html#typing.TYPE_CHECKING
 if TYPE_CHECKING:
     from jbi.models import ActionContext, ActionParams
     from jbi.services.bugzilla import BugzillaService

--- a/jbi/steps.py
+++ b/jbi/steps.py
@@ -40,7 +40,7 @@ def create_issue(context: ActionContext, parameters: ActionParams):
 
     # In the payload of a bug creation, the `comment` field is `null`.
     # We fetch the list of comments to use the first one as the Jira issue description.
-    comment_list = bugzilla.get_client().get_comments(bug.id)
+    comment_list = bugzilla.get_service().client.get_comments(bug.id)
     description = comment_list[0].text if comment_list else ""
 
     jira_create_response = jira.create_jira_issue(context, description, issue_type)
@@ -55,7 +55,7 @@ def create_issue(context: ActionContext, parameters: ActionParams):
 
 def add_link_to_jira(context: ActionContext, parameters: ActionParams):
     """Add the URL to the Jira issue in the `see_also` field on the Bugzilla ticket"""
-    bugzilla_response = bugzilla.add_link_to_jira(context)
+    bugzilla_response = bugzilla.get_service().add_link_to_jira(context)
     context = context.append_responses(bugzilla_response)
     return context
 
@@ -73,7 +73,7 @@ def maybe_delete_duplicate(context: ActionContext, parameters: ActionParams):
     re-retrieve it to ensure we have the latest data, and delete any duplicate
     if two Jira issues were created for the same Bugzilla ticket.
     """
-    latest_bug = bugzilla.get_client().get_bug(context.bug.id)
+    latest_bug = bugzilla.get_service().client.get_bug(context.bug.id)
     jira_response_delete = jira.delete_jira_issue_if_duplicate(context, latest_bug)
     if jira_response_delete:
         context = context.append_responses(jira_response_delete)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -76,11 +76,11 @@ def actions():
 def mocked_bugzilla(request):
     if "no_mocked_bugzilla" in request.keywords:
         yield None
-        bugzilla.get_client.cache_clear()
+        bugzilla.get_service.cache_clear()
     else:
         with mock.patch("jbi.services.bugzilla.BugzillaClient") as mocked_bz:
             yield mocked_bz()
-            bugzilla.get_client.cache_clear()
+            bugzilla.get_service.cache_clear()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -87,11 +87,11 @@ def mocked_bugzilla(request):
 def mocked_jira(request):
     if "no_mocked_jira" in request.keywords:
         yield None
-        jira.get_client.cache_clear()
+        jira.get_service.cache_clear()
     else:
         with mock.patch("jbi.services.jira.JiraClient") as mocked_jira:
             yield mocked_jira()
-            jira.get_client.cache_clear()
+            jira.get_service.cache_clear()
 
 
 @pytest.fixture

--- a/tests/unit/services/test_bugzilla.py
+++ b/tests/unit/services/test_bugzilla.py
@@ -6,7 +6,7 @@ from responses import matchers
 
 from jbi.environment import get_settings
 from jbi.models import BugzillaWebhookRequest
-from jbi.services.bugzilla import BugzillaClientError, get_client
+from jbi.services.bugzilla import BugzillaClientError, get_service
 
 
 @pytest.fixture
@@ -25,7 +25,7 @@ def webhook_private_comment_example(
 
 @pytest.mark.no_mocked_bugzilla
 def test_timer_is_used_on_bugzilla_get_comments(mocked_responses, mocked_statsd):
-    bugzilla_client = get_client()
+    bugzilla_client = get_service().client
     mocked_responses.add(
         "GET",
         f"{get_settings().bugzilla_base_url}/rest/bug/42/comment",
@@ -50,7 +50,7 @@ def test_bugzilla_methods_are_retried_if_raising(mocked_responses):
     )
 
     # Not raising
-    get_client().get_comments(42)
+    get_service().client.get_comments(42)
 
     assert len(mocked_responses.calls) == 2
 
@@ -67,7 +67,7 @@ def test_bugzilla_key_is_passed_in_header(mocked_responses):
         ],
     )
 
-    assert get_client().logged_in()
+    assert get_service().client.logged_in()
 
     assert len(mocked_responses.calls) == 1
     # The following assertion is redundant with matchers but also more explicit.
@@ -82,7 +82,7 @@ def test_bugzilla_raises_if_response_has_error(mocked_responses):
     )
 
     with pytest.raises(BugzillaClientError) as exc:
-        get_client().get_bug(42)
+        get_service().client.get_bug(42)
 
     assert "not happy" in str(exc)
 
@@ -93,7 +93,7 @@ def test_bugzilla_get_bug_raises_if_response_has_no_bugs(mocked_responses):
     mocked_responses.add(responses.GET, url, json={"bugs": []})
 
     with pytest.raises(BugzillaClientError) as exc:
-        get_client().get_bug(42)
+        get_service().client.get_bug(42)
 
     assert "Unexpected response" in str(exc)
 
@@ -104,7 +104,7 @@ def test_bugzilla_get_comments_raises_if_response_has_no_bugs(mocked_responses):
     mocked_responses.add(responses.GET, url, json={"bugs": {"42": {}}})
 
     with pytest.raises(BugzillaClientError) as exc:
-        get_client().get_comments(42)
+        get_service().client.get_comments(42)
 
     assert "Unexpected response" in str(exc)
 
@@ -114,7 +114,7 @@ def test_bugzilla_update_bug_uses_a_put(mocked_responses):
     url = f"{get_settings().bugzilla_base_url}/rest/bug/42"
     mocked_responses.add(responses.PUT, url, json={"bugs": [{"id": 42}]})
 
-    get_client().update_bug(42, see_also={"add": ["http://url.com"]})
+    get_service().client.update_bug(42, see_also={"add": ["http://url.com"]})
 
     assert (
         mocked_responses.calls[0].request.body
@@ -166,7 +166,7 @@ def test_bugzilla_get_bug_comment(mocked_responses, webhook_private_comment_exam
         },
     )
 
-    expanded = get_client().get_bug(webhook_private_comment_example.bug.id)
+    expanded = get_service().client.get_bug(webhook_private_comment_example.bug.id)
 
     # then
     assert expanded.comment.creator == "mathieu@mozilla.org"
@@ -196,7 +196,7 @@ def test_bugzilla_missing_private_comment(
         },
     )
 
-    expanded = get_client().get_bug(webhook_private_comment_example.bug.id)
+    expanded = get_service().client.get_bug(webhook_private_comment_example.bug.id)
 
     assert not expanded.comment
 
@@ -224,7 +224,7 @@ def test_bugzilla_list_webhooks(mocked_responses):
         },
     )
 
-    webhooks = get_client().list_webhooks()
+    webhooks = get_service().client.list_webhooks()
 
     assert len(webhooks) == 1
     assert webhooks[0].event == "create,change,comment"
@@ -237,6 +237,6 @@ def test_bugzilla_list_webhooks_raises_if_response_has_no_webhooks(mocked_respon
     mocked_responses.add(responses.GET, url, json={})
 
     with pytest.raises(BugzillaClientError) as exc:
-        get_client().list_webhooks()
+        get_service().client.list_webhooks()
 
     assert "Unexpected response" in str(exc)

--- a/tests/unit/services/test_jira.py
+++ b/tests/unit/services/test_jira.py
@@ -26,8 +26,10 @@ def test_jira_create_issue_is_instrumented(
         },
     )
 
-    jira.create_jira_issue(context_create_example, "Description", issue_type="Task")
-    jira_client = jira.get_client()
+    jira.get_service().create_jira_issue(
+        context_create_example, "Description", issue_type="Task"
+    )
+    jira_client = jira.get_service().client
 
     jira_client.create_issue({})
 
@@ -49,7 +51,7 @@ def test_jira_calls_log_http_errors(mocked_responses, context_create_example, ca
 
     with caplog.at_level(logging.ERROR):
         with pytest.raises(requests.HTTPError):
-            jira.get_client().get_project_components(
+            jira.get_service().client.get_project_components(
                 context_create_example.jira.project
             )
 
@@ -78,7 +80,7 @@ def test_jira_retries_failing_connections_in_health_check(
     )
 
     with pytest.raises(ConnectionError):
-        jira.check_health(actions_factory())
+        jira.get_service().check_health(actions_factory())
 
     assert len(mocked_responses.calls) == 4
 
@@ -93,7 +95,7 @@ def test_jira_does_not_retry_4XX(mocked_responses, context_create_example):
     )
 
     with pytest.raises(requests.HTTPError):
-        jira.create_jira_issue(
+        jira.get_service().create_jira_issue(
             context=context_create_example, description="", issue_type="Task"
         )
 
@@ -132,7 +134,7 @@ def test_all_projects_components_exist(
         }
     )
     actions = Actions(__root__=[action])
-    result = jira._all_projects_components_exist(actions)
+    result = jira.get_service()._all_projects_components_exist(actions)
     assert result is expected_result
 
 
@@ -151,5 +153,5 @@ def test_all_projects_components_exist_no_components_param(
         url,
         json=[],
     )
-    result = jira._all_projects_components_exist(actions)
+    result = jira.get_service()._all_projects_components_exist(actions)
     assert result is True

--- a/tests/unit/test_steps.py
+++ b/tests/unit/test_steps.py
@@ -845,6 +845,7 @@ def test_maybe_update_components(
 ):
     mocked_jira.get_project_components.return_value = project_components
     context_create_example.bug.component = bug_component
+    context_create_example.jira.issue = context_create_example.jira.project + "-123"
 
     callable_object = Executor(
         action_params_factory(
@@ -916,6 +917,7 @@ def test_maybe_update_components_failing(
 def test_sync_whiteboard_labels(
     context_create_example: ActionContext, mocked_jira, action_params_factory
 ):
+    context_create_example.jira.issue = context_create_example.jira.project + "-123"
     callable_object = Executor(
         action_params_factory(
             jira_project_key=context_create_example.jira.project,
@@ -940,6 +942,7 @@ def test_sync_whiteboard_labels(
 def test_sync_whiteboard_labels_with_brackets(
     context_create_example: ActionContext, mocked_jira, action_params_factory
 ):
+    context_create_example.jira.issue = context_create_example.jira.project + "-123"
     callable_object = Executor(
         action_params_factory(
             jira_project_key=context_create_example.jira.project,
@@ -969,6 +972,8 @@ def test_sync_whiteboard_labels_update(
     action_params_factory,
     webhook_event_change_factory,
 ):
+    context_update_example.jira.issue = context_update_example.jira.project + "-123"
+
     context_update_example.event.changes = [
         webhook_event_change_factory(
             field="whiteboard",


### PR DESCRIPTION
This PR was partially motivated by #619. In it, importing the `steps` module into the `models` module to introspect it caused a circular import error.

The simple way to fix that would have been to do a late import. But, that being a code smell, I wondered if there were other ways to solve the problem and make other improvements in the process. This PR represents one attempt. It:

- Slightly refactors and clarifies the purposes of the classes found in the `services` modules. 

  Now, each module has two classes, a `Client` and a `Service`. The client class's only responsibility should be to make, receive, and parse HTTP requests. It then is used by a `Service` to complete "high-level" operations.

  This change helps clarify the responsibilities of each class. It also makes things slightly easier to test, in my opinion. Now, we can rely less on patching and instead pass fake or mock clients to services to make assertions.

- Reduces coupling between the `services` and `steps` modules

  Instead of implicitly depending on the services modules, step functions now take services as arguments. This allows us to not have to import the services directly into the steps module (only for type checking) and again makes testing easier by allowing us to make mocks or fakes as arguments rather than by patching.

- Makes the services FastAPI dependencies for router functions


After this change (in a follow up PR), importing the `steps` module into the `models` module to introspect it causes no errors.


This is a large change for a relatively small goal. If we decide we're okay with one late import, I can close this PR in favor of the "simple" approach.


Also, one problem lurking in the shadows is that as soon as we have to import a model into the `steps` module, we'll run into this problem again. Hopefully it doesn't come to that as long as we can use models only for typing purposes.