### PR TITLE
Add `sync_keyboard_labels` to the list of default steps

### DIFF
--- a/jbi/models.py
+++ b/jbi/models.py
@@ -33,10 +33,12 @@ class ActionSteps(BaseModel, frozen=True):
         "add_link_to_bugzilla",
         "add_link_to_jira",
         "sync_whiteboard_labels",
+        "sync_keywords_labels",
     ]
     existing: list[str] = [
         "update_issue_summary",
         "sync_whiteboard_labels",
+        "sync_keywords_labels",
         "add_jira_comments_for_changes",
     ]
     comment: list[str] = [


### PR DESCRIPTION
Once merged on `main`, this would add this step on the following projects in stage/nonprod:

- `nonprodtest`

And to the following projects once released in prod:

- `addons`
- `fidedi`
- `fxatps`
- `fxsync`
- `disco`
- `ads-eng`
- `mv3`
- `nimbus`
- `omc`
- `proton`
- `relops`
- `sng`
- `jbi-prodtest`