### PR TITLE
Add `rid` to logs with `asgi-correlation-id`

### DIFF
--- a/asgi.py
+++ b/asgi.py
@@ -13,7 +13,7 @@ if __name__ == "__main__":
             host=settings.host,
             port=settings.port,
             reload=settings.app_reload,
-            log_config=LOGGING_CONFIG,
+            log_config=None,
         )
     )
     server.run()

--- a/jbi/app.py
+++ b/jbi/app.py
@@ -13,13 +13,15 @@ from fastapi import FastAPI, Request, Response
 from fastapi.staticfiles import StaticFiles
 
 from jbi.environment import get_settings, get_version
-from jbi.log import format_request_summary_fields
+from jbi.log import CONFIG, format_request_summary_fields
 from jbi.router import router
 
 SRC_DIR = Path(__file__).parent
 
 settings = get_settings()
 version_info = get_version()
+
+logging.config.dictConfig(CONFIG)
 
 
 def traces_sampler(sampling_context: dict[str, Any]) -> float:

--- a/jbi/app.py
+++ b/jbi/app.py
@@ -8,6 +8,7 @@ from secrets import token_hex
 from typing import Any, Awaitable, Callable
 
 import sentry_sdk
+from asgi_correlation_id import CorrelationIdMiddleware
 from fastapi import FastAPI, Request, Response
 from fastapi.staticfiles import StaticFiles
 
@@ -69,3 +70,11 @@ async def request_summary(
         )
         summary_logger.info(exc, extra=log_fields)
         raise
+
+
+app.add_middleware(
+    CorrelationIdMiddleware,
+    header_name="X-Request-Id",
+    generator=lambda: token_hex(16),
+    validator=None,
+)

--- a/jbi/app.py
+++ b/jbi/app.py
@@ -50,16 +50,6 @@ app.mount("/static", StaticFiles(directory=SRC_DIR / "static"), name="static")
 
 
 @app.middleware("http")
-async def request_id(
-    request: Request, call_next: Callable[[Request], Awaitable[Response]]
-) -> Response:
-    """Read the request id from headers. This is set by NGinx."""
-    request.state.rid = request.headers.get("X-Request-Id", token_hex(16))
-    response = await call_next(request)
-    return response
-
-
-@app.middleware("http")
 async def request_summary(
     request: Request, call_next: Callable[[Request], Awaitable[Response]]
 ) -> Response:

--- a/jbi/log.py
+++ b/jbi/log.py
@@ -63,7 +63,6 @@ class RequestSummary(BaseModel):
     t: int
     time: str
     status_code: int
