### PR TITLE
Change method for fetching visible projects and issue types in __heartbeat__

### DIFF
--- a/jbi/configuration.py
+++ b/jbi/configuration.py
@@ -30,6 +30,7 @@ def get_actions_from_file(jbi_config_file: str) -> Actions:
 
 
 def get_actions(env=settings.env):
+    """Load actions from file determined by ENV name"""
     return get_actions_from_file(f"config/config.{env}.yaml")
 
 

--- a/jbi/configuration.py
+++ b/jbi/configuration.py
@@ -2,7 +2,6 @@
 Parsing and validating the YAML configuration occurs within this module
 """
 import logging
-from functools import lru_cache
 
 from pydantic import ValidationError
 from pydantic_yaml import parse_yaml_raw_as
@@ -18,12 +17,6 @@ class ConfigError(Exception):
     """Error when an exception occurs during processing config"""
 
 
-@lru_cache
-def get_actions() -> Actions:
-    """Load actions from file determined by ENV name"""
-    return get_actions_from_file(f"config/config.{settings.env}.yaml")
-
-
 def get_actions_from_file(jbi_config_file: str) -> Actions:
     """Convert and validate YAML configuration to `Action` objects"""
     try:
@@ -34,3 +27,10 @@ def get_actions_from_file(jbi_config_file: str) -> Actions:
     except ValidationError as exception:
         logger.exception(exception)
         raise ConfigError("Errors exist.") from exception
+
+
+def get_actions(env=settings.env):
+    return get_actions_from_file(f"config/config.{env}.yaml")
+
+
+ACTIONS = get_actions()

--- a/jbi/models.py
+++ b/jbi/models.py
@@ -138,12 +138,20 @@ class Actions(RootModel):
         """
         Inspect the list of actions:
          - Validate that lookup tags are uniques
