### PR TITLE
Use `factory-boy` and `pytest-factoryboy` to make object factories and fixtures

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -471,6 +471,38 @@ files = [
 test = ["pytest (>=6)"]
 
 [[package]]
+name = "factory-boy"
+version = "3.3.0"
+description = "A versatile test fixtures replacement based on thoughtbot's factory_bot for Ruby."
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "factory_boy-3.3.0-py2.py3-none-any.whl", hash = "sha256:a2cdbdb63228177aa4f1c52f4b6d83fab2b8623bf602c7dedd7eb83c0f69c04c"},
+    {file = "factory_boy-3.3.0.tar.gz", hash = "sha256:bc76d97d1a65bbd9842a6d722882098eb549ec8ee1081f9fb2e8ff29f0c300f1"},
+]
+
+[package.dependencies]
+Faker = ">=0.7.0"
+
+[package.extras]
+dev = ["Django", "Pillow", "SQLAlchemy", "coverage", "flake8", "isort", "mongoengine", "sqlalchemy-utils", "tox", "wheel (>=0.32.0)", "zest.releaser[recommended]"]
+doc = ["Sphinx", "sphinx-rtd-theme", "sphinxcontrib-spelling"]
+
+[[package]]
+name = "faker"
+version = "19.2.0"
+description = "Faker is a Python package that generates fake data for you."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "Faker-19.2.0-py3-none-any.whl", hash = "sha256:c6c1218482faf79ae1d791bb7124067d12339e0b8f400de855e2c281bcf78c77"},
+    {file = "Faker-19.2.0.tar.gz", hash = "sha256:78840b94843f3aa32a34a220b2b5e8b309e3ffff3a231b0c54e841bb68e0757d"},
+]
+
+[package.dependencies]
+python-dateutil = ">=2.4"
+
+[[package]]
 name = "fastapi"
 version = "0.100.0"
 description = "FastAPI framework, high performance, easy to learn, fast to code, ready for production"
@@ -683,6 +715,17 @@ zipp = ">=0.5"
 docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
 perf = ["ipython"]
 testing = ["flake8 (<5)", "flufl.flake8", "importlib-resources (>=1.3)", "packaging", "pyfakefs", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)", "pytest-perf (>=0.9.2)"]
+
+[[package]]
+name = "inflection"
+version = "0.5.1"
+description = "A port of Ruby on Rails inflector to Python"
+optional = false
+python-versions = ">=3.5"
+files = [
+    {file = "inflection-0.5.1-py2.py3-none-any.whl", hash = "sha256:f38b2b640938a4f35ade69ac3d053042959b62a0f1076a5bbaa1b9526605a8a2"},
+    {file = "inflection-0.5.1.tar.gz", hash = "sha256:1a29730d366e996aaacffb2f1f1cb9593dc38e2ddd30c91250c6dde09ea9b417"},
+]
 
 [[package]]
 name = "iniconfig"
@@ -1216,6 +1259,37 @@ pytest = ">=5.0.0"
 python-dotenv = ">=0.9.1"
 
 [[package]]
+name = "pytest-factoryboy"
+version = "2.5.1"
+description = "Factory Boy support for pytest."
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "pytest_factoryboy-2.5.1-py3-none-any.whl", hash = "sha256:41e3465935322188daefc8720f83cebb16bf3d3a430356dc91151c55f31d99c7"},
+    {file = "pytest_factoryboy-2.5.1.tar.gz", hash = "sha256:7275a52299b20c0f58b63fdf7326b3fd2b7cbefbdaa90fdcfc776bbe92197484"},
+]
+
+[package.dependencies]
+factory_boy = ">=2.10.0"
+inflection = "*"
+pytest = ">=5.0.0"
+typing_extensions = "*"
+
+[[package]]
+name = "python-dateutil"
+version = "2.8.2"
+description = "Extensions to the standard Python datetime module"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
+files = [
+    {file = "python-dateutil-2.8.2.tar.gz", hash = "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"},
+    {file = "python_dateutil-2.8.2-py2.py3-none-any.whl", hash = "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"},
+]
+
+[package.dependencies]
+six = ">=1.5"
+
+[[package]]
 name = "python-dotenv"
 version = "1.0.0"
 description = "Read key-value pairs from a .env file and set them as environment variables"
