### PR TITLE
New structure for Jira and Bugzilla clients + services

### DIFF
--- a/jbi/bugzilla/__init__.py
+++ b/jbi/bugzilla/__init__.py
@@ -1,0 +1,3 @@
+from .service import BugzillaService, get_service
+
+__all__ = ["get_service", "BugzillaService"]

--- a/jbi/bugzilla/__init__.py
+++ b/jbi/bugzilla/__init__.py
@@ -1,3 +1,2 @@
-from .service import BugzillaService, get_service
-
-__all__ = ["get_service", "BugzillaService"]
+from .service import BugzillaService as BugzillaService
+from .service import get_service as get_service

--- a/jbi/bugzilla/client.py
+++ b/jbi/bugzilla/client.py
@@ -1,0 +1,126 @@
+import logging
+
+import requests
+
+from jbi import environment
+from jbi.common.instrument import instrument
+from jbi.models import (
+    BugzillaApiResponse,
+    BugzillaBug,
+    BugzillaComment,
+    BugzillaComments,
+    BugzillaWebhooksResponse,
+)
+
+settings = environment.get_settings()
+
+logger = logging.getLogger(__name__)
+
+
+class BugzillaClientError(Exception):
+    """Errors raised by `BugzillaClient`."""
+
+
+instrumented_method = instrument(
+    prefix="bugzilla",
+    exceptions=(
+        BugzillaClientError,
+        requests.RequestException,
+    ),
+)
+
+
+class BugzillaClient:
+    """A wrapper around `requests` to interact with a Bugzilla REST API."""
+
+    def __init__(self, base_url, api_key):
+        """Initialize the client, without network activity."""
+        self.base_url = base_url
+        self.api_key = api_key
+        self._client = requests.Session()
+
+    def _call(self, verb, url, *args, **kwargs):
+        """Send HTTP requests with API key in querystring parameters."""
+        # Send API key in headers.
+        # https://bmo.readthedocs.io/en/latest/api/core/v1/general.html?highlight=x-bugzilla-api-key#authentication
+        headers = kwargs.setdefault("headers", {})
+        headers.setdefault("x-bugzilla-api-key", self.api_key)
+        try:
+            resp = self._client.request(verb, url, *args, **kwargs)
+            resp.raise_for_status()
+        except requests.HTTPError:
+            logger.exception("%s %s", verb, url)
+            raise
+        parsed = resp.json()
+        if parsed.get("error"):
+            raise BugzillaClientError(parsed["message"])
+        return parsed
+
+    @instrumented_method
+    def logged_in(self) -> bool:
+        """Verify the API key validity."""
+        # https://bugzilla.readthedocs.io/en/latest/api/core/v1/user.html#who-am-i
+        try:
+            resp = self._call("GET", f"{self.base_url}/rest/whoami")
+        except (requests.HTTPError, BugzillaClientError):
+            return False
+        return "id" in resp
+
+    @instrumented_method
+    def get_bug(self, bugid) -> BugzillaBug:
+        """Retrieve details about the specified bug id."""
+        # https://bugzilla.readthedocs.io/en/latest/api/core/v1/bug.html#rest-single-bug
+        url = f"{self.base_url}/rest/bug/{bugid}"
+        bug_info = self._call("GET", url)
+        parsed = BugzillaApiResponse.model_validate(bug_info)
+        if not parsed.bugs:
+            raise BugzillaClientError(
+                f"Unexpected response content from 'GET {url}' (no 'bugs' field)"
+            )
+        bug = parsed.bugs[0]
+        # If comment is private, then fetch it from server
+        if bug.comment and bug.comment.is_private:
+            comment_list = self.get_comments(bugid)
+            matching_comments = [c for c in comment_list if c.id == bug.comment.id]
+            # If no matching entry is found, set `bug.comment` to `None`.
+            found = matching_comments[0] if matching_comments else None
+            bug = bug.model_copy(update={"comment": found}, deep=True)
+        return bug
+
+    @instrumented_method
+    def get_comments(self, bugid) -> list[BugzillaComment]:
+        """Retrieve the list of comments of the specified bug id."""
+        # https://bugzilla.readthedocs.io/en/latest/api/core/v1/comment.html#rest-comments
+        url = f"{self.base_url}/rest/bug/{bugid}/comment"
+        comments_info = self._call("GET", url)
+        comments = comments_info.get("bugs", {}).get(str(bugid), {}).get("comments")
+        if comments is None:
+            raise BugzillaClientError(
+                f"Unexpected response content from 'GET {url}' (no 'bugs' field)"
+            )
+        return BugzillaComments.validate_python(comments)
+
+    @instrumented_method
+    def update_bug(self, bugid, **fields) -> BugzillaBug:
+        """Update the specified fields of the specified bug."""
+        # https://bugzilla.readthedocs.io/en/latest/api/core/v1/bug.html#rest-update-bug
+        url = f"{self.base_url}/rest/bug/{bugid}"
+        updated_info = self._call("PUT", url, json=fields)
+        parsed = BugzillaApiResponse.model_validate(updated_info)
+        if not parsed.bugs:
+            raise BugzillaClientError(
+                f"Unexpected response content from 'PUT {url}' (no 'bugs' field)"
+            )
+        return parsed.bugs[0]
+
+    @instrumented_method
+    def list_webhooks(self):
+        """List the currently configured webhooks, including their status."""
+        url = f"{self.base_url}/rest/webhooks/list"
+        webhooks_info = self._call("GET", url)
+        parsed = BugzillaWebhooksResponse.model_validate(webhooks_info)
+        if parsed.webhooks is None:
+            raise BugzillaClientError(
+                f"Unexpected response content from 'GET {url}' (no 'webhooks' field)"
+            )
+        return [wh for wh in parsed.webhooks if "/bugzilla_webhook" in wh.url]

