### PR TITLE
Mark all pydantic models as `frozen`

### DIFF
--- a/jbi/bugzilla/service.py
+++ b/jbi/bugzilla/service.py
@@ -93,11 +93,11 @@ class BugzillaService:
     def refresh_bug_data(self, bug: BugzillaBug):
         """Re-fetch a bug to ensure we have the most up-to-date data"""
 
-        updated_bug = self.client.get_bug(bug.id)
+        refreshed_bug_data = self.client.get_bug(bug.id)
         # When bugs come in as webhook payloads, they have a "comment"
         # attribute, but this field isn't available when we get a bug by ID.
         # So, we make sure to add the comment back if it was present on the bug.
-        updated_bug.comment = bug.comment
+        updated_bug = refreshed_bug_data.model_copy(update={"comment": bug.comment})
         return updated_bug
 
     def list_webhooks(self):

--- a/jbi/log.py
+++ b/jbi/log.py
@@ -78,7 +78,7 @@ CONFIG = {
 }
 
 
-class RequestSummary(BaseModel):
+class RequestSummary(BaseModel, frozen=True):
     """Request summary as specified by MozLog format"""
 
     agent: str

--- a/jbi/models.py
+++ b/jbi/models.py
@@ -29,7 +29,7 @@ logger = logging.getLogger(__name__)
 JIRA_HOSTNAMES = ("jira", "atlassian")
 
 
