### PR TITLE
Log `IgnoreInvalidRequestError`s as INFO messages

### DIFF
--- a/jbi/runner.py
+++ b/jbi/runner.py
@@ -256,7 +256,7 @@ def execute_action(
         statsd.incr("jbi.bugzilla.processed.count")
         return details
     except IgnoreInvalidRequestError as exception:
-        logger.debug(
+        logger.info(
             "Ignore incoming request: %s",
             exception,
             extra=runner_context.update(operation=Operation.IGNORE).dict(),


### PR DESCRIPTION
Knowing why JBI ignored a particular webhook request helps us answer the question "why didn't my bug sync?", so it seems `INFO` worthy.