@@ -1387,8 +1461,7 @@ files = [
     {file = "ruamel.yaml.clib-0.2.7-cp310-cp310-win32.whl", hash = "sha256:763d65baa3b952479c4e972669f679fe490eee058d5aa85da483ebae2009d231"},
     {file = "ruamel.yaml.clib-0.2.7-cp310-cp310-win_amd64.whl", hash = "sha256:d000f258cf42fec2b1bbf2863c61d7b8918d31ffee905da62dede869254d3b8a"},
     {file = "ruamel.yaml.clib-0.2.7-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:045e0626baf1c52e5527bd5db361bc83180faaba2ff586e763d3d5982a876a9e"},
-    {file = "ruamel.yaml.clib-0.2.7-cp311-cp311-macosx_13_0_arm64.whl", hash = "sha256:1a6391a7cabb7641c32517539ca42cf84b87b667bad38b78d4d42dd23e957c81"},
-    {file = "ruamel.yaml.clib-0.2.7-cp311-cp311-manylinux2014_aarch64.whl", hash = "sha256:9c7617df90c1365638916b98cdd9be833d31d337dbcd722485597b43c4a215bf"},
+    {file = "ruamel.yaml.clib-0.2.7-cp311-cp311-macosx_12_6_arm64.whl", hash = "sha256:721bc4ba4525f53f6a611ec0967bdcee61b31df5a56801281027a3a6d1c2daf5"},
     {file = "ruamel.yaml.clib-0.2.7-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:41d0f1fa4c6830176eef5b276af04c89320ea616655d01327d5ce65e50575c94"},
     {file = "ruamel.yaml.clib-0.2.7-cp311-cp311-win32.whl", hash = "sha256:f6d3d39611ac2e4f62c3128a9eed45f19a6608670c5a2f4f07f24e8de3441d38"},
     {file = "ruamel.yaml.clib-0.2.7-cp311-cp311-win_amd64.whl", hash = "sha256:da538167284de58a52109a9b89b8f6a53ff8437dd6dc26d33b57bf6699153122"},
@@ -1957,4 +2030,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10 <3.12"
-content-hash = "429bd118d24231fde18d3e236fa6d9c59c9bc6a071c6c371a4182ac4bcef4f65"
+content-hash = "46138b412a2ef76ccbb7dcaf319f3ef157f63abe2486369e8f64378f05562c93"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,8 @@ pytest-dotenv = "^0.5.2"
 types-requests = "^2.31.0"
 responses = "^0.23.2"
 httpx = "^0.24.1"
+factory-boy = "^3.3.0"
+pytest-factoryboy = "^2.5.1"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ from unittest import mock
 import pytest
 import responses
 from fastapi.testclient import TestClient
+from pytest_factoryboy import register
 
 from jbi import Operation
 from jbi.app import app
@@ -52,6 +53,20 @@ def capturelogs(request):
 def mocked_statsd():
     with mock.patch("jbi.services.common.statsd") as _mocked_statsd:
         yield _mocked_statsd
+
+
+register(ActionContextFactory)
+register(ActionFactory)
+register(ActionsFactory)
+register(ActionParamsFactory)
+register(BugFactory)
+register(BugzillaWebhookFactory)
+register(CommentFactory)
+register(JiraContextFactory)
+register(WebhookFactory)
+register(WebhookEventChangeFactory)
+register(WebhookEventFactory)
+register(WebhookUserFactory)
 
 
 @pytest.fixture

--- a/tests/fixtures/factories.py
+++ b/tests/fixtures/factories.py
@@ -1,226 +1,181 @@
 from secrets import token_hex
 
-import pytest
+import factory
 
 from jbi import Operation, models
 
 
-@pytest.fixture
-def action_params_factory():
-    def _action_params_factory(**overrides):
-        params = {
-            "jira_project_key": "JBI",
-            "jira_components": [],
-            "labels_brackets": "no",
-            "status_map": {},
-            "resolution_map": {},
-            "issue_type_map": {"task": "Task", "defect": "Bug"},
-            **overrides,
-        }
-        return models.ActionParams.parse_obj(params)
+class ActionParamsFactory(factory.Factory):
+    class Meta:
+        model = models.ActionParams
 
-    return _action_params_factory
+    jira_project_key = "JBI"
+    jira_components = []
+    labels_brackets = "no"
+    status_map = {}
+    resolution_map = {}
+    issue_type_map = {"task": "Task", "defect": "Bug"}
 
 
-@pytest.fixture
-def action_factory(action_params_factory):
-    def _action_factory(**overrides):
-        action = {
-            "whiteboard_tag": "devtest",
-            "bugzilla_user_id": "tbd",
-            "description": "test config",
-            "parameters": action_params_factory(),
-            **overrides,
-        }
-        return models.Action.parse_obj(action)
+class ActionFactory(factory.Factory):
+    class Meta:
+        model = models.Action
 
-    return _action_factory
+    whiteboard_tag = "devtest"
+    bugzilla_user_id = "tbd"
+    description = "test config"
+    parameters = factory.SubFactory(ActionParamsFactory)
 
 
-@pytest.fixture
-def actions_factory(action_factory):
-    def _actions_factory(**overrides):
-        actions = {
-            "__root__": [action_factory()],
-            **overrides,
-        }
-        return models.Actions.parse_obj(actions)
+class ActionsFactory(factory.Factory):
+    class Meta:
+        model = models.Actions
 
-    return _actions_factory
+    actions = factory.List([factory.SubFactory(ActionFactory)])
 
-
-@pytest.fixture
-def bug_factory():
-    def _bug_factory(**overrides):
-        bug = {
-            "assigned_to": "nobody@mozilla.org",
-            "comment": None,
-            "component": "General",
-            "creator": "nobody@mozilla.org",
-            "flags": [],
-            "id": 654321,
-            "is_private": False,
-            "keywords": [],
-            "priority": "",
-            "product": "JBI",
-            "resolution": "",
-            "see_also": [],
-            "severity": "--",
-            "status": "NEW",
-            "summary": "JBI Test",
-            "type": "defect",
-            "whiteboard": "[devtest]",
-            **overrides,
-        }
-        return models.BugzillaBug.parse_obj(bug)
-
-    return _bug_factory
+    @classmethod
+    def _create(cls, model_class, *args, **kwargs):
+        return model_class(__root__=kwargs["actions"])
 
 
-@pytest.fixture
-def webhook_user_factory():
-    def _webhook_user_factory(**overrides):
-        user = {
-            "id": 123456,
-            "login": "nobody@mozilla.org",
-            "real_name": "Nobody [ :nobody ]",
-            **overrides,
-        }
-        return models.BugzillaWebhookUser.parse_obj(user)
+class BugzillaWebhookCommentFactory(factory.Factory):
+    class Meta:
+        model = models.BugzillaWebhookComment
 
-    return _webhook_user_factory
+    body = None
+    id = None
+    number = None
+    is_private = None
+    creation_time = None
 
 
-@pytest.fixture
-def webhook_event_factory(webhook_user_factory):
-    def _webhook_event_factory(**overrides):
-        event = {
-            "action": "create",
-            "changes": None,
-            "routing_key": "bug.create",
-            "target": "bug",
-            "time": "2022-03-23T20:10:17.495000+00:00",
-            "user": webhook_user_factory(),
-            **overrides,
-        }
-        return models.BugzillaWebhookEvent.parse_obj(event)
+class BugFactory(factory.Factory):
+    class Meta:
+        model = models.BugzillaBug
 
-    return _webhook_event_factory
-
-
-@pytest.fixture
-def webhook_event_change_factory():
-    def _webhook_event_change_factory(**overrides):
-        event = {
-            "field": "field",
-            "removed": "old value",
-            "added": "new value",
-            **overrides,
-        }
-        return models.BugzillaWebhookEventChange.parse_obj(event)
-
-    return _webhook_event_change_factory
-
-
-@pytest.fixture
-def webhook_factory(bug_factory, webhook_event_factory):
-    def _webhook_factory(**overrides):
-        webhook_event = {
-            "bug": bug_factory(),
-            "event": webhook_event_factory(),
-            "webhook_id": 34,
-            "webhook_name": "local-test",
-            **overrides,
-        }
-        return models.BugzillaWebhookRequest.parse_obj(webhook_event)
-
-    return _webhook_factory
-
-
-@pytest.fixture
-def comment_factory():
-    def _comment_factory(**overrides):
-        return models.BugzillaComment.parse_obj(
-            {
-                "id": 343,
-                "text": "comment text",
-                "bug_id": 654321,
-                "count": 1,
-                "is_private": True,
-                "creator": "mathieu@mozilla.org",
-                **overrides,
-            }
+    class Params:
+        with_comment = factory.Trait(
+            comment=factory.SubFactory(BugzillaWebhookCommentFactory)
         )
 
-    return _comment_factory
+    assigned_to = "nobody@mozilla.org"
+    comment = None
+    component = "General"
+    creator = "nobody@mozilla.org"
+    flags = []
+    id = 654321
+    is_private = False
+    keywords = []
+    priority = ""
+    product = "JBI"
+    resolution = ""
+    see_also = []
+    severity = "--"
+    status = "NEW"
+    summary = "JBI Test"
+    type = "defect"
+    whiteboard = "[devtest]"
 
 
-@pytest.fixture
-def action_context_factory(
-    action_factory, bug_factory, webhook_event_factory, jira_context_factory
-):
-    def _action_context_factory(**overrides):
-        return models.ActionContext.parse_obj(
-            {
-                "action": action_factory(),
-                "rid": token_hex(16),
-                "operation": Operation.IGNORE,
-                "bug": bug_factory(),
-                "event": webhook_event_factory(),
-                "jira": jira_context_factory(),
-                **overrides,
-            },
-        )
+class WebhookUserFactory(factory.Factory):
+    class Meta:
+        model = models.BugzillaWebhookUser
 
-    return _action_context_factory
+    id = 123456
+    login = "nobody@mozilla.org"
+    real_name = "Nobody [ :nobody ]"
 
 
-@pytest.fixture
-def jira_context_factory():
-    def _jira_context_factory(**overrides):
-        return models.JiraContext.parse_obj(
-            {
-                "project": "JBI",
-                "issue": None,
-                **overrides,
-            }
-        )
+class WebhookEventChangeFactory(factory.Factory):
+    class Meta:
+        model = models.BugzillaWebhookEventChange
 
-    return _jira_context_factory
+    field = "field"
+    removed = "old value"
+    added = "new value"
 
 
-@pytest.fixture
-def bugzilla_webhook_factory():
-    def _bugzilla_webhook_factory(**overrides):
-        return models.BugzillaWebhook.parse_obj(
-            {
-                "component": "General",
-                "creator": "admin@mozilla.bugs",
-                "enabled": True,
-                "errors": 0,
-                "event": "create,change,attachment,comment",
-                "id": 1,
-                "name": "Test Webhooks",
-                "product": "Firefox",
-                "url": "http://server.example.com/bugzilla_webhook",
-                **overrides,
-            }
-        )
+class WebhookEventFactory(factory.Factory):
+    class Meta:
+        model = models.BugzillaWebhookEvent
 
-    return _bugzilla_webhook_factory
+    action = "create"
+    changes = None
+    routing_key = "bug.create"
+    target = "bug"
+    time = "2022-03-23T20:10:17.495000+00:00"
+    user = factory.SubFactory(WebhookUserFactory)
+
+
+class WebhookFactory(factory.Factory):
+    class Meta:
+        model = models.BugzillaWebhookRequest
+
+    bug = factory.SubFactory(BugFactory)
+    event = factory.SubFactory(WebhookEventFactory)
+    webhook_id = 34
+    webhook_name = "local-test"
+
+
+class CommentFactory(factory.Factory):
+    class Meta:
+        model = models.BugzillaComment
+
+    id = 343
+    text = "comment text"
+    bug_id = 654321
+    count = 1
+    is_private = True
+    creator = "mathieu@mozilla.org"
+
+
+class JiraContextFactory(factory.Factory):
+    class Meta:
+        model = models.JiraContext
+
+    project = "JBI"
+    issue = None
+    labels = []
+
+
+class ActionContextFactory(factory.Factory):
+    class Meta:
+        model = models.ActionContext
+
+    action = factory.SubFactory(ActionFactory)
+    rid = factory.LazyFunction(lambda: token_hex(16))
+    operation = Operation.IGNORE
+    bug = factory.SubFactory(BugFactory)
+    event = factory.SubFactory(WebhookEventFactory)
+    jira = factory.SubFactory(JiraContextFactory)
+
+
+class BugzillaWebhookFactory(factory.Factory):
+    class Meta:
+        model = models.BugzillaWebhook
+
+    component = "General"
+    creator = "admin@mozilla.bugs"
+    enabled = True
+    errors = 0
+    event = "create,change,attachment,comment"
+    id = 1
+    name = "Test Webhooks"
+    product = "Firefox"
+    url = "http://server.example.com/bugzilla_webhook"
 
 
 __all__ = [
-    "action_context_factory",
-    "action_factory",
-    "action_params_factory",
-    "actions_factory",
-    "bug_factory",
-    "bugzilla_webhook_factory",
-    "comment_factory",
-    "jira_context_factory",
-    "webhook_event_change_factory",
-    "webhook_event_factory",
-    "webhook_factory",
-    "webhook_user_factory",
+    "ActionContextFactory",
+    "ActionFactory",
+    "ActionParamsFactory",
+    "ActionsFactory",
+    "BugFactory",
+    "BugzillaWebhookFactory",
+    "CommentFactory",
+    "JiraContextFactory",
+    "WebhookEventChangeFactory",
+    "WebhookEventFactory",
+    "WebhookFactory",
+    "WebhookUserFactory",
 ]

--- a/tests/unit/test_router.py
+++ b/tests/unit/test_router.py
@@ -7,8 +7,7 @@ from fastapi.testclient import TestClient
 
 from jbi.app import app
 from jbi.environment import get_settings
-from jbi.models import BugzillaWebhook, BugzillaWebhookRequest
-from tests.fixtures.factories import bugzilla_webhook_factory
+from jbi.models import BugzillaWebhookRequest
 
 
 def test_read_root(anon_client):

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -13,23 +13,14 @@ from jbi.runner import Executor, execute_action
 
 
 @pytest.fixture
-def webhook_comment_example(
-    webhook_user_factory,
-    bug_factory,
-    webhook_event_factory,
-    webhook_factory,
-    comment_factory,
-) -> BugzillaWebhookRequest:
-    user = webhook_user_factory(login="mathieu@mozilla.org")
-    comment = comment_factory(number=2, body="hello")
-    bug = bug_factory(
-        see_also=["https://mozilla.atlassian.net/browse/JBI-234"],
-        comment=comment,
+def webhook_comment_example(webhook_factory) -> BugzillaWebhookRequest:
+    return webhook_factory(
+        bug__see_also=["https://mozilla.atlassian.net/browse/JBI-234"],
+        bug__comment__number=2,
+        bug__comment__body="hello",
+        event__target="comment",
+        event__user__login="mathieu@mozilla.org",
     )
-    event = webhook_event_factory(target="comment", user=user)
-    webhook_payload = webhook_factory(bug=bug, event=event)
-
-    return webhook_payload
 
 
 def test_bugzilla_object_is_always_fetched(

--- a/tests/unit/test_steps.py
+++ b/tests/unit/test_steps.py
@@ -34,42 +34,29 @@ ALL_STEPS = {
 
 
 @pytest.fixture
-def context_update_example(
-    action_context_factory, bug_factory, jira_context_factory
-) -> ActionContext:
-    bug = bug_factory(see_also=["https://mozilla.atlassian.net/browse/JBI-234"])
-    context = action_context_factory(
+def context_update_example(action_context_factory) -> ActionContext:
+    return action_context_factory(
         operation=Operation.UPDATE,
-        bug=bug,
-        jira=jira_context_factory(issue=bug.extract_from_see_also()),
+        bug__see_also=["https://mozilla.atlassian.net/browse/JBI-234"],
+        jira__issue="JBI-234",
     )
-    return context
 
 
 @pytest.fixture
 def context_update_resolution_example(
-    bug_factory,
-    webhook_event_factory,
-    webhook_event_change_factory,
-    action_context_factory,
-    jira_context_factory,
+    webhook_event_change_factory, action_context_factory
 ) -> ActionContext:
-    bug = bug_factory(see_also=["https://mozilla.atlassian.net/browse/JBI-234"])
-    event = webhook_event_factory(
-        action="modify",
-        changes=[
+    return action_context_factory(
+        operation=Operation.UPDATE,
+        bug__see_also=["https://mozilla.atlassian.net/browse/JBI-234"],
+        event__action="modify",
+        event__changes=[
             webhook_event_change_factory(
                 field="resolution", removed="OPEN", added="FIXED"
-            ),
+            )
         ],
+        jira__issue="JBI-234",
     )
-    context = action_context_factory(
-        operation=Operation.UPDATE,
-        bug=bug,
-        event=event,
-        jira=jira_context_factory(issue=bug.extract_from_see_also()),
-    )
-    return context
 
 
 def test_created_public(


### PR DESCRIPTION
Factoryboy is a slight improvement over our DIY factory setup because it makes it easier to set "deep" attributes of objects.

Before
```python
@pytest.fixture
def context_comment_example(
    webhook_user_factory,
    bug_factory,
    webhook_event_factory,
    action_context_factory,
    jira_context_factory,
) -> ActionContext:
    user = webhook_user_factory(login="mathieu@mozilla.org")
    comment = BugzillaWebhookComment.parse_obj({"number": 2, "body": "hello"})
    bug = bug_factory(
        see_also=["https://mozilla.atlassian.net/browse/JBI-234"],
        comment=comment,
    )
    event = webhook_event_factory(target="comment", user=user)
    context = action_context_factory(
        operation=Operation.COMMENT,
        bug=bug,
        event=event,
        jira=jira_context_factory(issue=bug.extract_from_see_also()),
    )
    return context

```
After
```python
@pytest.fixture
def context_comment_example(action_context_factory) -> ActionContext:
    return action_context_factory(
        operation=Operation.COMMENT,
        bug__see_also=["https://mozilla.atlassian.net/browse/JBI-234"],
        bug__with_comment=True,
        bug__comment__number=2,
        bug__comment__body="hello",
        event__target="comment",
        event__user__login="mathieu@mozilla.org",
        jira__issue="JBI-234",
    )
```

My hope is that this more ergonomic API will encourage using factories directly more often, rather than creating many one-off fixtures with slightly different attributes.