--- a/jbi/bugzilla/service.py
+++ b/jbi/bugzilla/service.py
@@ -1,7 +1,3 @@
-"""Contains a Bugzilla REST client and functions comprised of common operations
-with that REST client
-"""
-
 import logging
 from functools import lru_cache
 
@@ -9,12 +5,13 @@ import requests
 from statsd.defaults.env import statsd
 
 from jbi import Operation, environment
-from jbi.bugzilla.client import BugzillaClient, BugzillaClientError
 from jbi.common.instrument import ServiceHealth
 from jbi.models import (
     ActionContext,
     BugzillaBug,
 )
+
+from .client import BugzillaClient, BugzillaClientError
 
 settings = environment.get_settings()
 

--- a/jbi/common/instrument.py
+++ b/jbi/common/instrument.py
@@ -27,13 +27,13 @@ def instrument(prefix: str, exceptions: Sequence[Type[Exception]], **backoff_par
     """
 
     def decorator(func):
-        @wraps(func)
         @backoff.on_exception(
             backoff.expo,
             exceptions,
             max_tries=settings.max_retries + 1,
             **backoff_params,
         )
+        @wraps(func)
         def wrapper(*args, **kwargs):
             # Increment the call counter.
             statsd.incr(f"jbi.{prefix}.methods.{func.__name__}.count")

--- a/jbi/jira/__init__.py
+++ b/jbi/jira/__init__.py
@@ -1,3 +1,2 @@
-from .service import JiraService, get_service
-
-__all__ = ["JiraService", "get_service"]
+from .service import JiraService as JiraService
+from .service import get_service as get_service

--- a/jbi/jira/__init__.py
+++ b/jbi/jira/__init__.py
@@ -1,0 +1,3 @@
+from .service import JiraService, get_service
+
+__all__ = ["JiraService", "get_service"]

--- a/jbi/jira/client.py
+++ b/jbi/jira/client.py
@@ -1,0 +1,125 @@
+import logging
+from typing import Collection, Iterable, Optional
+
+import requests
+from atlassian import Jira
+from atlassian import errors as atlassian_errors
+from atlassian.rest_client import log as atlassian_logger
+from requests import exceptions as requests_exceptions
+
+from jbi import environment
+from jbi.common.instrument import instrument
+
+settings = environment.get_settings()
+
+logger = logging.getLogger(__name__)
+
+
+def fatal_code(exc):
+    """Do not retry 4XX errors, mark them as fatal."""
+    try:
+        return 400 <= exc.response.status_code < 500
+    except AttributeError:
+        # `ApiError` or `ConnectionError` won't have response attribute.
+        return False
+
+
+instrumented_method = instrument(
+    prefix="jira",
+    exceptions=(
+        atlassian_errors.ApiError,
+        requests_exceptions.RequestException,
+    ),
+    giveup=fatal_code,
+)
+
+
+class JiraCreateError(Exception):
+    """Error raised on Jira issue creation."""
+
+
+class JiraClient(Jira):
+    """Adapted Atlassian Jira client that logs errors and wraps methods
+    in our instrumentation decorator.
+    """
+
+    def raise_for_status(self, *args, **kwargs):
+        """Catch and log HTTP errors responses of the Jira self.client.
+
+        Without this the actual requests and responses are not exposed when an error
+        occurs, which makes troubleshooting tedious.
+        """
+        try:
+            return super().raise_for_status(*args, **kwargs)
+        except requests.HTTPError as exc:
+            request = exc.request
+            response = exc.response
+            atlassian_logger.error(
+                "HTTP: %s %s -> %s %s",
+                request.method,
+                request.path_url,
+                response.status_code,
+                response.reason,
+                extra={"body": response.text},
+            )
+            raise
+
+    get_server_info = instrumented_method(Jira.get_server_info)
+    get_project_components = instrumented_method(Jira.get_project_components)
+    update_issue = instrumented_method(Jira.update_issue)
+    update_issue_field = instrumented_method(Jira.update_issue_field)
+    set_issue_status = instrumented_method(Jira.set_issue_status)
+    issue_add_comment = instrumented_method(Jira.issue_add_comment)
+    create_issue = instrumented_method(Jira.create_issue)
+    get_project = instrumented_method(Jira.get_project)
+
+    @instrumented_method
+    def paginated_projects(
+        self,
+        included_archived=None,
+        expand=None,
+        url=None,
+        keys: Optional[Collection[str]] = None,
+    ):
+        """Returns a paginated list of projects visible to the user.
+
+        https://developer.atlassian.com/cloud/jira/platform/rest/v2/api-group-projects/#api-rest-api-2-project-search-get
+
+        We've patched this method of the Jira client to accept the `keys` param.
+        """
+
+        if not self.cloud:
+            raise ValueError(
+                "``projects_from_cloud`` method is only available for Jira Cloud platform"
+            )
+
+        params = []
+
+        if keys is not None:
+            if len(keys) > 50:
+                raise ValueError("Up to 50 project keys can be provided.")
+            params = [("keys", key) for key in keys]
+
+        if included_archived:
+            params.append(("includeArchived", included_archived))
+        if expand:
+            params.append(("expand", expand))
+        page_url = url or self.resource_url("project/search")
+        is_url_absolute = bool(page_url.lower().startswith("http"))
+        return self.get(page_url, params=params, absolute=is_url_absolute)
+
+    @instrumented_method
+    def permitted_projects(self, permissions: Optional[Iterable] = None) -> list[dict]:
+        """Fetches projects that the user has the required permissions for
+
+        https://developer.atlassian.com/cloud/jira/platform/rest/v2/api-group-permissions/#api-rest-api-2-permissions-project-post
+        """
+        if permissions is None:
+            permissions = []
+
+        response = self.post(
+            "/rest/api/2/permissions/project",
+            json={"permissions": list(permissions)},
+        )
+        projects: list[dict] = response["projects"]
+        return projects

--- a/jbi/jira/service.py
+++ b/jbi/jira/service.py
@@ -1,6 +1,3 @@
-"""Contains a Jira REST client and functions comprised of common operations
-with that REST client
-"""
 # This import is needed (as of Pyhon 3.11) to enable type checking with modules
 # imported under `TYPE_CHECKING`
 # https://docs.python.org/3/whatsnew/3.7.html#pep-563-postponed-evaluation-of-annotations
@@ -18,8 +15,9 @@ from requests import exceptions as requests_exceptions
 
 from jbi import Operation, environment
 from jbi.common.instrument import ServiceHealth
-from jbi.jira.client import JiraClient, JiraCreateError
 from jbi.models import ActionContext, BugzillaBug
+
+from .client import JiraClient, JiraCreateError
 
 # https://docs.python.org/3.11/library/typing.html#typing.TYPE_CHECKING
 if TYPE_CHECKING:

--- a/jbi/router.py
+++ b/jbi/router.py
@@ -9,12 +9,11 @@ from fastapi.encoders import jsonable_encoder
 from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
 
-from jbi import bugzilla
+from jbi import bugzilla, jira
 from jbi.configuration import ACTIONS
 from jbi.environment import Settings, get_settings, get_version
 from jbi.models import Actions, BugzillaWebhookRequest
 from jbi.runner import IgnoreInvalidRequestError, execute_action
-from jbi.services import jira
 
 SettingsDep = Annotated[Settings, Depends(get_settings)]
 ActionsDep = Annotated[Actions, Depends(lambda: ACTIONS)]

--- a/jbi/router.py
+++ b/jbi/router.py
@@ -9,11 +9,12 @@ from fastapi.encoders import jsonable_encoder
 from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
 
+from jbi import bugzilla
 from jbi.configuration import ACTIONS
 from jbi.environment import Settings, get_settings, get_version
 from jbi.models import Actions, BugzillaWebhookRequest
 from jbi.runner import IgnoreInvalidRequestError, execute_action
-from jbi.services import bugzilla, jira
+from jbi.services import jira
 
 SettingsDep = Annotated[Settings, Depends(get_settings)]
 ActionsDep = Annotated[Actions, Depends(lambda: ACTIONS)]

--- a/jbi/runner.py
+++ b/jbi/runner.py
@@ -8,7 +8,7 @@ from typing import Optional
 
 from statsd.defaults.env import statsd
 
-from jbi import ActionResult, Operation, bugzilla
+from jbi import ActionResult, Operation, bugzilla, jira
 from jbi import steps as steps_module
 from jbi.environment import get_settings
 from jbi.errors import ActionNotFoundError, IgnoreInvalidRequestError
@@ -21,7 +21,6 @@ from jbi.models import (
     JiraContext,
     RunnerContext,
 )
-from jbi.services import jira
 from jbi.steps import StepStatus
 
 logger = logging.getLogger(__name__)

--- a/jbi/runner.py
+++ b/jbi/runner.py
@@ -8,7 +8,7 @@ from typing import Optional
 
 from statsd.defaults.env import statsd
 
-from jbi import ActionResult, Operation
+from jbi import ActionResult, Operation, bugzilla
 from jbi import steps as steps_module
 from jbi.environment import get_settings
 from jbi.errors import ActionNotFoundError, IgnoreInvalidRequestError
@@ -21,7 +21,7 @@ from jbi.models import (
     JiraContext,
     RunnerContext,
 )
-from jbi.services import bugzilla, jira
+from jbi.services import jira
 from jbi.steps import StepStatus
 
 logger = logging.getLogger(__name__)

--- a/jbi/services/__init__.py
+++ b/jbi/services/__init__.py
@@ -1,5 +1,0 @@
-"""Exports the bugzilla and jira services modules for convenience"""
-
-from . import jira
-
-__all__ = ["jira"]

--- a/jbi/services/__init__.py
+++ b/jbi/services/__init__.py
@@ -1,5 +1,5 @@
 """Exports the bugzilla and jira services modules for convenience"""
 
-from . import bugzilla, jira
+from . import jira
 
-__all__ = ["bugzilla", "jira"]
+__all__ = ["jira"]

--- a/jbi/services/bugzilla.py
+++ b/jbi/services/bugzilla.py
@@ -9,6 +9,7 @@ import requests
 from statsd.defaults.env import statsd
 
 from jbi import Operation, environment
+from jbi.common.instrument import ServiceHealth, instrument
 from jbi.models import (
     ActionContext,
     BugzillaApiResponse,
@@ -17,8 +18,6 @@ from jbi.models import (
     BugzillaComments,
     BugzillaWebhooksResponse,
 )
-
-from .common import ServiceHealth, instrument
 
 settings = environment.get_settings()
 

--- a/jbi/services/bugzilla.py
+++ b/jbi/services/bugzilla.py
@@ -9,128 +9,16 @@ import requests
 from statsd.defaults.env import statsd
 
 from jbi import Operation, environment
-from jbi.common.instrument import ServiceHealth, instrument
+from jbi.bugzilla.client import BugzillaClient, BugzillaClientError
+from jbi.common.instrument import ServiceHealth
 from jbi.models import (
     ActionContext,
-    BugzillaApiResponse,
     BugzillaBug,
-    BugzillaComment,
-    BugzillaComments,
-    BugzillaWebhooksResponse,
 )
 
 settings = environment.get_settings()
 
 logger = logging.getLogger(__name__)
-
-
-class BugzillaClientError(Exception):
-    """Errors raised by `BugzillaClient`."""
-
-
-instrumented_method = instrument(
-    prefix="bugzilla",
-    exceptions=(
-        BugzillaClientError,
-        requests.RequestException,
-    ),
-)
-
-
-class BugzillaClient:
-    """A wrapper around `requests` to interact with a Bugzilla REST API."""
-
-    def __init__(self, base_url, api_key):
-        """Initialize the client, without network activity."""
-        self.base_url = base_url
-        self.api_key = api_key
-        self._client = requests.Session()
-
-    def _call(self, verb, url, *args, **kwargs):
-        """Send HTTP requests with API key in querystring parameters."""
-        # Send API key in headers.
-        # https://bmo.readthedocs.io/en/latest/api/core/v1/general.html?highlight=x-bugzilla-api-key#authentication
-        headers = kwargs.setdefault("headers", {})
-        headers.setdefault("x-bugzilla-api-key", self.api_key)
-        try:
-            resp = self._client.request(verb, url, *args, **kwargs)
-            resp.raise_for_status()
-        except requests.HTTPError:
-            logger.exception("%s %s", verb, url)
-            raise
-        parsed = resp.json()
-        if parsed.get("error"):
-            raise BugzillaClientError(parsed["message"])
-        return parsed
-
-    @instrumented_method
-    def logged_in(self) -> bool:
-        """Verify the API key validity."""
-        # https://bugzilla.readthedocs.io/en/latest/api/core/v1/user.html#who-am-i
-        try:
-            resp = self._call("GET", f"{self.base_url}/rest/whoami")
-        except (requests.HTTPError, BugzillaClientError):
-            return False
-        return "id" in resp
-
-    @instrumented_method
-    def get_bug(self, bugid) -> BugzillaBug:
-        """Retrieve details about the specified bug id."""
-        # https://bugzilla.readthedocs.io/en/latest/api/core/v1/bug.html#rest-single-bug
-        url = f"{self.base_url}/rest/bug/{bugid}"
-        bug_info = self._call("GET", url)
-        parsed = BugzillaApiResponse.model_validate(bug_info)
-        if not parsed.bugs:
-            raise BugzillaClientError(
-                f"Unexpected response content from 'GET {url}' (no 'bugs' field)"
-            )
-        bug = parsed.bugs[0]
-        # If comment is private, then fetch it from server
-        if bug.comment and bug.comment.is_private:
-            comment_list = self.get_comments(bugid)
-            matching_comments = [c for c in comment_list if c.id == bug.comment.id]
-            # If no matching entry is found, set `bug.comment` to `None`.
-            found = matching_comments[0] if matching_comments else None
-            bug = bug.model_copy(update={"comment": found}, deep=True)
-        return bug
-
-    @instrumented_method
-    def get_comments(self, bugid) -> list[BugzillaComment]:
-        """Retrieve the list of comments of the specified bug id."""
-        # https://bugzilla.readthedocs.io/en/latest/api/core/v1/comment.html#rest-comments
-        url = f"{self.base_url}/rest/bug/{bugid}/comment"
-        comments_info = self._call("GET", url)
-        comments = comments_info.get("bugs", {}).get(str(bugid), {}).get("comments")
-        if comments is None:
-            raise BugzillaClientError(
-                f"Unexpected response content from 'GET {url}' (no 'bugs' field)"
-            )
-        return BugzillaComments.validate_python(comments)
-
-    @instrumented_method
-    def update_bug(self, bugid, **fields) -> BugzillaBug:
-        """Update the specified fields of the specified bug."""
-        # https://bugzilla.readthedocs.io/en/latest/api/core/v1/bug.html#rest-update-bug
-        url = f"{self.base_url}/rest/bug/{bugid}"
-        updated_info = self._call("PUT", url, json=fields)
-        parsed = BugzillaApiResponse.model_validate(updated_info)
-        if not parsed.bugs:
-            raise BugzillaClientError(
-                f"Unexpected response content from 'PUT {url}' (no 'bugs' field)"
-            )
-        return parsed.bugs[0]
-
-    @instrumented_method
-    def list_webhooks(self):
-        """List the currently configured webhooks, including their status."""
-        url = f"{self.base_url}/rest/webhooks/list"
-        webhooks_info = self._call("GET", url)
-        parsed = BugzillaWebhooksResponse.model_validate(webhooks_info)
-        if parsed.webhooks is None:
-            raise BugzillaClientError(
-                f"Unexpected response content from 'GET {url}' (no 'webhooks' field)"
-            )
-        return [wh for wh in parsed.webhooks if "/bugzilla_webhook" in wh.url]
 
 
 class BugzillaService:

--- a/jbi/services/jira.py
+++ b/jbi/services/jira.py
@@ -20,9 +20,8 @@ from atlassian.rest_client import log as atlassian_logger
 from requests import exceptions as requests_exceptions
 
 from jbi import Operation, environment
+from jbi.common.instrument import ServiceHealth, instrument
 from jbi.models import ActionContext, BugzillaBug
-
-from .common import ServiceHealth, instrument
 
 # https://docs.python.org/3.11/library/typing.html#typing.TYPE_CHECKING
 if TYPE_CHECKING:

--- a/jbi/services/jira.py
+++ b/jbi/services/jira.py
@@ -11,16 +11,14 @@ import concurrent
 import json
 import logging
 from functools import lru_cache
-from typing import TYPE_CHECKING, Any, Collection, Iterable, Optional
+from typing import TYPE_CHECKING, Any, Iterable, Optional
 
 import requests
-from atlassian import Jira
-from atlassian import errors as atlassian_errors
-from atlassian.rest_client import log as atlassian_logger
 from requests import exceptions as requests_exceptions
 
 from jbi import Operation, environment
-from jbi.common.instrument import ServiceHealth, instrument
+from jbi.common.instrument import ServiceHealth
+from jbi.jira.client import JiraClient, JiraCreateError
 from jbi.models import ActionContext, BugzillaBug
 
 # https://docs.python.org/3.11/library/typing.html#typing.TYPE_CHECKING
@@ -40,116 +38,6 @@ JIRA_REQUIRED_PERMISSIONS = {
     "DELETE_ISSUES",
     "EDIT_ISSUES",
 }
-
-
-def fatal_code(exc):
-    """Do not retry 4XX errors, mark them as fatal."""
-    try:
-        return 400 <= exc.response.status_code < 500
-    except AttributeError:
-        # `ApiError` or `ConnectionError` won't have response attribute.
-        return False
-
-
-instrumented_method = instrument(
-    prefix="jira",
-    exceptions=(
-        atlassian_errors.ApiError,
-        requests_exceptions.RequestException,
-    ),
-    giveup=fatal_code,
-)
-
-
-class JiraCreateError(Exception):
-    """Error raised on Jira issue creation."""
-
-
-class JiraClient(Jira):
-    """Adapted Atlassian Jira client that logs errors and wraps methods
-    in our instrumentation decorator.
-    """
-
-    def raise_for_status(self, *args, **kwargs):
-        """Catch and log HTTP errors responses of the Jira self.client.
-
-        Without this the actual requests and responses are not exposed when an error
-        occurs, which makes troubleshooting tedious.
-        """
-        try:
-            return super().raise_for_status(*args, **kwargs)
-        except requests.HTTPError as exc:
-            request = exc.request
-            response = exc.response
-            atlassian_logger.error(
-                "HTTP: %s %s -> %s %s",
-                request.method,
-                request.path_url,
-                response.status_code,
-                response.reason,
-                extra={"body": response.text},
-            )
-            raise
-
-    get_server_info = instrumented_method(Jira.get_server_info)
-    get_project_components = instrumented_method(Jira.get_project_components)
-    update_issue = instrumented_method(Jira.update_issue)
-    update_issue_field = instrumented_method(Jira.update_issue_field)
-    set_issue_status = instrumented_method(Jira.set_issue_status)
-    issue_add_comment = instrumented_method(Jira.issue_add_comment)
-    create_issue = instrumented_method(Jira.create_issue)
-    get_project = instrumented_method(Jira.get_project)
-
-    @instrumented_method
-    def paginated_projects(
-        self,
-        included_archived=None,
-        expand=None,
-        url=None,
-        keys: Optional[Collection[str]] = None,
-    ):
-        """Returns a paginated list of projects visible to the user.
-
-        https://developer.atlassian.com/cloud/jira/platform/rest/v2/api-group-projects/#api-rest-api-2-project-search-get
-
-        We've patched this method of the Jira client to accept the `keys` param.
-        """
-
-        if not self.cloud:
-            raise ValueError(
-                "``projects_from_cloud`` method is only available for Jira Cloud platform"
-            )
-
-        params = []
-
-        if keys is not None:
-            if len(keys) > 50:
-                raise ValueError("Up to 50 project keys can be provided.")
-            params = [("keys", key) for key in keys]
-
-        if included_archived:
-            params.append(("includeArchived", included_archived))
-        if expand:
-            params.append(("expand", expand))
-        page_url = url or self.resource_url("project/search")
-        is_url_absolute = bool(page_url.lower().startswith("http"))
-        return self.get(page_url, params=params, absolute=is_url_absolute)
-
-    @instrumented_method
-    def permitted_projects(self, permissions: Optional[Iterable] = None) -> list[dict]:
-        """Fetches projects that the user has the required permissions for
-
-        https://developer.atlassian.com/cloud/jira/platform/rest/v2/api-group-permissions/#api-rest-api-2-permissions-project-post
-        """
-        if permissions is None:
-            permissions = []
-
-        response = self.post(
-            "/rest/api/2/permissions/project",
-            json={"permissions": list(permissions)},
-        )
-        projects: list[dict] = response["projects"]
-        return projects
 
 
 class JiraService:

--- a/jbi/steps.py
+++ b/jbi/steps.py
@@ -35,8 +35,8 @@ class StepStatus(Enum):
 # https://docs.python.org/3.11/library/typing.html#typing.TYPE_CHECKING
 if TYPE_CHECKING:
     from jbi.bugzilla.service import BugzillaService
+    from jbi.jira.service import JiraService
     from jbi.models import ActionContext, ActionParams
-    from jbi.services.jira import JiraService
 
     StepResult = tuple[StepStatus, ActionContext]
 

--- a/jbi/steps.py
+++ b/jbi/steps.py
@@ -35,7 +35,7 @@ class StepStatus(Enum):
 # https://docs.python.org/3.11/library/typing.html#typing.TYPE_CHECKING
 if TYPE_CHECKING:
     from jbi.bugzilla.service import BugzillaService
-    from jbi.jira.service import JiraService
+    from jbi.jira import JiraService
     from jbi.models import ActionContext, ActionParams
 
     StepResult = tuple[StepStatus, ActionContext]

--- a/jbi/steps.py
+++ b/jbi/steps.py
@@ -34,8 +34,8 @@ class StepStatus(Enum):
 
 # https://docs.python.org/3.11/library/typing.html#typing.TYPE_CHECKING
 if TYPE_CHECKING:
+    from jbi.bugzilla.service import BugzillaService
     from jbi.models import ActionContext, ActionParams
-    from jbi.services.bugzilla import BugzillaService
     from jbi.services.jira import JiraService
 
     StepResult = tuple[StepStatus, ActionContext]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,7 +51,7 @@ def capturelogs(request):
 
 @pytest.fixture(autouse=True)
 def mocked_statsd():
-    with mock.patch("jbi.services.common.statsd") as _mocked_statsd:
+    with mock.patch("jbi.common.instrument.statsd") as _mocked_statsd:
         yield _mocked_statsd
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,12 +10,12 @@ from fastapi.testclient import TestClient
 from pytest_factoryboy import register
 
 import tests.fixtures.factories as factories
-from jbi import Operation
+from jbi import Operation, bugzilla
 from jbi.app import app
 from jbi.configuration import get_actions
 from jbi.environment import Settings
 from jbi.models import ActionContext
-from jbi.services import bugzilla, jira
+from jbi.services import jira
 
 
 class FilteredLogCaptureFixture(pytest.LogCaptureFixture):
@@ -98,7 +98,7 @@ def mocked_bugzilla(request):
         yield None
         bugzilla.get_service.cache_clear()
     else:
-        with mock.patch("jbi.services.bugzilla.BugzillaClient") as mocked_bz:
+        with mock.patch("jbi.bugzilla.service.BugzillaClient") as mocked_bz:
             yield mocked_bz()
             bugzilla.get_service.cache_clear()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,12 +10,11 @@ from fastapi.testclient import TestClient
 from pytest_factoryboy import register
 
 import tests.fixtures.factories as factories
-from jbi import Operation, bugzilla
+from jbi import Operation, bugzilla, jira
 from jbi.app import app
 from jbi.configuration import get_actions
 from jbi.environment import Settings
 from jbi.models import ActionContext
-from jbi.services import jira
 
 
 class FilteredLogCaptureFixture(pytest.LogCaptureFixture):
@@ -109,7 +108,7 @@ def mocked_jira(request):
         yield None
         jira.get_service.cache_clear()
     else:
-        with mock.patch("jbi.services.jira.JiraClient") as mocked_jira:
+        with mock.patch("jbi.jira.service.JiraClient") as mocked_jira:
             yield mocked_jira()
             jira.get_service.cache_clear()
 

--- a/tests/unit/bugzilla/test_client.py
+++ b/tests/unit/bugzilla/test_client.py
@@ -2,9 +2,8 @@ import pytest
 import responses
 from responses import matchers
 
-from jbi.environment import get_settings
+from jbi.bugzilla.client import BugzillaClient, BugzillaClientError
 from jbi.models import BugzillaWebhookRequest
-from jbi.services.bugzilla import BugzillaClientError, get_service
 
 
 @pytest.fixture
@@ -21,12 +20,20 @@ def webhook_private_comment_example(
     return webhook_payload
 
 
+@pytest.fixture
+def bugzilla_client(settings):
+    return BugzillaClient(
+        base_url=settings.bugzilla_base_url, api_key=settings.bugzilla_api_key
+    )
+
+
 @pytest.mark.no_mocked_bugzilla
-def test_timer_is_used_on_bugzilla_get_comments(mocked_responses, mocked_statsd):
-    bugzilla_client = get_service().client
+def test_timer_is_used_on_bugzilla_get_comments(
+    bugzilla_client, settings, mocked_responses, mocked_statsd
+):
     mocked_responses.add(
         "GET",
-        f"{get_settings().bugzilla_base_url}/rest/bug/42/comment",
+        f"{settings.bugzilla_base_url}/rest/bug/42/comment",
         json={
             "bugs": {"42": {"comments": []}},
         },
@@ -36,8 +43,10 @@ def test_timer_is_used_on_bugzilla_get_comments(mocked_responses, mocked_statsd)
 
 
 @pytest.mark.no_mocked_bugzilla
-def test_bugzilla_methods_are_retried_if_raising(mocked_responses):
-    url = f"{get_settings().bugzilla_base_url}/rest/bug/42/comment"
+def test_bugzilla_methods_are_retried_if_raising(
+    bugzilla_client, settings, mocked_responses
+):
+    url = f"{settings.bugzilla_base_url}/rest/bug/42/comment"
     mocked_responses.add(responses.GET, url, status=503, json={})
     mocked_responses.add(
         responses.GET,
@@ -48,14 +57,14 @@ def test_bugzilla_methods_are_retried_if_raising(mocked_responses):
     )
 
     # Not raising
-    get_service().client.get_comments(42)
+    bugzilla_client.get_comments(42)
 
     assert len(mocked_responses.calls) == 2
 
 
 @pytest.mark.no_mocked_bugzilla
-def test_bugzilla_key_is_passed_in_header(mocked_responses):
-    url = f"{get_settings().bugzilla_base_url}/rest/whoami"
+def test_bugzilla_key_is_passed_in_header(bugzilla_client, settings, mocked_responses):
+    url = f"{settings.bugzilla_base_url}/rest/whoami"
     mocked_responses.add(
         responses.GET,
         url,
@@ -65,7 +74,7 @@ def test_bugzilla_key_is_passed_in_header(mocked_responses):
         ],
     )
 
-    assert get_service().client.logged_in()
+    assert bugzilla_client.logged_in()
 
     assert len(mocked_responses.calls) == 1
     # The following assertion is redundant with matchers but also more explicit.
@@ -73,46 +82,52 @@ def test_bugzilla_key_is_passed_in_header(mocked_responses):
 
 
 @pytest.mark.no_mocked_bugzilla
-def test_bugzilla_raises_if_response_has_error(mocked_responses):
-    url = f"{get_settings().bugzilla_base_url}/rest/bug/42"
+def test_bugzilla_raises_if_response_has_error(
+    bugzilla_client, settings, mocked_responses
+):
+    url = f"{settings.bugzilla_base_url}/rest/bug/42"
     mocked_responses.add(
         responses.GET, url, json={"error": True, "message": "not happy"}
     )
 
     with pytest.raises(BugzillaClientError) as exc:
-        get_service().client.get_bug(42)
+        bugzilla_client.get_bug(42)
 
     assert "not happy" in str(exc)
 
 
 @pytest.mark.no_mocked_bugzilla
-def test_bugzilla_get_bug_raises_if_response_has_no_bugs(mocked_responses):
-    url = f"{get_settings().bugzilla_base_url}/rest/bug/42"
+def test_bugzilla_get_bug_raises_if_response_has_no_bugs(
+    bugzilla_client, settings, mocked_responses
+):
+    url = f"{settings.bugzilla_base_url}/rest/bug/42"
     mocked_responses.add(responses.GET, url, json={"bugs": []})
 
     with pytest.raises(BugzillaClientError) as exc:
-        get_service().client.get_bug(42)
+        bugzilla_client.get_bug(42)
 
     assert "Unexpected response" in str(exc)
 
 
 @pytest.mark.no_mocked_bugzilla
-def test_bugzilla_get_comments_raises_if_response_has_no_bugs(mocked_responses):
-    url = f"{get_settings().bugzilla_base_url}/rest/bug/42/comment"
+def test_bugzilla_get_comments_raises_if_response_has_no_bugs(
+    bugzilla_client, settings, mocked_responses
+):
+    url = f"{settings.bugzilla_base_url}/rest/bug/42/comment"
     mocked_responses.add(responses.GET, url, json={"bugs": {"42": {}}})
 
     with pytest.raises(BugzillaClientError) as exc:
-        get_service().client.get_comments(42)
+        bugzilla_client.get_comments(42)
 
     assert "Unexpected response" in str(exc)
 
 
 @pytest.mark.no_mocked_bugzilla
-def test_bugzilla_update_bug_uses_a_put(mocked_responses):
-    url = f"{get_settings().bugzilla_base_url}/rest/bug/42"
+def test_bugzilla_update_bug_uses_a_put(bugzilla_client, settings, mocked_responses):
+    url = f"{settings.bugzilla_base_url}/rest/bug/42"
     mocked_responses.add(responses.PUT, url, json={"bugs": [{"id": 42}]})
 
-    get_service().client.update_bug(42, see_also={"add": ["http://url.com"]})
+    bugzilla_client.update_bug(42, see_also={"add": ["http://url.com"]})
 
     assert (
         mocked_responses.calls[0].request.body
@@ -121,10 +136,12 @@ def test_bugzilla_update_bug_uses_a_put(mocked_responses):
 
 
 @pytest.mark.no_mocked_bugzilla
-def test_bugzilla_get_bug_comment(mocked_responses, webhook_private_comment_example):
+def test_bugzilla_get_bug_comment(
+    bugzilla_client, settings, mocked_responses, webhook_private_comment_example
+):
     # given
     bug_url = (
-        f"{get_settings().bugzilla_base_url}/rest/bug/%s"
+        f"{settings.bugzilla_base_url}/rest/bug/%s"
         % webhook_private_comment_example.bug.id
     )
     mocked_responses.add(
@@ -164,7 +181,7 @@ def test_bugzilla_get_bug_comment(mocked_responses, webhook_private_comment_exam
         },
     )
 
-    expanded = get_service().client.get_bug(webhook_private_comment_example.bug.id)
+    expanded = bugzilla_client.get_bug(webhook_private_comment_example.bug.id)
 
     # then
     assert expanded.comment.creator == "mathieu@mozilla.org"
@@ -173,11 +190,13 @@ def test_bugzilla_get_bug_comment(mocked_responses, webhook_private_comment_exam
 
 @pytest.mark.no_mocked_bugzilla
 def test_bugzilla_missing_private_comment(
+    bugzilla_client,
+    settings,
     mocked_responses,
     webhook_private_comment_example,
 ):
     bug_url = (
-        f"{get_settings().bugzilla_base_url}/rest/bug/%s"
+        f"{settings.bugzilla_base_url}/rest/bug/%s"
         % webhook_private_comment_example.bug.id
     )
     mocked_responses.add(
@@ -194,14 +213,14 @@ def test_bugzilla_missing_private_comment(
         },
     )
 
-    expanded = get_service().client.get_bug(webhook_private_comment_example.bug.id)
+    expanded = bugzilla_client.get_bug(webhook_private_comment_example.bug.id)
 
     assert not expanded.comment
 
 
 @pytest.mark.no_mocked_bugzilla
-def test_bugzilla_list_webhooks(mocked_responses):
-    url = f"{get_settings().bugzilla_base_url}/rest/webhooks/list"
+def test_bugzilla_list_webhooks(bugzilla_client, settings, mocked_responses):
+    url = f"{settings.bugzilla_base_url}/rest/webhooks/list"
     mocked_responses.add(
         responses.GET,
         url,
@@ -222,7 +241,7 @@ def test_bugzilla_list_webhooks(mocked_responses):
         },
     )
 
-    webhooks = get_service().client.list_webhooks()
+    webhooks = bugzilla_client.list_webhooks()
 
     assert len(webhooks) == 1
     assert webhooks[0].event == "create,change,comment"
@@ -230,11 +249,13 @@ def test_bugzilla_list_webhooks(mocked_responses):
 
 
 @pytest.mark.no_mocked_bugzilla
-def test_bugzilla_list_webhooks_raises_if_response_has_no_webhooks(mocked_responses):
-    url = f"{get_settings().bugzilla_base_url}/rest/webhooks/list"
+def test_bugzilla_list_webhooks_raises_if_response_has_no_webhooks(
+    bugzilla_client, settings, mocked_responses
+):
+    url = f"{settings.bugzilla_base_url}/rest/webhooks/list"
     mocked_responses.add(responses.GET, url, json={})
 
     with pytest.raises(BugzillaClientError) as exc:
-        get_service().client.list_webhooks()
+        bugzilla_client.list_webhooks()
 
     assert "Unexpected response" in str(exc)

--- a/tests/unit/jira/test_client.py
+++ b/tests/unit/jira/test_client.py
@@ -1,0 +1,104 @@
+import logging
+
+import pytest
+import requests
+import responses
+
+from jbi.jira.client import JiraClient
+
+
+@pytest.fixture
+def jira_client(settings):
+    return JiraClient(
+        url=settings.jira_base_url,
+        username=settings.jira_username,
+        password=settings.jira_api_key,
+        cloud=True,
+    )
+
+
+def test_jira_create_issue_is_instrumented(
+    settings, jira_client, mocked_responses, context_create_example, mocked_statsd
+):
+    url = f"{settings.jira_base_url}rest/api/2/issue"
+    mocked_responses.add(
+        responses.POST,
+        url,
+        json={
+            "id": "10000",
+            "key": "ED-24",
+        },
+    )
+
+    jira_client.create_issue({})
+
+    mocked_statsd.incr.assert_called_with("jbi.jira.methods.create_issue.count")
+    mocked_statsd.timer.assert_called_with("jbi.jira.methods.create_issue.timer")
+
+
+def test_jira_calls_log_http_errors(
+    settings, jira_client, mocked_responses, context_create_example, caplog
+):
+    url = f"{settings.jira_base_url}rest/api/2/project/{context_create_example.jira.project}/components"
+    mocked_responses.add(
+        responses.GET,
+        url,
+        status=404,
+        json={
+            "errorMessages": ["No project could be found with key 'X'."],
+            "errors": {},
+        },
+    )
+
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(requests.HTTPError):
+            jira_client.get_project_components(context_create_example.jira.project)
+
+    log_messages = [log.msg % log.args for log in caplog.records]
+    idx = log_messages.index(
+        "HTTP: GET /rest/api/2/project/JBI/components -> 404 Not Found"
+    )
+    log_record = caplog.records[idx]
+    assert (
+        log_record.body
+        == '{"errorMessages": ["No project could be found with key \'X\'."], "errors": {}}'
+    )
+
+
+def test_paginated_projects_no_keys(settings, jira_client, mocked_responses):
+    url = f"{settings.jira_base_url}rest/api/2/project/search"
+    mocked_response_data = {"some": "data"}
+    mocked_responses.add(
+        responses.GET,
+        url,
+        status=200,
+        match=[responses.matchers.query_string_matcher(None)],
+        json=mocked_response_data,
+    )
+    resp = jira_client.paginated_projects()
+    assert resp == mocked_response_data
+
+
+def test_paginated_projects_with_keys(
+    settings, jira_client, mocked_responses, action_factory
+):
+    action_factory()
+    url = f"{settings.jira_base_url}rest/api/2/project/search"
+    mocked_response_data = {"some": "data"}
+    mocked_responses.add(
+        responses.GET,
+        url,
+        status=200,
+        match=[responses.matchers.query_string_matcher("keys=ABC&keys=DEF")],
+        json=mocked_response_data,
+    )
+    resp = jira_client.paginated_projects(keys=["ABC", "DEF"])
+    assert resp == mocked_response_data
+
+
+def test_paginated_projects_greater_than_50_keys(
+    settings, jira_client, mocked_responses
+):
+    keys = [str(i) for i in range(51)]
+    with pytest.raises(ValueError):
+        jira_client.paginated_projects(keys=keys)

--- a/tests/unit/jira/test_service.py
+++ b/tests/unit/jira/test_service.py
@@ -18,7 +18,7 @@ def jira_service(settings):
         cloud=True,
     )
 
-    return jira.service.JiraService(client=client)
+    return jira.JiraService(client=client)
 
 
 def test_jira_retries_failing_connections_in_health_check(

--- a/tests/unit/test_router.py
+++ b/tests/unit/test_router.py
@@ -224,7 +224,7 @@ def test_heartbeat_bugzilla_reports_webhooks_errors(
         bugzilla_webhook_factory(id=2, errors=3, name="Search Toolbar"),
     ]
 
-    with mock.patch("jbi.services.bugzilla.statsd") as mocked:
+    with mock.patch("jbi.bugzilla.service.statsd") as mocked:
         anon_client.get("/__heartbeat__")
 
     mocked.gauge.assert_any_call(

--- a/tests/unit/test_steps.py
+++ b/tests/unit/test_steps.py
@@ -6,9 +6,10 @@ import requests
 
 from jbi import Operation, steps
 from jbi.environment import get_settings
+from jbi.jira import JiraService
+from jbi.jira.client import JiraCreateError
 from jbi.models import ActionContext, JiraComponents
 from jbi.runner import Executor
-from jbi.services.jira import JiraCreateError, JiraService
 
 ALL_STEPS = {
     "new": [


### PR DESCRIPTION
In this PR, we introduce a slightly new structure for the code we use to communicate with Jira and Bugzilla.

Before, we had a `services` package with a `jira` and `bugzilla` module. 
```
jbi
├── services
    ├── __init__.py
    ├── bugzilla.py
    ├── common.py
    └── jira.py
```
Each of those modules had a `*Client` and `*Service` class.

Now, we do essentially the same thing, except we have:

```
jbi
├── bugzilla
│   ├── __init__.py
│   ├── client.py
│   └── service.py
├── common
│   ├── __init__.py
│   └── instrument.py
└── jira
    ├── __init__.py
    ├── client.py
    └── service.py
```

this is to:
  - reinforce the separate concerns of a `client` and `service`, especially in tests
    - a client should only make HTTP requests and receive responses
    - services should use clients to do higher-level project operations
  - allow for the continued encapsulation of different domains. For example, instead of one `models` module, it might make sense to move certain models under specific namespaces