### PR TITLE
Fix #723: turn markdown into Jira syntax on comments and description

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,6 +28,8 @@ jobs:
         id: setup-python
         with:
           python-version: "3.12"
+      - name: Install pandoc
+        run: sudo apt-get install -y pandoc
       - name: Install poetry
         run: pipx install poetry
       - uses: actions/cache@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,11 @@ RUN $POETRY_HOME/bin/poetry install --without dev --no-root
 
 # `production` stage uses the dependencies downloaded in the `base` stage
 FROM python:3.12.1-slim as production
+
+# Install pandoc for markdown to Jira conversions.
+RUN apt-get -y update && \
+    apt-get -y install --no-install-recommends pandoc
+
 ENV PORT=8000 \
     PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \

--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ graph TD
 
 # Development
 
+We use [pandoc](https://pandoc.org) to convert markdown to the Jira syntax. Make sure the binary is found in path or [specify your custom location](https://github.com/JessicaTegner/pypandoc#specifying-the-location-of-pandoc-binaries).
+
 - `make start`: run the application locally (http://localhost:8000)
 - `make test`: run the unit tests suites
 - `make lint`: static analysis of the code base

--- a/bin/healthcheck.py
+++ b/bin/healthcheck.py
@@ -12,5 +12,9 @@ session = requests.Session()
 retries = Retry(total=5, backoff_factor=0.1, status_forcelist=[500, 502, 503, 504])
 session.mount("http://", HTTPAdapter(max_retries=retries))
 if __name__ == "__main__":
-    response = session.get(f"http://0.0.0.0:{PORT}/")
+    url = f"http://0.0.0.0:{PORT}"
+    response = session.get(f"{url}/")
     response.raise_for_status()
+
+    hb_response = session.get(f"{url}/__heartbeat__")
+    assert hb_response.json["pandoc_install"]

--- a/bin/healthcheck.py
+++ b/bin/healthcheck.py
@@ -2,19 +2,29 @@
 
 import os
 
+import backoff
 import requests
-from requests.adapters import HTTPAdapter, Retry
 
-PORT = os.environ["PORT"]
+PORT = os.getenv("PORT", "8000")
 
-session = requests.Session()
 
-retries = Retry(total=5, backoff_factor=0.1, status_forcelist=[500, 502, 503, 504])
-session.mount("http://", HTTPAdapter(max_retries=retries))
-if __name__ == "__main__":
+@backoff.on_exception(
+    backoff.expo,
+    requests.exceptions.RequestException,
+    max_tries=5,
+)
+def check_server():
     url = f"http://0.0.0.0:{PORT}"
-    response = session.get(f"{url}/")
+    response = requests.get(f"{url}/")
     response.raise_for_status()
 
-    hb_response = session.get(f"{url}/__heartbeat__")
-    assert hb_response.json["pandoc_install"]
+    hb_response = requests.get(f"{url}/__heartbeat__")
+    hb_details = hb_response.json()
+    # Check that pandoc is installed, but ignore other checks
+    # like connection to Jira or Bugzilla.
+    assert hb_details["jira"]["pandoc_install"]
+    print("Ok")
+
+
+if __name__ == "__main__":
+    check_server()

--- a/jbi/jira/service.py
+++ b/jbi/jira/service.py
@@ -215,7 +215,9 @@ class JiraService:
         fields: dict[str, Any] = {
             "summary": bug.summary,
             "issuetype": {"name": issue_type},
-            "description": markdown_to_jira(description[:JIRA_DESCRIPTION_CHAR_LIMIT]),
+            "description": markdown_to_jira(
+                description, max_length=JIRA_DESCRIPTION_CHAR_LIMIT
+            ),
             "project": {"key": context.jira.project},
         }
         logger.debug(
@@ -411,9 +413,9 @@ class JiraService:
             bug.id,
             extra=context.model_dump(),
         )
-        truncated_summary = markdown_to_jira(bug.summary or "")[
-            :JIRA_DESCRIPTION_CHAR_LIMIT
-        ]
+        truncated_summary = markdown_to_jira(
+            bug.summary or "", max_length=JIRA_DESCRIPTION_CHAR_LIMIT
+        )
         fields: dict[str, str] = {
             "summary": truncated_summary,
         }

--- a/jbi/jira/utils.py
+++ b/jbi/jira/utils.py
@@ -1,0 +1,12 @@
+import logging
+
+import pypandoc  # type: ignore
+
+logging.getLogger("pypandoc").addHandler(logging.NullHandler())
+
+
+def markdown_to_jira(markdown: str) -> str:
+    """
+    Convert markdown content into Jira specific markup language.
+    """
+    return pypandoc.convert_text(markdown, "jira", format="md").strip()  # type: ignore

--- a/jbi/jira/utils.py
+++ b/jbi/jira/utils.py
@@ -5,8 +5,11 @@ import pypandoc  # type: ignore
 logging.getLogger("pypandoc").addHandler(logging.NullHandler())
 
 
-def markdown_to_jira(markdown: str) -> str:
+def markdown_to_jira(markdown: str, max_length: int = 0) -> str:
     """
     Convert markdown content into Jira specific markup language.
     """
+    if max_length > 0 and len(markdown) > max_length:
+        # Truncate on last word.
+        markdown = markdown[:max_length].rsplit(maxsplit=1)[0]
     return pypandoc.convert_text(markdown, "jira", format="md").strip()  # type: ignore

--- a/poetry.lock
+++ b/poetry.lock
@@ -1133,6 +1133,17 @@ plugins = ["importlib-metadata"]
 windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
+name = "pypandoc"
+version = "1.12"
+description = "Thin wrapper for pandoc."
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "pypandoc-1.12-py3-none-any.whl", hash = "sha256:efb4f7d68ead8bec32e22b62f02d5608a1700978b51bfc4af286fd6acfe9d218"},
+    {file = "pypandoc-1.12.tar.gz", hash = "sha256:8f44740a9f074e121d81b489f073160421611d4ead62d1b306aeb11aab3c32df"},
+]
+
+[[package]]
 name = "pytest"
 version = "8.0.0"
 description = "pytest: simple powerful testing with Python"