-class ActionSteps(BaseModel):
+class ActionSteps(BaseModel, frozen=True):
     """Step functions to run for each type of Bugzilla webhook payload"""
 
     new: list[str] = [
@@ -63,7 +63,7 @@ class ActionSteps(BaseModel):
         return function_names
 
 
-class JiraComponents(BaseModel):
+class JiraComponents(BaseModel, frozen=True):
     """Controls how Jira components are set on issues in the `maybe_update_components` step."""
 
     use_bug_component: bool = True
@@ -72,7 +72,7 @@ class JiraComponents(BaseModel):
     set_custom_components: list[str] = []
 
 
-class ActionParams(BaseModel):
+class ActionParams(BaseModel, frozen=True):
     """Params passed to Action step functions"""
 
     jira_project_key: str
@@ -84,7 +84,7 @@ class ActionParams(BaseModel):
     issue_type_map: dict[str, str] = {"task": "Task", "defect": "Bug"}
 
 
-class Action(BaseModel):
+class Action(BaseModel, frozen=True):
     """
     Action is the inner model for each action in the configuration file"""
 
@@ -164,7 +164,7 @@ class Actions(RootModel):
     model_config = ConfigDict(ignored_types=(functools.cached_property,))
 
 
-class BugzillaWebhookUser(BaseModel):
+class BugzillaWebhookUser(BaseModel, frozen=True):
     """Bugzilla User Object"""
 
     id: int
@@ -172,17 +172,15 @@ class BugzillaWebhookUser(BaseModel):
     real_name: str
 
 
-class BugzillaWebhookEventChange(BaseModel):
+class BugzillaWebhookEventChange(BaseModel, frozen=True, coerce_numbers_to_str=True):
     """Bugzilla Change Object"""
-
-    model_config = ConfigDict(coerce_numbers_to_str=True)
 
     field: str
     removed: str
     added: str
 
 
-class BugzillaWebhookEvent(BaseModel):
+class BugzillaWebhookEvent(BaseModel, frozen=True):
     """Bugzilla Event Object"""
 
     action: str
@@ -198,7 +196,7 @@ class BugzillaWebhookEvent(BaseModel):
         return [c.field for c in self.changes] if self.changes else []
 
 
-class BugzillaWebhookComment(BaseModel):
+class BugzillaWebhookComment(BaseModel, frozen=True):
     """Bugzilla Comment Object"""
 
     body: Optional[str] = None
@@ -208,7 +206,7 @@ class BugzillaWebhookComment(BaseModel):
     creation_time: Optional[datetime.datetime] = None
 
 
-class BugzillaBug(BaseModel):
+class BugzillaBug(BaseModel, frozen=True):
     """Bugzilla Bug Object"""
 
     id: int
@@ -293,7 +291,7 @@ class BugzillaBug(BaseModel):
         raise ActionNotFoundError(", ".join(actions.by_tag.keys()))
 
 
-class BugzillaWebhookRequest(BaseModel):
+class BugzillaWebhookRequest(BaseModel, frozen=True):
     """Bugzilla Webhook Request Object"""
 
     webhook_id: int
@@ -302,7 +300,7 @@ class BugzillaWebhookRequest(BaseModel):
     bug: BugzillaBug
 
 
-class BugzillaComment(BaseModel):
+class BugzillaComment(BaseModel, frozen=True):
     """Bugzilla Comment"""
 
     id: int
@@ -314,14 +312,14 @@ class BugzillaComment(BaseModel):
 BugzillaComments = TypeAdapter(list[BugzillaComment])
 
 
-class BugzillaApiResponse(BaseModel):
+class BugzillaApiResponse(BaseModel, frozen=True):
     """Bugzilla Response Object"""
 
     faults: Optional[list] = None
     bugs: Optional[list[BugzillaBug]] = None
 
 
-class BugzillaWebhook(BaseModel):
+class BugzillaWebhook(BaseModel, frozen=True):
     """Bugzilla Webhook"""
 
     id: int
@@ -343,13 +341,13 @@ class BugzillaWebhook(BaseModel):
         return f"{self.id}-{name}-{product}"
 
 
-class BugzillaWebhooksResponse(BaseModel):
+class BugzillaWebhooksResponse(BaseModel, frozen=True):
     """Bugzilla Webhooks List Response Object"""
 
     webhooks: Optional[list[BugzillaWebhook]] = None
 
 
-class Context(BaseModel):
+class Context(BaseModel, frozen=True):
     """Generic log context throughout JBI"""
 
     def update(self, **kwargs):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -70,7 +70,6 @@ register(factories.WebhookUserFactory)
 register(
     factories.ActionContextFactory, "context_create_example", operation=Operation.CREATE
 )
-register(factories.WebhookFactory, "webhook_create_example")
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,6 @@ from pytest_factoryboy import register
 import tests.fixtures.factories as factories
 from jbi import Operation, bugzilla, jira
 from jbi.app import app
-from jbi.configuration import get_actions
 from jbi.environment import Settings
 from jbi.models import ActionContext
 
@@ -56,7 +55,7 @@ def mocked_statsd():
 
 register(factories.ActionContextFactory)
 register(factories.ActionFactory)
-register(factories.ActionsFactory)
+register(factories.ActionsFactory, "_actions")
 register(factories.ActionParamsFactory)
 register(factories.BugFactory)
 register(factories.BugzillaWebhookFactory)
@@ -86,9 +85,9 @@ def settings():
     return Settings()
 
 
-@pytest.fixture(autouse=True)
-def actions():
-    return get_actions()
+@pytest.fixture()
+def actions(actions_factory):
+    return actions_factory()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/fixtures/factories.py
+++ b/tests/fixtures/factories.py
@@ -173,19 +173,3 @@ class BugzillaWebhookFactory(PydanticFactory):
     name = "Test Webhooks"
     product = "Firefox"
     url = "http://server.example.com/bugzilla_webhook"
-
-
-__all__ = [
-    "ActionContextFactory",
-    "ActionFactory",
-    "ActionParamsFactory",
-    "ActionsFactory",
-    "BugFactory",
-    "BugzillaWebhookFactory",
-    "CommentFactory",
-    "JiraContextFactory",
-    "WebhookEventChangeFactory",
-    "WebhookEventFactory",
-    "WebhookFactory",
-    "WebhookUserFactory",
-]

--- a/tests/fixtures/factories.py
+++ b/tests/fixtures/factories.py
@@ -3,7 +3,24 @@ import factory
 from jbi import Operation, models
 
 
-class ActionParamsFactory(factory.Factory):
+class PydanticFactory(factory.Factory):
+    """
+    - factory_instance(**kwargs) -> Model(**kwargs)
+    - factory_instance.create(**kwargs) -> Model(**kwargs)
+    - factory_instance.build(**kwargs) -> Model.model_construct(**kwargs)
+    
+    https://docs.pydantic.dev/latest/api/base_model/#pydantic.main.BaseModel.model_construct
+    """
+
+    class Meta:
+        abstract = True
+
+    @classmethod
+    def _build(cls, model_class, *args, **kwargs):
+        return model_class.model_construct(**kwargs)
+
+
+class ActionParamsFactory(PydanticFactory):
     class Meta:
         model = models.ActionParams
 
@@ -15,7 +32,7 @@ class ActionParamsFactory(factory.Factory):
     issue_type_map = {"task": "Task", "defect": "Bug"}
 
 
-class ActionFactory(factory.Factory):
+class ActionFactory(PydanticFactory):
     class Meta:
         model = models.Action
 
@@ -25,14 +42,14 @@ class ActionFactory(factory.Factory):
     parameters = factory.SubFactory(ActionParamsFactory)
 
 
-class ActionsFactory(factory.Factory):
+class ActionsFactory(PydanticFactory):
     class Meta:
         model = models.Actions
 
     root = factory.List([factory.SubFactory(ActionFactory)])
 
 
-class BugzillaWebhookCommentFactory(factory.Factory):
+class BugzillaWebhookCommentFactory(PydanticFactory):
     class Meta:
         model = models.BugzillaWebhookComment
 
@@ -43,7 +60,7 @@ class BugzillaWebhookCommentFactory(factory.Factory):
     creation_time = None
 
 
-class BugFactory(factory.Factory):
+class BugFactory(PydanticFactory):
     class Meta:
         model = models.BugzillaBug
 
@@ -71,7 +88,7 @@ class BugFactory(factory.Factory):
     whiteboard = "[devtest]"
 
 
-class WebhookUserFactory(factory.Factory):
+class WebhookUserFactory(PydanticFactory):
     class Meta:
         model = models.BugzillaWebhookUser
 
@@ -80,7 +97,7 @@ class WebhookUserFactory(factory.Factory):
     real_name = "Nobody [ :nobody ]"
 
 
-class WebhookEventChangeFactory(factory.Factory):
+class WebhookEventChangeFactory(PydanticFactory):
     class Meta:
         model = models.BugzillaWebhookEventChange
 
@@ -89,7 +106,7 @@ class WebhookEventChangeFactory(factory.Factory):
     added = "new value"
 
 
-class WebhookEventFactory(factory.Factory):
+class WebhookEventFactory(PydanticFactory):
     class Meta:
         model = models.BugzillaWebhookEvent
 
@@ -101,7 +118,7 @@ class WebhookEventFactory(factory.Factory):
     user = factory.SubFactory(WebhookUserFactory)
 
 
-class WebhookFactory(factory.Factory):
+class WebhookFactory(PydanticFactory):
     class Meta:
         model = models.BugzillaWebhookRequest
 
@@ -111,7 +128,7 @@ class WebhookFactory(factory.Factory):
     webhook_name = "local-test"
 
 
-class CommentFactory(factory.Factory):
+class CommentFactory(PydanticFactory):
     class Meta:
         model = models.BugzillaComment
 
@@ -123,7 +140,7 @@ class CommentFactory(factory.Factory):
     creator = "mathieu@mozilla.org"
 
 
-class JiraContextFactory(factory.Factory):
+class JiraContextFactory(PydanticFactory):
     class Meta:
         model = models.JiraContext
 
@@ -132,7 +149,7 @@ class JiraContextFactory(factory.Factory):
     labels = []
 
 
-class ActionContextFactory(factory.Factory):
+class ActionContextFactory(PydanticFactory):
     class Meta:
         model = models.ActionContext
 
@@ -143,7 +160,7 @@ class ActionContextFactory(factory.Factory):
     jira = factory.SubFactory(JiraContextFactory)
 
 
-class BugzillaWebhookFactory(factory.Factory):
+class BugzillaWebhookFactory(PydanticFactory):
     class Meta:
         model = models.BugzillaWebhook
 

--- a/tests/fixtures/factories.py
+++ b/tests/fixtures/factories.py
@@ -8,7 +8,7 @@ class PydanticFactory(factory.Factory):
     - factory_instance(**kwargs) -> Model(**kwargs)
     - factory_instance.create(**kwargs) -> Model(**kwargs)
     - factory_instance.build(**kwargs) -> Model.model_construct(**kwargs)
-    
+
     https://docs.pydantic.dev/latest/api/base_model/#pydantic.main.BaseModel.model_construct
     """
 

--- a/tests/unit/jira/test_client.py
+++ b/tests/unit/jira/test_client.py
@@ -79,10 +79,7 @@ def test_paginated_projects_no_keys(settings, jira_client, mocked_responses):
     assert resp == mocked_response_data
 
 
-def test_paginated_projects_with_keys(
-    settings, jira_client, mocked_responses, action_factory
-):
-    action_factory()
+def test_paginated_projects_with_keys(settings, jira_client, mocked_responses):
     url = f"{settings.jira_base_url}rest/api/2/project/search"
     mocked_response_data = {"some": "data"}
     mocked_responses.add(

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -37,12 +37,12 @@ def test_request_summary_defaults_user_agent_to_empty_string(caplog, anon_client
         assert summary.agent == ""
 
 
-def test_422_errors_are_logged(webhook_create_example, caplog):
-    webhook_create_example.bug = None
+def test_422_errors_are_logged(webhook_factory, caplog):
+    webhook = webhook_factory.build(bug=None)
 
     with TestClient(app) as anon_client:
         with caplog.at_level(logging.INFO):
-            anon_client.post("/bugzilla_webhook", data=webhook_create_example.json())
+            anon_client.post("/bugzilla_webhook", data=webhook.model_dump_json())
 
     logged = [r for r in caplog.records if r.name == "jbi.app"][0]
     assert logged.errors[0]["loc"] == ("body", "bug")

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -79,13 +79,13 @@ def test_traces_sampler(sampling_context, expected):
 
 
 def test_errors_are_reported_to_sentry(
-    anon_client, webhook_create_example: BugzillaWebhookRequest
+    anon_client, bugzilla_webhook_request: BugzillaWebhookRequest
 ):
     with patch("sentry_sdk.hub.Hub.capture_event") as mocked:
         with patch("jbi.router.execute_action", side_effect=ValueError):
             with pytest.raises(ValueError):
                 anon_client.post(
-                    "/bugzilla_webhook", data=webhook_create_example.model_dump_json()
+                    "/bugzilla_webhook", data=bugzilla_webhook_request.model_dump_json()
                 )
 
     assert mocked.called, "Sentry captured the exception"
@@ -93,11 +93,11 @@ def test_errors_are_reported_to_sentry(
 
 def test_request_id_is_passed_down_to_logger_contexts(
     caplog,
-    webhook_create_example: BugzillaWebhookRequest,
+    bugzilla_webhook_request: BugzillaWebhookRequest,
     mocked_jira,
     mocked_bugzilla,
 ):
-    mocked_bugzilla.get_bug.return_value = webhook_create_example.bug
+    mocked_bugzilla.get_bug.return_value = bugzilla_webhook_request.bug
     mocked_jira.create_issue.return_value = {
         "key": "JBI-1922",
     }
@@ -105,7 +105,7 @@ def test_request_id_is_passed_down_to_logger_contexts(
         with TestClient(app) as anon_client:
             anon_client.post(
                 "/bugzilla_webhook",
-                data=webhook_create_example.model_dump_json(),
+                data=bugzilla_webhook_request.model_dump_json(),
                 headers={
                     "X-Request-Id": "foo-bar",
                 },

--- a/tests/unit/test_configuration.py
+++ b/tests/unit/test_configuration.py
@@ -20,7 +20,7 @@ def test_actual_jbi_files():
     )
 
 
-def test_filename_uses_env(mocker, actions, settings):
+def test_filename_uses_env(mocker, settings):
     get_actions_from_file_spy = mocker.spy(configuration, "get_actions_from_file")
     assert settings.env == "local"
 

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -119,9 +119,9 @@ def test_product_component(product, component, expected, bug_factory):
         "[example][DevTest][example]",
     ],
 )
-def test_lookup_action_found(whiteboard, actions_factory, bug_factory):
+def test_lookup_action_found(whiteboard, actions, bug_factory):
     bug = bug_factory(id=1234, whiteboard=whiteboard)
-    action = bug.lookup_action(actions_factory())
+    action = bug.lookup_action(actions)
     assert action.whiteboard_tag == "devtest"
     assert "test config" in action.description
 
@@ -148,10 +148,10 @@ def test_lookup_action_found(whiteboard, actions_factory, bug_factory):
         "[foo] devtest [bar]",
     ],
 )
-def test_lookup_action_not_found(whiteboard, actions_factory, bug_factory):
+def test_lookup_action_not_found(whiteboard, actions, bug_factory):
     bug = bug_factory(id=1234, whiteboard=whiteboard)
     with pytest.raises(ActionNotFoundError) as exc_info:
-        bug.lookup_action(actions_factory())
+        bug.lookup_action(actions)
     assert str(exc_info.value) == "devtest"
 
 

--- a/tests/unit/test_router.py
+++ b/tests/unit/test_router.py
@@ -301,11 +301,11 @@ def test_jira_heartbeat_unknown_issue_types(anon_client, mocked_jira):
 
 @pytest.mark.parametrize("method", ["HEAD", "GET"])
 def test_read_heartbeat_success(
-    anon_client, method, mocked_jira, mocked_bugzilla, bugzilla_webhook_factory
+    anon_client, method, mocked_jira, mocked_bugzilla, bugzilla_webhook
 ):
     """/__heartbeat__ returns 200 when checks succeed."""
     mocked_bugzilla.logged_in.return_value = True
-    mocked_bugzilla.list_webhooks.return_value = [bugzilla_webhook_factory()]
+    mocked_bugzilla.list_webhooks.return_value = [bugzilla_webhook]
     mocked_jira.get_server_info.return_value = {}
     mocked_jira.paginated_projects.return_value = {
         "values": [

--- a/tests/unit/test_router.py
+++ b/tests/unit/test_router.py
@@ -81,11 +81,11 @@ def test_statics_are_served(anon_client):
 
 
 def test_webhook_is_200_if_action_succeeds(
-    webhook_create_example: BugzillaWebhookRequest,
+    bugzilla_webhook_request: BugzillaWebhookRequest,
     mocked_jira,
     mocked_bugzilla,
 ):
-    mocked_bugzilla.get_bug.return_value = webhook_create_example.bug
+    mocked_bugzilla.get_bug.return_value = bugzilla_webhook_request.bug
     mocked_bugzilla.update_bug.return_value = {
         "bugs": [
             {
@@ -109,7 +109,7 @@ def test_webhook_is_200_if_action_succeeds(
 
     with TestClient(app) as anon_client:
         response = anon_client.post(
-            "/bugzilla_webhook", data=webhook_create_example.model_dump_json()
+            "/bugzilla_webhook", data=bugzilla_webhook_request.model_dump_json()
         )
         assert response
         assert response.status_code == 200

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -12,17 +12,6 @@ from jbi.models import ActionContext, BugzillaWebhookRequest
 from jbi.runner import Executor, execute_action
 
 
-@pytest.fixture
-def webhook_comment_example(webhook_factory) -> BugzillaWebhookRequest:
-    return webhook_factory(
-        bug__see_also=["https://mozilla.atlassian.net/browse/JBI-234"],
-        bug__comment__number=2,
-        bug__comment__body="hello",
-        event__target="comment",
-        event__user__login="mathieu@mozilla.org",
-    )
-
-
 def test_bugzilla_object_is_always_fetched(
     mocked_jira, mocked_bugzilla, webhook_create_example, actions_factory, bug_factory
 ):
@@ -34,87 +23,71 @@ def test_bugzilla_object_is_always_fetched(
     mocked_bugzilla.get_bug.return_value = fetched_bug
     mocked_jira.get_issue.return_value = {"fields": {"project": {"key": "JBI"}}}
 
-    execute_action(
-        request=webhook_create_example,
-        actions=actions_factory(),
-    )
+    execute_action(request=webhook_create_example, actions=actions_factory())
 
     mocked_bugzilla.get_bug.assert_called_once_with(webhook_create_example.bug.id)
 
 
 def test_request_is_ignored_because_project_mismatch(
-    webhook_create_example: BugzillaWebhookRequest,
+    webhook_factory,
     actions_factory,
     mocked_jira,
     mocked_bugzilla,
     bug_factory,
+    settings,
 ):
-    bug = bug_factory(
-        id=webhook_create_example.bug.id,
-        see_also=[f"{get_settings().jira_base_url}browse/JBI-234"],
-    )
-    webhook_create_example.bug = bug
-    mocked_bugzilla.get_bug.return_value = bug
+    webhook = webhook_factory(bug__see_also=[f"{settings.jira_base_url}browse/JBI-234"])
+    mocked_bugzilla.get_bug.return_value = webhook.bug
     mocked_jira.get_issue.return_value = {"fields": {"project": {"key": "FXDROID"}}}
 
     with pytest.raises(IgnoreInvalidRequestError) as exc_info:
-        execute_action(
-            request=webhook_create_example,
-            actions=actions_factory(),
-        )
+        execute_action(request=webhook, actions=actions_factory())
 
     assert str(exc_info.value) == "ignore linked project 'FXDROID' (!='JBI')"
 
 
 def test_request_is_ignored_because_private(
-    webhook_create_example: BugzillaWebhookRequest,
+    webhook_factory,
     actions_factory,
     mocked_bugzilla,
     bug_factory,
 ):
-    bug = bug_factory(id=webhook_create_example.bug.id, is_private=True)
-    webhook_create_example.bug = bug
-    mocked_bugzilla.get_bug.return_value = bug
+    webhook = webhook_factory(bug__is_private=True)
+    mocked_bugzilla.get_bug.return_value = webhook.bug
 
     with pytest.raises(IgnoreInvalidRequestError) as exc_info:
-        execute_action(
-            request=webhook_create_example,
-            actions=actions_factory(),
-        )
+        execute_action(request=webhook, actions=actions_factory())
 
     assert str(exc_info.value) == "private bugs are not supported"
 
 
 def test_added_comment_without_linked_issue_is_ignored(
-    webhook_comment_example: BugzillaWebhookRequest,
-    actions_factory,
-    mocked_bugzilla,
+    actions_factory, mocked_bugzilla, webhook_factory
 ):
-    webhook_comment_example.bug.see_also = []
-    mocked_bugzilla.get_bug.return_value = webhook_comment_example.bug
+    webhook_with_comment = webhook_factory(
+        bug__see_also=[],
+        bug__comment__number=2,
+        bug__comment__body="hello",
+        event__target="comment",
+        event__user__login="mathieu@mozilla.org",
+    )
+    mocked_bugzilla.get_bug.return_value = webhook_with_comment.bug
 
     with pytest.raises(IgnoreInvalidRequestError) as exc_info:
-        execute_action(
-            request=webhook_comment_example,
-            actions=actions_factory(),
-        )
+        execute_action(request=webhook_with_comment, actions=actions_factory())
     assert str(exc_info.value) == "ignore event target 'comment'"
 
 
 def test_request_is_ignored_because_no_action(
-    webhook_create_example: BugzillaWebhookRequest,
+    webhook_factory,
     actions_factory,
     mocked_bugzilla,
 ):
-    assert webhook_create_example.bug
-    webhook_create_example.bug.whiteboard = "bar"
-    mocked_bugzilla.get_bug.return_value = webhook_create_example.bug
+    webhook = webhook_factory(bug__whiteboard="bar")
+    mocked_bugzilla.get_bug.return_value = webhook.bug
 
     with pytest.raises(IgnoreInvalidRequestError) as exc_info:
-        execute_action(
-            request=webhook_create_example,
-            actions=actions_factory(),
-        )
+        execute_action(request=webhook, actions=actions_factory())
     assert str(exc_info.value) == "no bug whiteboard matching action tags: devtest"
 
 
@@ -127,10 +100,7 @@ def test_execution_logging_for_successful_requests(
     mocked_bugzilla.get_bug.return_value = webhook_create_example.bug
 
     with capturelogs.for_logger("jbi.runner").at_level(logging.DEBUG):
-        execute_action(
-            request=webhook_create_example,
-            actions=actions_factory(),
-        )
+        execute_action(request=webhook_create_example, actions=actions_factory())
 
     assert {
         "Handling incoming request",
@@ -141,20 +111,16 @@ def test_execution_logging_for_successful_requests(
 
 def test_execution_logging_for_ignored_requests(
     capturelogs,
-    webhook_create_example: BugzillaWebhookRequest,
+    webhook_factory: BugzillaWebhookRequest,
     actions_factory,
     mocked_bugzilla,
 ):
-    assert webhook_create_example.bug
-    webhook_create_example.bug.whiteboard = "foo"
-    mocked_bugzilla.get_bug.return_value = webhook_create_example.bug
+    webhook = webhook_factory(bug__whiteboard="foo")
+    mocked_bugzilla.get_bug.return_value = webhook.bug
 
     with capturelogs.for_logger("jbi.runner").at_level(logging.DEBUG):
         with pytest.raises(IgnoreInvalidRequestError):
-            execute_action(
-                request=webhook_create_example,
-                actions=actions_factory(),
-            )
+            execute_action(request=webhook, actions=actions_factory())
 
     assert capturelogs.messages == [
         "Handling incoming request",
@@ -172,10 +138,7 @@ def test_action_is_logged_as_success_if_returns_true(
 
     with mock.patch("jbi.runner.Executor.__call__", return_value=(True, {})):
         with capturelogs.for_logger("jbi.runner").at_level(logging.DEBUG):
-            execute_action(
-                request=webhook_create_example,
-                actions=actions_factory(),
-            )
+            execute_action(request=webhook_create_example, actions=actions_factory())
 
     captured_log_msgs = [(r.getMessage(), r.operation) for r in capturelogs.records]
 
@@ -201,10 +164,7 @@ def test_action_is_logged_as_ignore_if_returns_false(
 
     with mock.patch("jbi.runner.Executor.__call__", return_value=(False, {})):
         with capturelogs.for_logger("jbi.runner").at_level(logging.DEBUG):
-            execute_action(
-                request=webhook_create_example,
-                actions=actions_factory(),
-            )
+            execute_action(request=webhook_create_example, actions=actions_factory())
 
     captured_log_msgs = [(r.getMessage(), r.operation) for r in capturelogs.records]
 
@@ -219,20 +179,16 @@ def test_action_is_logged_as_ignore_if_returns_false(
 
 
 def test_counter_is_incremented_on_ignored_requests(
-    webhook_create_example: BugzillaWebhookRequest,
+    webhook_factory,
     actions_factory,
     mocked_bugzilla,
 ):
-    assert webhook_create_example.bug
-    webhook_create_example.bug.whiteboard = "foo"
-    mocked_bugzilla.get_bug.return_value = webhook_create_example.bug
+    webhoook = webhook_factory(bug__whiteboard="foo")
+    mocked_bugzilla.get_bug.return_value = webhoook.bug
 
     with mock.patch("jbi.runner.statsd") as mocked:
         with pytest.raises(IgnoreInvalidRequestError):
-            execute_action(
-                request=webhook_create_example,
-                actions=actions_factory(),
-            )
+            execute_action(request=webhoook, actions=actions_factory())
     mocked.incr.assert_called_with("jbi.bugzilla.ignored.count")
 
 
@@ -244,29 +200,26 @@ def test_counter_is_incremented_on_processed_requests(
     mocked_bugzilla.get_bug.return_value = webhook_create_example.bug
 
     with mock.patch("jbi.runner.statsd") as mocked:
-        execute_action(
-            request=webhook_create_example,
-            actions=actions_factory(),
-        )
+        execute_action(request=webhook_create_example, actions=actions_factory())
     mocked.incr.assert_called_with("jbi.bugzilla.processed.count")
 
 
 def test_runner_ignores_if_jira_issue_is_not_readable(
-    webhook_comment_example: BugzillaWebhookRequest,
     actions_factory,
+    webhook_factory,
     mocked_bugzilla,
     mocked_jira,
     capturelogs,
 ):
+    webhook = webhook_factory(
+        bug__see_also=["https://mozilla.atlassian.net/browse/JBI-234"],
+    )
     mocked_jira.get_issue.return_value = None
-    mocked_bugzilla.get_bug.return_value = webhook_comment_example.bug
+    mocked_bugzilla.get_bug.return_value = webhook.bug
 
     with capturelogs.for_logger("jbi.runner").at_level(logging.DEBUG):
         with pytest.raises(IgnoreInvalidRequestError) as exc_info:
-            execute_action(
-                request=webhook_comment_example,
-                actions=actions_factory(),
-            )
+            execute_action(request=webhook, actions=actions_factory())
 
     assert str(exc_info.value) == "ignore unreadable issue JBI-234"
     assert capturelogs.messages == [
@@ -276,22 +229,20 @@ def test_runner_ignores_if_jira_issue_is_not_readable(
 
 
 def test_runner_ignores_request_if_jira_is_linked_but_without_whiteboard(
-    webhook_comment_example: BugzillaWebhookRequest,
+    webhook_factory,
     actions_factory,
     mocked_bugzilla,
 ):
-    mocked_bugzilla.get_bug.return_value = webhook_comment_example.bug
-    webhook_comment_example.bug.whiteboard = "[not-matching-local-config]"
-
-    assert (
-        webhook_comment_example.bug.extract_from_see_also(project_key="foo") is not None
+    webhook = webhook_factory(
+        bug__see_also=["https://mozilla.atlassian.net/browse/JBI-234"],
+        bug__whiteboard="[not-matching-local-config]",
     )
+    mocked_bugzilla.get_bug.return_value = webhook.bug
+
+    assert webhook.bug.extract_from_see_also(project_key="foo") is not None
 
     with pytest.raises(IgnoreInvalidRequestError) as exc_info:
-        execute_action(
-            request=webhook_comment_example,
-            actions=actions_factory(),
-        )
+        execute_action(request=webhook, actions=actions_factory())
 
     assert str(exc_info.value) == "no bug whiteboard matching action tags: devtest"
 
@@ -475,10 +426,7 @@ def test_counter_is_incremented_for_create(
     )
     mocked_bugzilla.get_bug.return_value = webhook_payload.bug
     with mock.patch("jbi.runner.statsd") as mocked:
-        execute_action(
-            request=webhook_factory(),
-            actions=actions_factory(),
-        )
+        execute_action(request=webhook_factory(), actions=actions_factory())
     mocked.incr.assert_any_call("jbi.operation.create.count")
 
 
@@ -492,10 +440,7 @@ def test_counter_is_incremented_for_update(
     mocked_bugzilla.get_bug.return_value = webhook_payload.bug
     mocked_jira.get_issue.return_value = {"fields": {"project": {"key": "JBI"}}}
     with mock.patch("jbi.runner.statsd") as mocked:
-        execute_action(
-            request=webhook_payload,
-            actions=actions_factory(),
-        )
+        execute_action(request=webhook_payload, actions=actions_factory())
     mocked.incr.assert_any_call("jbi.operation.update.count")
 
 
@@ -509,8 +454,5 @@ def test_counter_is_incremented_for_comment(
     mocked_bugzilla.get_bug.return_value = webhook_payload.bug
     mocked_jira.get_issue.return_value = {"fields": {"project": {"key": "JBI"}}}
     with mock.patch("jbi.runner.statsd") as mocked:
-        execute_action(
-            request=webhook_payload,
-            actions=actions_factory(),
-        )
+        execute_action(request=webhook_payload, actions=actions_factory())
     mocked.incr.assert_any_call("jbi.operation.comment.count")


### PR DESCRIPTION
This PR sets [`frozen=True`](https://docs.pydantic.dev/latest/api/config/#pydantic.config.ConfigDict.frozen) on our Pydantic models to enforce "immutability". As immutable as you can get in Python, anyway. 

This change actually didn't have much of an impact on our application code, which is good. Most of the changes involved our test code. These included:

- instead of using a model instance as a fixture then modifying the data in the tests, use factories to create a model with the desired attributes directly in the tests
- in instances where we used a factory without overriding any kwargs (e.g. `bugzilla_webhook_factory()`), use the fixture [provided by pytest-factoryboy when registering the factory](https://pytest-factoryboy.readthedocs.io/en/stable/#model-fixture) instead