+         - Ensure we haven't exceeded our maximum configured project limit (see error below)
          - If the action's bugzilla_user_id is "tbd", emit a warning.
         """
         tags = [action.whiteboard_tag.lower() for action in actions]
         duplicated_tags = [t for i, t in enumerate(tags) if t in tags[:i]]
         if duplicated_tags:
             raise ValueError(f"actions have duplicated lookup tags: {duplicated_tags}")
+
+        if len(tags) > 50:
+            raise ValueError(
+                "The Jira client's `paginated_projects` method assumes we have "
+                "up to 50 projects configured. Adjust that implementation before "
+                "removing this validation check."
+            )
 
         for action in actions:
             if action.bugzilla_user_id == "tbd":

--- a/jbi/router.py
+++ b/jbi/router.py
@@ -106,8 +106,7 @@ def get_bugzilla_webhooks(bugzilla_service: BugzillaServiceDep):
 @router.get("/jira_projects/")
 def get_jira_projects(jira_service: JiraServiceDep):
     """API for viewing projects that are currently accessible by API"""
-    visible_projects: list[dict] = jira_service.fetch_visible_projects()
-    return [project["key"] for project in visible_projects]
+    return jira_service.fetch_visible_projects()
 
 
 SRC_DIR = Path(__file__).parent

--- a/jbi/router.py
+++ b/jbi/router.py
@@ -9,14 +9,14 @@ from fastapi.encoders import jsonable_encoder
 from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
 
-from jbi.configuration import get_actions
+from jbi.configuration import ACTIONS
 from jbi.environment import Settings, get_settings, get_version
 from jbi.models import Actions, BugzillaWebhookRequest
 from jbi.runner import IgnoreInvalidRequestError, execute_action
 from jbi.services import bugzilla, jira
 
 SettingsDep = Annotated[Settings, Depends(get_settings)]
-ActionsDep = Annotated[Actions, Depends(get_actions)]
+ActionsDep = Annotated[Actions, Depends(lambda: ACTIONS)]
 VersionDep = Annotated[dict, Depends(get_version)]
 BugzillaServiceDep = Annotated[bugzilla.BugzillaService, Depends(bugzilla.get_service)]
 JiraServiceDep = Annotated[jira.JiraService, Depends(jira.get_service)]

--- a/poetry.lock
+++ b/poetry.lock
@@ -1331,6 +1331,23 @@ pytest = ">=6.2"
 typing_extensions = "*"
 
 [[package]]
+name = "pytest-mock"
+version = "3.12.0"
+description = "Thin-wrapper around the mock package for easier use with pytest"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pytest-mock-3.12.0.tar.gz", hash = "sha256:31a40f038c22cad32287bb43932054451ff5583ff094bca6f675df2f8bc1a6e9"},
+    {file = "pytest_mock-3.12.0-py3-none-any.whl", hash = "sha256:0972719a7263072da3a21c7f4773069bcc7486027d7e8e1f81d98a47e701bc4f"},
+]
+
+[package.dependencies]
+pytest = ">=5.0"
+
+[package.extras]
+dev = ["pre-commit", "pytest-asyncio", "tox"]
+
+[[package]]
 name = "python-dateutil"
 version = "2.8.2"
 description = "Extensions to the standard Python datetime module"
@@ -2131,4 +2148,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.12, <3.13"
-content-hash = "e127c1b3a30b9309b2cbf82d35557edf9f14747dab6d136991637491151a1f90"
+content-hash = "86bf9d83bc4603dd7aecb5b19a866775695462693915060dfe4f0a3f238f59fe"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ responses = "^0.24.1"
 httpx = "^0.25.2"
 factory-boy = "^3.3.0"
 pytest-factoryboy = "^2.6.0"
+pytest-mock = "^3.12.0"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -83,7 +83,7 @@ def settings():
 
 @pytest.fixture(autouse=True)
 def actions():
-    return get_actions
+    return get_actions()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -83,8 +83,7 @@ def settings():
 
 @pytest.fixture(autouse=True)
 def actions():
-    get_actions.cache_clear()
-    return get_actions()
+    return get_actions
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/test_configuration.py
+++ b/tests/unit/test_configuration.py
@@ -1,8 +1,6 @@
-from unittest import mock
-
 import pytest
 
-from jbi import configuration, environment
+from jbi import configuration
 
 
 def test_mock_jbi_files():
@@ -22,8 +20,10 @@ def test_actual_jbi_files():
     )
 
 
-def test_filename_uses_env():
-    configuration.get_actions.cache_clear()
-    with mock.patch("jbi.configuration.get_actions_from_file") as mocked:
-        configuration.get_actions()
-    mocked.assert_called_with("config/config.local.yaml")
+def test_filename_uses_env(mocker, actions, settings):
+    get_actions_from_file_spy = mocker.spy(configuration, "get_actions_from_file")
+    assert settings.env == "local"
+
+    configuration.get_actions()
+
+    get_actions_from_file_spy.assert_called_with("config/config.local.yaml")

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -172,3 +172,9 @@ def test_payload_changes_list(webhook_event_change_factory, webhook_event_factor
         "status",
         "assignee",
     ]
+
+
+def test_max_configured_projects_raises_error(action_factory):
+    actions = [action_factory(whiteboard_tag=str(i)) for i in range(51)]
+    with pytest.raises(pydantic.ValidationError):
+        Actions(root=actions)


### PR DESCRIPTION
From the commit message for fd461335341ddabae96714b2b0841023c4020a9d:

In v6.3.6, we bumped atlassian-python-api from 3.41.4. That bump included a [PR](https://github.com/atlassian-api/atlassian-python-api/pull/1270) which changed the way the library fetched projects. This somehow affected our project when we fetched visible projects and issue types in the heartbeat. We never fully determined the root cause, but the while loop in the linked PR was suspect.

In this commit, we make further improvements to the code that's involved in the heartbeat to make it more efficient.

Note that one of the tradeoffs we made for now was hardcoding the maximum number of projects that may be configured at 50. This is due to the way we fetch issue types by project. This is something that we can fix in the future, but is not a problem that we need to solve for now since we only have 26 projects configured.