@@ -1254,7 +1265,6 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
-    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef"},
     {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
     {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
     {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
@@ -2018,4 +2028,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.12, <3.13"
-content-hash = "4dff1077b38eb2adca0e1854efca2973754acd742f58a58e020844a01008acc1"
+content-hash = "bec984ba6bc302e9e64c70a3f935d8db2e63f135b523399d2812ac2707f02518"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ statsd = "^4.0.1"
 requests = "^2.31.0"
 pydantic-settings = "^2.1.0"
 asgi-correlation-id = "^4.3.0"
+pypandoc = "^1.12"
 
 [tool.poetry.group.dev.dependencies]
 pre-commit = "^3.5.0"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -131,7 +131,7 @@ def context_comment_example(action_context_factory) -> ActionContext:
         bug__see_also=["https://mozilla.atlassian.net/browse/JBI-234"],
         bug__with_comment=True,
         bug__comment__number=2,
-        bug__comment__body="hello",
+        bug__comment__body="> hello\n>\n\nworld",
         event__target="comment",
         event__user__login="mathieu@mozilla.org",
         jira__issue="JBI-234",

--- a/tests/unit/jira/test_utils.py
+++ b/tests/unit/jira/test_utils.py
@@ -1,0 +1,47 @@
+from textwrap import dedent
+
+from jbi.jira.utils import markdown_to_jira
+
+
+def test_markdown_to_jira():
+    markdown = dedent(
+        """
+    Mixed nested lists
+
+    * a
+    * bulleted
+      - with
+      - nested
+        1. nested-nested
+      - numbered
+    * list
+
+    this was `inline` value ``that`` is turned into ```monospace``` tag.
+
+    this sentence __has__ **bold** and _has_ *italic*.
+
+    this was ~~wrong~~.
+    """
+    ).lstrip()
+
+    jira = dedent(
+        """
+    Mixed nested lists
+
+    * a
+    * bulleted
+    ** with
+    ** nested
+    **# nested-nested
+    ** numbered
+    * list
+
+    this was {{inline}} value {{that}} is turned into {{monospace}} tag.
+
+    this sentence *has* *bold* and _has_ _italic_.
+
+    this was -wrong-.
+    """
+    ).strip()
+
+    assert markdown_to_jira(markdown) == jira

--- a/tests/unit/jira/test_utils.py
+++ b/tests/unit/jira/test_utils.py
@@ -1,5 +1,7 @@
 from textwrap import dedent
 
+import pytest
+
 from jbi.jira.utils import markdown_to_jira
 
 
@@ -45,3 +47,22 @@ def test_markdown_to_jira():
     ).strip()
 
     assert markdown_to_jira(markdown) == jira
+
+
+def test_markdown_to_jira_with_malformed_input():
+    assert markdown_to_jira("[link|http://noend") == "\\[link|http://noend"
+
+
+@pytest.mark.parametrize(
+    "markdown, expected, max_length",
+    [
+        ("a" * 10, "aaaaa", 5),
+        ("aa aaa", "aa", 5),
+        ("aa\naaa", "aa", 5),
+        ("aa\taaa", "aa", 5),
+        ("aaaaaa", "aaaaa", 5),
+        ("aaaaa ", "aaaaa", 5),
+    ],
+)
+def test_markdown_to_jira_with_max_chars(markdown, expected, max_length):
+    assert markdown_to_jira(markdown, max_length=max_length) == expected

--- a/tests/unit/test_router.py
+++ b/tests/unit/test_router.py
@@ -188,6 +188,7 @@ def test_read_heartbeat_all_services_fail(anon_client, mocked_jira, mocked_bugzi
             "all_projects_have_permissions": False,
             "all_project_custom_components_exist": False,
             "all_projects_issue_types_exist": False,
+            "pandoc_install": True,
         },
         "bugzilla": {
             "up": False,
@@ -209,6 +210,7 @@ def test_read_heartbeat_jira_services_fails(anon_client, mocked_jira):
         "all_projects_have_permissions": False,
         "all_project_custom_components_exist": False,
         "all_projects_issue_types_exist": False,
+        "pandoc_install": True,
     }
 
 
@@ -349,6 +351,7 @@ def test_read_heartbeat_success(
                 "all_projects_have_permissions": True,
                 "all_project_custom_components_exist": True,
                 "all_projects_issue_types_exist": True,
+                "pandoc_install": True,
             },
             "bugzilla": {
                 "up": True,

--- a/tests/unit/test_steps.py
+++ b/tests/unit/test_steps.py
@@ -150,9 +150,12 @@ def test_modified_public(
     action_context = action_context_factory(
         operation=Operation.UPDATE,
         bug__see_also=["https://mozilla.atlassian.net/browse/JBI-234"],
+        bug__summary="JBI [Test](http://test.com)",
         jira__issue="JBI-234",
         event__changes=[
-            webhook_event_change_factory(field="summary", removed="", added="JBI Test")
+            webhook_event_change_factory(
+                field="summary", removed="", added="JBI [Test](http://test.com)"
+            )
         ],
     )
 
@@ -168,7 +171,7 @@ def test_modified_public(
 
     mocked_jira.update_issue_field.assert_called_once_with(
         key="JBI-234",
-        fields={"summary": "JBI Test"},
+        fields={"summary": "JBI [Test|http://test.com]"},
     )
 
 
@@ -227,7 +230,7 @@ def test_added_comment(
 
     mocked_jira.issue_add_comment.assert_called_once_with(
         issue_key="JBI-234",
-        comment="*mathieu@mozilla.org* commented: \nhello",
+        comment="*mathieu@mozilla.org* commented: \nbq. hello\nworld",
     )
 
 

--- a/tests/unit/test_steps.py
+++ b/tests/unit/test_steps.py
@@ -227,7 +227,7 @@ def test_added_comment(
 
     mocked_jira.issue_add_comment.assert_called_once_with(
         issue_key="JBI-234",
-        comment="*(mathieu@mozilla.org)* commented: \n{quote}hello{quote}",
+        comment="*mathieu@mozilla.org* commented: \nhello",
     )
 
 
@@ -254,7 +254,7 @@ def test_create_with_no_assignee(
 ):
     mocked_bugzilla.get_bug.return_value = context_create_example.bug
     mocked_bugzilla.get_comments.return_value = [
-        comment_factory(text="Initial comment")
+        comment_factory(text="Initial `comment`")
     ]
     mocked_jira.create_issue.return_value = {"key": "new-id"}
     callable_object = Executor(
@@ -269,7 +269,7 @@ def test_create_with_no_assignee(
         fields={
             "summary": "JBI Test",
             "issuetype": {"name": "Bug"},
-            "description": "Initial comment",
+            "description": "Initial {{comment}}",
             "project": {"key": "JBI"},
         },
     )


### PR DESCRIPTION
Fix #723

Use `pandoc` instead of #836 