### PR TITLE
Remove JB project in prod

### DIFF
--- a/config/config.prod.yaml
+++ b/config/config.prod.yaml
@@ -215,13 +215,6 @@
       UNCONFIRMED: To Do
       NEW: To Do
 
-- whiteboard_tag: prodtest
-  bugzilla_user_id: 644672
-  description: Prod testing whiteboard tag (JBI Bin Project)
-  parameters:
-    jira_project_key: JB
-    labels_brackets: both
-
 - whiteboard_tag: proton
   bugzilla_user_id: tbd
   description: Proton whiteboard tag for Firefox Frontend


### PR DESCRIPTION
Projects without issues are archived. We had this JB project to test things in production, but never really took advantage of it.
Let's remove this and use the stage instance Mozit Test for testing