### PR TITLE
Add resolution map for FXP, PCF, and SP3

### DIFF
--- a/config/config.prod.yaml
+++ b/config/config.prod.yaml
@@ -390,6 +390,15 @@
       WORKSFORME: Done
       INCOMPLETE: Done
       MOVED: Done
+    resolution_map:
+      FIXED: Done
+      INVALID: Invalid
+      WONTFIX: "Won't Do"
+      INACTIVE: Inactive
+      DUPLICATE: Duplicate
+      WORKSFORME: "Cannot Reproduce"
+      INCOMPLETE: Incomplete
+      MOVED: Moved
 
 - whiteboard_tag: dataplatform
   bugzilla_user_id: tbd

--- a/config/config.prod.yaml
+++ b/config/config.prod.yaml
@@ -173,7 +173,15 @@
       WORKSFORME: Done
       INCOMPLETE: Done
       MOVED: Done
-
+    resolution_map:
+      FIXED: Done
+      INVALID: Invalid
+      WONTFIX: "Won't Do"
+      INACTIVE: Inactive
+      DUPLICATE: Duplicate
+      WORKSFORME: "Cannot Reproduce"
+      INCOMPLETE: Incomplete
+      MOVED: Moved
 - whiteboard_tag: fxsync
   bugzilla_user_id: 624105
   description: Firefox Sync Team whiteboard tag

--- a/config/config.prod.yaml
+++ b/config/config.prod.yaml
@@ -292,6 +292,15 @@
       WORKSFORME: Done
       INCOMPLETE: Done
       MOVED: Done
+    resolution_map:
+      FIXED: Done
+      INVALID: Invalid
+      WONTFIX: "Won't Do"
+      INACTIVE: Inactive
+      DUPLICATE: Duplicate
+      WORKSFORME: "Cannot Reproduce"
+      INCOMPLETE: Incomplete
+      MOVED: Moved
 
 - whiteboard_tag: proton
   bugzilla_user_id: tbd


### PR DESCRIPTION
When I originally tried to include a resolution map there seemed to be some issues, which led to it being removed. I think it was related to #334 but it's not clear to me now so I thought I'd try again. If it's still not working as documented, maybe we can try to work through the issues? In preparation for this change I have made sure that the resolution field is present for all of the projects, and that all resolution values mentioned in this patch are available in Jira.