-    rid: str
 
 
 def format_request_summary_fields(
@@ -82,5 +81,4 @@ def format_request_summary_fields(
         t=int((current_time - request_time) * 1000.0),
         time=datetime.fromtimestamp(current_time).isoformat(),
         status_code=status_code,
-        rid=request.state.rid,
     ).model_dump()

--- a/jbi/log.py
+++ b/jbi/log.py
@@ -8,6 +8,7 @@ import time
 from datetime import datetime
 from typing import Optional
 
+from asgi_correlation_id import CorrelationIdFilter
 from fastapi import Request
 from pydantic import BaseModel
 
@@ -15,16 +16,41 @@ from jbi.environment import get_settings
 
 settings = get_settings()
 
+
+class RequestIdFilter(CorrelationIdFilter):
+    """Renames `correlation_id` log field to `rid`"""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def filter(self, record) -> bool:
+        result = super().filter(record)  # Apply the existing filter
+
+        # Rename the field from 'correlation_id' to 'rid'
+        if hasattr(record, "correlation_id"):
+            setattr(record, "rid", getattr(record, "correlation_id"))
+            delattr(record, "correlation_id")
+
+        return result
+
+
 CONFIG = {
     "version": 1,
     "disable_existing_loggers": False,
+    "filters": {
+        "request_id": {
+            "()": RequestIdFilter,
+            "uuid_length": 32,
+            "default_value": "-",
+        },
+    },
     "formatters": {
         "mozlog_json": {
             "()": "dockerflow.logging.JsonLogFormatter",
             "logger_name": "jbi",
         },
         "text": {
-            "format": "%(asctime)s %(levelname)-8s %(name)-15s %(message)s",
+            "format": "%(asctime)s %(levelname)-8s [%(rid)s] %(name)-15s %(message)s",
             "datefmt": "%Y-%m-%d %H:%M:%S",
         },
     },
@@ -32,6 +58,7 @@ CONFIG = {
         "console": {
             "level": settings.log_level.upper(),
             "class": "logging.StreamHandler",
+            "filters": ["request_id"],
             "formatter": "text"
             if settings.log_format.lower() == "text"
             else "mozlog_json",

--- a/jbi/models.py
+++ b/jbi/models.py
@@ -286,7 +286,6 @@ class BugzillaBug(BaseModel):
 class BugzillaWebhookRequest(BaseModel):
     """Bugzilla Webhook Request Object"""
 
-    rid: str = ""  # This field has a default since it's not parsed from body.
     webhook_id: int
     webhook_name: str
     event: BugzillaWebhookEvent
@@ -362,7 +361,6 @@ BugId = TypedDict("BugId", {"id": Optional[int]})
 class RunnerContext(Context, extra="forbid"):
     """Logging context from runner"""
 
-    rid: str
     operation: Operation
     event: BugzillaWebhookEvent
     action: Optional[Action] = None
@@ -373,7 +371,6 @@ class ActionContext(Context, extra="forbid"):
     """Logging context from actions"""
 
     action: Action
-    rid: str
     operation: Operation
     current_step: Optional[str] = None
     event: BugzillaWebhookEvent

--- a/jbi/router.py
+++ b/jbi/router.py
@@ -79,7 +79,6 @@ def bugzilla_webhook(
     webhook_request: BugzillaWebhookRequest = Body(..., embed=False),
 ):
     """API endpoint that Bugzilla Webhook Events request"""
-    webhook_request.rid = request.state.rid
     try:
         result = execute_action(webhook_request, actions)
         return result

--- a/jbi/runner.py
+++ b/jbi/runner.py
@@ -152,7 +152,6 @@ def execute_action(
     """
     bug, event = request.bug, request.event
     runner_context = RunnerContext(
-        rid=request.rid,
         bug=bug,
         event=event,
         operation=Operation.HANDLE,
@@ -190,7 +189,6 @@ def execute_action(
 
         action_context = ActionContext(
             action=action,
-            rid=request.rid,
             bug=bug,
             event=event,
             operation=Operation.IGNORE,

--- a/poetry.lock
+++ b/poetry.lock
@@ -33,6 +33,23 @@ test = ["anyio[trio]", "coverage[toml] (>=4.5)", "hypothesis (>=4.0)", "mock (>=
 trio = ["trio (<0.22)"]
 
 [[package]]
+name = "asgi-correlation-id"
+version = "4.2.0"
+description = "Middleware correlating project logs to individual requests"
+optional = false
+python-versions = ">=3.7,<4.0"
+files = [
+    {file = "asgi_correlation_id-4.2.0-py3-none-any.whl", hash = "sha256:bd3321a4022f38179db775d27c40cb45130ac9429d569cd59b5474cb2f65fb1b"},
+    {file = "asgi_correlation_id-4.2.0.tar.gz", hash = "sha256:9d7dcfc2ed016f6e594fffd553788ac70129db7f92bb4dc268ab0b1a3284de5a"},
+]
+
+[package.dependencies]
+starlette = ">=0.18"
+
+[package.extras]
+celery = ["celery"]
+
+[[package]]
 name = "astroid"
 version = "2.15.7"
 description = "An abstract syntax tree for Python with inference support."
@@ -1567,8 +1584,7 @@ files = [
     {file = "ruamel.yaml.clib-0.2.7-cp310-cp310-win32.whl", hash = "sha256:763d65baa3b952479c4e972669f679fe490eee058d5aa85da483ebae2009d231"},
     {file = "ruamel.yaml.clib-0.2.7-cp310-cp310-win_amd64.whl", hash = "sha256:d000f258cf42fec2b1bbf2863c61d7b8918d31ffee905da62dede869254d3b8a"},
     {file = "ruamel.yaml.clib-0.2.7-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:045e0626baf1c52e5527bd5db361bc83180faaba2ff586e763d3d5982a876a9e"},
-    {file = "ruamel.yaml.clib-0.2.7-cp311-cp311-macosx_13_0_arm64.whl", hash = "sha256:1a6391a7cabb7641c32517539ca42cf84b87b667bad38b78d4d42dd23e957c81"},
-    {file = "ruamel.yaml.clib-0.2.7-cp311-cp311-manylinux2014_aarch64.whl", hash = "sha256:9c7617df90c1365638916b98cdd9be833d31d337dbcd722485597b43c4a215bf"},
+    {file = "ruamel.yaml.clib-0.2.7-cp311-cp311-macosx_12_6_arm64.whl", hash = "sha256:721bc4ba4525f53f6a611ec0967bdcee61b31df5a56801281027a3a6d1c2daf5"},
     {file = "ruamel.yaml.clib-0.2.7-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:41d0f1fa4c6830176eef5b276af04c89320ea616655d01327d5ce65e50575c94"},
     {file = "ruamel.yaml.clib-0.2.7-cp311-cp311-win32.whl", hash = "sha256:f6d3d39611ac2e4f62c3128a9eed45f19a6608670c5a2f4f07f24e8de3441d38"},
     {file = "ruamel.yaml.clib-0.2.7-cp311-cp311-win_amd64.whl", hash = "sha256:da538167284de58a52109a9b89b8f6a53ff8437dd6dc26d33b57bf6699153122"},
@@ -2118,4 +2134,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10 <3.12"
-content-hash = "a2a0b4f21310bed05e18252647c50b6f13d17ff5bf59dfa50dd83f95fddc3bfe"
+content-hash = "9827e89b88e001f6f81b79d0415a97afe3b3661036b47d094b55a3bd81356ca0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ backoff = "^2.2.1"
 statsd = "^4.0.1"
 requests = "^2.31.0"
 pydantic-settings = "^2.1.0"
+asgi-correlation-id = "^4.2.0"
 
 [tool.poetry.group.dev.dependencies]
 pre-commit = "^3.5.0"

--- a/tests/fixtures/factories.py
+++ b/tests/fixtures/factories.py
@@ -139,7 +139,6 @@ class ActionContextFactory(factory.Factory):
         model = models.ActionContext
 
     action = factory.SubFactory(ActionFactory)
-    rid = factory.LazyFunction(lambda: token_hex(16))
     operation = Operation.IGNORE
     bug = factory.SubFactory(BugFactory)
     event = factory.SubFactory(WebhookEventFactory)

--- a/tests/unit/services/test_jira.py
+++ b/tests/unit/services/test_jira.py
@@ -167,7 +167,6 @@ def test_get_issue(mocked_responses, action_context_factory, capturelogs):
 
     assert response == mock_response_data
     for record in capturelogs.records:
-        assert record.rid == context.rid
         assert record.action["whiteboard_tag"] == context.action.whiteboard_tag
 
     before, after = capturelogs.messages
@@ -184,9 +183,6 @@ def test_get_issue_handles_404(mocked_responses, action_context_factory, capture
         return_val = jira.get_service().get_issue(context=context, issue_key="JBI-234")
 
     assert return_val is None
-
-    for record in capturelogs.records:
-        assert record.rid == context.rid
 
     before, after = capturelogs.records
     assert before.levelno == logging.DEBUG
@@ -208,7 +204,6 @@ def test_get_issue_reraises_other_erroring_status_codes(
             jira.get_service().get_issue(context=context, issue_key="JBI-234")
 
     [record] = capturelogs.records
-    assert record.rid == context.rid
     assert record.levelno == logging.DEBUG
     assert record.message == "Getting issue JBI-234"
 
@@ -228,10 +223,6 @@ def test_update_issue_resolution(mocked_responses, action_context_factory, captu
         jira.get_service().update_issue_resolution(
             context=context, jira_resolution="DONEZO"
         )
-
-    for record in capturelogs.records:
-        assert record.rid == context.rid
-        assert record.levelno == logging.DEBUG
 
     before, after = capturelogs.messages
     assert before == "Updating resolution of Jira issue JBI-234 to DONEZO"
@@ -258,10 +249,8 @@ def test_update_issue_resolution_raises(
                 context=context, jira_resolution="DONEZO"
             )
 
-    [record] = capturelogs.records
-    assert record.rid == context.rid
-    assert record.levelno == logging.DEBUG
-    assert record.message == "Updating resolution of Jira issue JBI-234 to DONEZO"
+    [message] = capturelogs.messages
+    assert message == "Updating resolution of Jira issue JBI-234 to DONEZO"
 
 
 def test_create_jira_issue(mocked_responses, action_context_factory, capturelogs):
@@ -292,10 +281,6 @@ def test_create_jira_issue(mocked_responses, action_context_factory, capturelogs
         )
 
     assert response == mocked_response_data
-
-    for record in capturelogs.records:
-        assert record.rid == context.rid
-        assert record.levelno == logging.DEBUG
 
     before, after = capturelogs.records
     assert before.message == f"Creating new Jira issue for Bug {context.bug.id}"
@@ -339,12 +324,10 @@ def test_create_jira_issue_when_list_is_returned(
     before, after = capturelogs.records
     assert before.message == f"Creating new Jira issue for Bug {context.bug.id}"
     assert before.levelno == logging.DEBUG
-    assert before.rid == context.rid
     assert before.fields == issue_fields
 
     assert after.message == f"Jira issue JBI-234 created for Bug {context.bug.id}"
     assert after.levelno == logging.DEBUG
-    assert after.rid == context.rid
     assert after.response == [mocked_issue_data]
 
 
@@ -375,11 +358,9 @@ def test_create_jira_issue_returns_errors(
 
     before, after = capturelogs.records
     assert before.message == f"Creating new Jira issue for Bug {context.bug.id}"
-    assert before.rid == context.rid
     assert before.levelno == logging.DEBUG
     assert before.fields == issue_fields
 
     assert after.message == f"Failed to create issue for Bug {context.bug.id}"
-    assert after.rid == context.rid
     assert after.levelno == logging.ERROR
     assert after.response == fake_error_data

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -9,34 +9,32 @@ from jbi.environment import get_settings
 from jbi.models import BugzillaWebhookRequest
 
 
-def test_request_summary_is_logged(caplog):
+def test_request_summary_is_logged(caplog, anon_client):
     with caplog.at_level(logging.INFO):
-        with TestClient(app) as anon_client:
-            # https://fastapi.tiangolo.com/advanced/testing-events/
-            anon_client.get(
-                "/",
-                headers={
-                    "X-Request-Id": "foo-bar",
-                },
-            )
+        # https://fastapi.tiangolo.com/advanced/testing-events/
+        anon_client.get(
+            "/",
+            headers={
+                "X-Request-Id": "foo-bar",
+            },
+        )
 
-            summary = [r for r in caplog.records if r.name == "request.summary"][0]
+    summary = [r for r in caplog.records if r.name == "request.summary"][0]
 
-            assert summary.rid == "foo-bar"
-            assert summary.method == "GET"
-            assert summary.path == "/"
-            assert summary.querystring == "{}"
+    assert summary.rid == "foo-bar"
+    assert summary.method == "GET"
+    assert summary.path == "/"
+    assert summary.querystring == "{}"
 
 
-def test_request_summary_defaults_user_agent_to_empty_string(caplog):
+def test_request_summary_defaults_user_agent_to_empty_string(caplog, anon_client):
     with caplog.at_level(logging.INFO):
-        with TestClient(app) as anon_client:
-            del anon_client.headers["User-Agent"]
-            anon_client.get("/")
+        del anon_client.headers["User-Agent"]
+        anon_client.get("/")
 
-            summary = [r for r in caplog.records if r.name == "request.summary"][0]
+        summary = [r for r in caplog.records if r.name == "request.summary"][0]
 
-            assert summary.agent == ""
+        assert summary.agent == ""
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR adds [`asgi-correlation-id`](https://github.com/snok/asgi-correlation-id), which provides a filter to add a request id (what they call a "correlation id") to logs by using a `ContextVar`.

Here's an example when calling `__heartbeat__`, where I didn't take too much care in settings configuration properly (I also patched the heartbeat route handler -- more on that in another PR)

```
{"Timestamp": 1701795525209590016, "Type": "jbi.services.bugzilla", "Logger": "jbi", "Hostname": "gbeckley-kxmd6r", "EnvVersion": "2.0", "Severity": 6, "Pid": 34650, "Fields": {"rid": "b3b2499f04fe642a618c24506045796c", "msg": "No webhooks enabled"}}
{"Timestamp": 1701795525797857024, "Type": "jbi.services.jira", "Logger": "jbi", "Hostname": "gbeckley-kxmd6r", "EnvVersion": "2.0", "Severity": 3, "Pid": 34650, "Fields": {"rid": "b3b2499f04fe642a618c24506045796c", "msg": "Jira projects {'DevTest'} are not visible with configured credentials"}}
{"Timestamp": 1701795525911177984, "Type": "atlassian.rest_client", "Logger": "jbi", "Hostname": "gbeckley-kxmd6r", "EnvVersion": "2.0", "Severity": 3, "Pid": 34650, "Fields": {"body": "{\"errorMessages\":[\"Could not find project with provided key.\"],\"errors\":{}}", "rid": "-", "msg": "HTTP: GET /rest/api/2/mypermissions?permissions=ADD_COMMENTS%2CCREATE_ISSUES%2CEDIT_ISSUES%2CDELETE_ISSUES&projectKey=DevTest -> 404 Not Found"}}
{"Timestamp": 1701795525911500032, "Type": "backoff", "Logger": "jbi", "Hostname": "gbeckley-kxmd6r", "EnvVersion": "2.0", "Severity": 3, "Pid": 34650, "Fields": {"rid": "-", "msg": "Giving up wrapper(...) after 1 tries (requests.exceptions.HTTPError: Could not find project with provided key.)"}}
{"Timestamp": 1701795525911770880, "Type": "jbi.services.jira", "Logger": "jbi", "Hostname": "gbeckley-kxmd6r", "EnvVersion": "2.0", "Severity": 4, "Pid": 34650, "Fields": {"rid": "b3b2499f04fe642a618c24506045796c", "msg": "Failed to fetch permissions for project DevTest"}}
{"Timestamp": 1701795526029776896, "Type": "atlassian.rest_client", "Logger": "jbi", "Hostname": "gbeckley-kxmd6r", "EnvVersion": "2.0", "Severity": 3, "Pid": 34650, "Fields": {"body": "{\"errorMessages\":[\"No project could be found with key 'DevTest'.\"],\"errors\":{}}", "rid": "b3b2499f04fe642a618c24506045796c", "msg": "HTTP: GET /rest/api/2/project/DevTest/components -> 404 Not Found"}}
{"Timestamp": 1701795526030150912, "Type": "backoff", "Logger": "jbi", "Hostname": "gbeckley-kxmd6r", "EnvVersion": "2.0", "Severity": 3, "Pid": 34650, "Fields": {"rid": "b3b2499f04fe642a618c24506045796c", "msg": "Giving up wrapper(...) after 1 tries (requests.exceptions.HTTPError: No project could be found with key 'DevTest'.)"}}
{"Timestamp": 1701795526143874048, "Type": "atlassian.rest_client", "Logger": "jbi", "Hostname": "gbeckley-kxmd6r", "EnvVersion": "2.0", "Severity": 3, "Pid": 34650, "Fields": {"body": "{\"errorMessages\":[\"No project could be found with key 'DevTest'.\"],\"errors\":{}}", "rid": "b3b2499f04fe642a618c24506045796c", "msg": "HTTP: GET /rest/api/2/project/DevTest -> 404 Not Found"}}
{"Timestamp": 1701795526144160000, "Type": "backoff", "Logger": "jbi", "Hostname": "gbeckley-kxmd6r", "EnvVersion": "2.0", "Severity": 3, "Pid": 34650, "Fields": {"rid": "b3b2499f04fe642a618c24506045796c", "msg": "Giving up wrapper(...) after 1 tries (requests.exceptions.HTTPError: No project could be found with key 'DevTest'.)"}}
{"Timestamp": 1701795526144962048, "Type": "request.summary", "Logger": "jbi", "Hostname": "gbeckley-kxmd6r", "EnvVersion": "2.0", "Severity": 6, "Pid": 34650, "Fields": {"agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:122.0) Gecko/20100101 Firefox/122.0", "path": "/__heartbeat__", "method": "GET", "lang": "en-US,en;q=0.5", "querystring": "{}", "errno": 0, "t": 1376, "time": "2023-12-05T11:58:46.144848", "status_code": 503, "rid": "b3b2499f04fe642a618c24506045796c"}}
```

One note: the `rid` does not seem to be preserved in instances where we use a `ThreadPoolExecutor`. I believe this is a limitation of Context Vars. We can investigate how to copy this context to other threads in a future PR, but this seems "good enough" for now, and we have other ways to diagnose what's going on in the heartbeat