### PR TITLE
Fix #723: format comment with Jira syntax

### DIFF
--- a/jbi/jira/md2jira.py
+++ b/jbi/jira/md2jira.py
@@ -74,12 +74,14 @@ def convert_line(line: str) -> str:
     line = re.sub(r"\[(.+?)\]\((.+?)\)", r"[\1|\2]", line)
     # Strikethrough
     line = re.sub(r"~~(.+?)~~", r"-\1-", line)
+    # Italic.
+    # _this_ but not __this__
+    line = re.sub(r"([^_])_([^_]+?)_", r"\1_\2_", line)
+    # *this* but not **this**
+    line = re.sub(r"([^\*])\*([^\*]+?)\*", r"\1_\2_", line)
     # Bold
     line = re.sub(r"\*\*(.+?)\*\*", r"*\1*", line)
     line = re.sub(r"__(.+?)__", r"*\1*", line)
-    # Italic
-    line = re.sub(r"\*(.+?)\*", r"_\1_", line)
-    line = re.sub(r"_(.+?)_", r"_\1_", line)
     # Monospace
     line = re.sub(r"`+(.+?)`+", r"{{\1}}", line)
     return line

--- a/jbi/jira/md2jira.py
+++ b/jbi/jira/md2jira.py
@@ -1,0 +1,61 @@
+import re
+
+
+def convert(markdown: str) -> str:
+    """
+    Best effort to transform Bugzilla markdown to Jira text formatting.
+    https://jira.atlassian.com/secure/WikiRendererHelpAction.jspa?section=all
+    """
+    result = markdown
+
+    # Convert multiline code blocks
+    result = re.sub(
+        r"```(\w+)?\n(.*?)\n```",
+        lambda match: f"{{code:{match.group(1)}}}\n{match.group(2)}\n{{code}}"
+        if match.group(1)
+        else f"{{code}}\n{match.group(2)}\n{{code}}",
+        result,
+        flags=re.MULTILINE | re.DOTALL,
+    )
+
+    converted = []
+    block = False
+    quote = False
+    for line in result.splitlines():
+        if line.startswith(">"):
+            if not quote:
+                converted.append("{quote}")
+            quote = True
+        else:
+            if quote:
+                converted.append("{quote}")
+            quote = False
+
+        if quote:
+            converted.append(convert_line(re.sub("^>\\s*", "", line)))
+        else:
+            if line.startswith("{code"):
+                block = not block
+            if block:
+                converted.append(line)
+            else:
+                converted.append(convert_line(line))
+
+    return "\n".join(converted)
+
+
+def convert_line(line: str) -> str:
+    # Titles
+    for level in range(7, 0, -1):
+        line = re.sub("^" + ("#" * level) + "\\s*(.+)", f"h{level}. \\1", line)
+    # Links
+    line = re.sub(r"\[(.+?)\]\((.+?)\)", r"[\1|\2]", line)
+    # Strikethrough
+    line = re.sub(r"~~(.+?)~~", r"-\1-", line)
+    # Bold
+    line = re.sub(r"\*\*(.+?)\*\*", r"*\1*", line)
+    line = re.sub(r"__(.+?)__", r"*\1*", line)
+    # Italic
+    line = re.sub(r"\*(.+?)\*", r"_\1_", line)
+    line = re.sub(r"_(.+?)_", r"_\1_", line)
+    return line

--- a/jbi/jira/md2jira.py
+++ b/jbi/jira/md2jira.py
@@ -71,4 +71,6 @@ def convert_line(line: str) -> str:
     # Italic
     line = re.sub(r"\*(.+?)\*", r"_\1_", line)
     line = re.sub(r"_(.+?)_", r"_\1_", line)
+    # Monospace
+    line = re.sub(r"`+(.+?)`+", r"{{\1}}", line)
     return line

--- a/jbi/jira/md2jira.py
+++ b/jbi/jira/md2jira.py
@@ -7,7 +7,7 @@ def convert(markdown: str) -> str:
     https://jira.atlassian.com/secure/WikiRendererHelpAction.jspa?section=all
 
     Known Limitations:
