### PR TITLE
Add labeler action

### DIFF
--- a/.github/workflows/labeler..yaml
+++ b/.github/workflows/labeler..yaml
@@ -1,0 +1,12 @@
+name: "Pull Request Labeler"
+on:
+  - pull_request_target
+
+jobs:
+  triage:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v4


### PR DESCRIPTION
When we closed https://github.com/mozilla/jira-bugzilla-integration/pull/624, we didn't actually add a workflow to call the [actions/labeler](https://github.com/actions/labeler) action 🤦🏻 

https://github.com/actions/labeler#create-workflow