### PR TITLE
Revert "Add resolution map for FXP, PCF, and SP3 (#735)"

### DIFF
--- a/config/config.prod.yaml
+++ b/config/config.prod.yaml
@@ -173,15 +173,7 @@
       WORKSFORME: Done
       INCOMPLETE: Done
       MOVED: Done
-    resolution_map:
-      FIXED: Done
-      INVALID: Invalid
-      WONTFIX: "Won't Do"
-      INACTIVE: Inactive
-      DUPLICATE: Duplicate
-      WORKSFORME: "Cannot Reproduce"
-      INCOMPLETE: Incomplete
-      MOVED: Moved
+
 - whiteboard_tag: fxsync
   bugzilla_user_id: 624105
   description: Firefox Sync Team whiteboard tag
@@ -299,15 +291,6 @@
       WORKSFORME: Done
       INCOMPLETE: Done
       MOVED: Done
-    resolution_map:
-      FIXED: Done
-      INVALID: Invalid
-      WONTFIX: "Won't Do"
-      INACTIVE: Inactive
-      DUPLICATE: Duplicate
-      WORKSFORME: "Cannot Reproduce"
-      INCOMPLETE: Incomplete
-      MOVED: Moved
 
 - whiteboard_tag: proton
   bugzilla_user_id: tbd
@@ -397,15 +380,6 @@
       WORKSFORME: Done
       INCOMPLETE: Done
       MOVED: Done
-    resolution_map:
-      FIXED: Done
-      INVALID: Invalid
-      WONTFIX: "Won't Do"
-      INACTIVE: Inactive
-      DUPLICATE: Duplicate
-      WORKSFORME: "Cannot Reproduce"
-      INCOMPLETE: Incomplete
-      MOVED: Moved
 
 - whiteboard_tag: dataplatform
   bugzilla_user_id: tbd


### PR DESCRIPTION
This reverts commit 6534c8a1f15760402b265676f7e9b78f11c87048.


https://mozilla.sentry.io/issues/4605706692/?referrer=slack&notification_uuid=64937fea-2bab-43ff-b039-80f992424ffb&alert_rule_id=11827252&alert_type=issue