-    - No nested lists
+    - No mixed nested lists
     - No nested quoted text (eg. quote of quote)
     - No images
     - No tables
@@ -61,6 +61,15 @@ def convert_line(line: str) -> str:
     # Titles
     for level in range(7, 0, -1):
         line = re.sub("^" + ("#" * level) + "\\s*(.+)", f"h{level}. \\1", line)
+    # Lists
+    for level in range(4, -1, -1):
+        line = re.sub(
+            "^" + (r"\s{2}" * level) + r"(\*|\-|\d+\.)",
+            lambda match: r"#" * (level + 1)
+            if "." in match.group(1)
+            else match.group(1) * (level + 1),
+            line,
+        )
     # Links
     line = re.sub(r"\[(.+?)\]\((.+?)\)", r"[\1|\2]", line)
     # Strikethrough

--- a/jbi/jira/service.py
+++ b/jbi/jira/service.py
@@ -15,6 +15,7 @@ from requests import exceptions as requests_exceptions
 
 from jbi import Operation, bugzilla, environment
 from jbi.common.instrument import ServiceHealth
+from jbi.jira import md2jira
 from jbi.models import ActionContext
 
 from .client import JiraClient, JiraCreateError
@@ -213,7 +214,7 @@ class JiraService:
         fields: dict[str, Any] = {
             "summary": bug.summary,
             "issuetype": {"name": issue_type},
-            "description": description[:JIRA_DESCRIPTION_CHAR_LIMIT],
+            "description": md2jira.convert(description)[:JIRA_DESCRIPTION_CHAR_LIMIT],
             "project": {"key": context.jira.project},
         }
         logger.debug(
@@ -257,7 +258,7 @@ class JiraService:
 
         issue_key = context.jira.issue
         formatted_comment = (
-            f"*({commenter})* commented: \n{{quote}}{comment.body}{{quote}}"
+            f"*{commenter}* commented: \n{md2jira.convert(comment.body or "")}"
         )
         jira_response = self.client.issue_add_comment(
             issue_key=issue_key,

--- a/tests/unit/jira/test_md2jira.py
+++ b/tests/unit/jira/test_md2jira.py
@@ -1,0 +1,130 @@
+from textwrap import dedent
+
+from jbi.jira.md2jira import convert
+
+
+def test_titles():
+    converted = convert(
+        dedent(
+            """
+    # top
+
+    ## subtitle
+
+    * a list
+    * an item
+    """
+        )
+    )
+    assert converted == dedent(
+        """
+    h1. top
+
+    h2. subtitle
+
+    * a list
+    * an item"""
+    )
+
+
+def test_bold_and_italic():
+    converted = convert(
+        dedent(
+            """
+    this sentence __has__ **bold** and _has_ *italic*
+    """
+        )
+    )
+    assert converted == convert(
+        dedent(
+            """
+    this sentence *has* *bold* and _has_ _italic_
+    """
+        )
+    )
+
+
+def test_strikethrough():
+    converted = convert(
+        dedent(
+            """
+    this was ~~wrong~~
+    """
+        )
+    )
+    assert converted == convert(
+        dedent(
+            """
+    this was -wrong-
+    """
+        )
+    )
+
+
+def test_links():
+    converted = convert(
+        dedent(
+            """
+    there is a [link](http://site.com)
+    """
+        )
+    )
+    assert converted == convert(
+        dedent(
+            """
+    there is a [link|http://site.com]
+    """
+        )
+    )
+
+
+def test_multiline_codeblocks():
+    converted = convert(
+        dedent(
+            """
+    ```py
+    # some code
+    print("hola munda")
+    ```
+
+    ```
+    some code
+    ```
+    """
+        )
+    )
+    assert converted == dedent(
+        """
+    {code:py}
+    # some code
+    print("hola munda")
+    {code}
+
+    {code}
+    some code
+    {code}"""
+    )
+
+
+def test_quotes():
+    converted = convert(
+        dedent(
+            """
+    Some text
+
+    > A previous *text*
+    >
+    my answer
+    """
+        )
+    )
+    assert converted == dedent(
+        """
+    Some text
+
+    {quote}
+    A previous _text_
+
+    {quote}
+    my answer"""
+    )

--- a/tests/unit/jira/test_md2jira.py
+++ b/tests/unit/jira/test_md2jira.py
@@ -75,6 +75,78 @@ def test_monospace():
     )
 
 
+def test_lists():
+    converted = convert(
+        dedent(
+            """
+    A bulleted list
+
+    * some
+    * bullet
+      * indented
+      * bullets
+    * points
+
+    A list item
+
+    - different
+    - bullet
+    - types
+
+    A number list
+
+    1. a
+    2. numbered
+    11. list
+
+    Mixed nested lists
+
+    * a
+    * bulleted
+      * with
+      * nested
+        * nested-nested
+      * numbered
+    * list
+    """
+        )
+    )
+    assert converted == (
+        dedent(
+            """
+    A bulleted list
+
+    * some
+    * bullet
+    ** indented
+    ** bullets
+    * points
+
+    A list item
+
+    - different
+    - bullet
+    - types
+
+    A number list
+
+    # a
+    # numbered
+    # list
+
+    Mixed nested lists
+
+    * a
+    * bulleted
+    ** with
+    ** nested
+    *** nested-nested
+    ** numbered
+    * list"""
+        )
+    )
+
+
 def test_links():
     converted = convert(
         dedent(

--- a/tests/unit/jira/test_md2jira.py
+++ b/tests/unit/jira/test_md2jira.py
@@ -61,6 +61,23 @@ def test_strikethrough():
     )
 
 
+def test_monospace():
+    converted = convert(
+        dedent(
+            """
+    this was `inline` value ``that`` is turned into ```monospace``` tag.
+    """
+        )
+    )
+    assert converted == convert(
+        dedent(
+            """
+    this was {{inline}} value {{that}} is turned into {{monospace}} tag.
+    """
+        )
+    )
+
+
 def test_links():
     converted = convert(
         dedent(

--- a/tests/unit/jira/test_md2jira.py
+++ b/tests/unit/jira/test_md2jira.py
@@ -35,11 +35,10 @@ def test_bold_and_italic():
     """
         )
     )
-    assert converted == convert(
+    assert converted == (
         dedent(
             """
-    this sentence *has* *bold* and _has_ _italic_
-    """
+    this sentence *has* *bold* and _has_ _italic_"""
         )
     )
 
@@ -52,11 +51,10 @@ def test_strikethrough():
     """
         )
     )
-    assert converted == convert(
+    assert converted == (
         dedent(
             """
-    this was -wrong-
-    """
+    this was -wrong-"""
         )
     )
 
@@ -69,11 +67,10 @@ def test_monospace():
     """
         )
     )
-    assert converted == convert(
+    assert converted == (
         dedent(
             """
-    this was {{inline}} value {{that}} is turned into {{monospace}} tag.
-    """
+    this was {{inline}} value {{that}} is turned into {{monospace}} tag."""
         )
     )
 
@@ -86,11 +83,10 @@ def test_links():
     """
         )
     )
-    assert converted == convert(
+    assert converted == (
         dedent(
             """
-    there is a [link|http://site.com]
-    """
+    there is a [link|http://site.com]"""
         )
     )
 

--- a/tests/unit/test_steps.py
+++ b/tests/unit/test_steps.py
@@ -227,7 +227,7 @@ def test_added_comment(
 
     mocked_jira.issue_add_comment.assert_called_once_with(
         issue_key="JBI-234",
-        comment="*(mathieu@mozilla.org)* commented: \n{quote}hello{quote}",
+        comment="*mathieu@mozilla.org* commented: \nhello",
     )
 
 


### PR DESCRIPTION
This is best effort, but should cover most cases.

A proper implementation would probably require using a pyparsing like https://pypi.org/project/jira2markdown/ does.

