### PR TITLE
Fix #702: heartbeat now returns 200 on warnings

### DIFF
--- a/bin/healthcheck.py
+++ b/bin/healthcheck.py
@@ -22,7 +22,7 @@ def check_server():
     hb_details = hb_response.json()
     # Check that pandoc is installed, but ignore other checks
     # like connection to Jira or Bugzilla.
-    assert hb_details["jira"]["pandoc_install"]
+    assert hb_details["checks"]["jira.pandoc_install"] == "ok"
     print("Ok")
 
 

--- a/jbi/bugzilla/service.py
+++ b/jbi/bugzilla/service.py
@@ -62,19 +62,19 @@ def get_service():
 
 
 @checks.register(name="bugzilla.up")
-def check_bugzilla_connection():
-    service = get_service()
+def check_bugzilla_connection(service=None):
+    service = service or get_service()
     if not service.client.logged_in():
         return [checks.Error("Login fails or service down", id="bugzilla.login")]
     return []
 
 
 @checks.register(name="bugzilla.all_webhooks_enabled")
-def check_bugzilla_webhooks():
-    service = get_service()
+def check_bugzilla_webhooks(service=None):
+    service = service or get_service()
 
     # Do not bother executing the rest of checks if connection fails.
-    if messages := check_bugzilla_connection():
+    if messages := check_bugzilla_connection(service):
         return messages
 
     # Check that all JBI webhooks are enabled in Bugzilla,

--- a/jbi/jira/service.py
+++ b/jbi/jira/service.py
@@ -11,10 +11,11 @@ from functools import lru_cache
 from typing import TYPE_CHECKING, Any, Iterable, Optional
 
 import requests
+from dockerflow import checks
 from requests import exceptions as requests_exceptions
 
 from jbi import Operation, bugzilla, environment
-from jbi.common.instrument import ServiceHealth
+from jbi.configuration import get_actions
 from jbi.jira.utils import markdown_to_jira
 from jbi.models import ActionContext
 
@@ -22,7 +23,7 @@ from .client import JiraClient, JiraCreateError
 
 # https://docs.python.org/3.11/library/typing.html#typing.TYPE_CHECKING
 if TYPE_CHECKING:
-    from jbi.models import Actions
+    pass
 
 settings = environment.get_settings()
 
@@ -50,140 +51,6 @@ class JiraService:
 
         projects = self.client.permitted_projects()
         return [project["key"] for project in projects]
-
-    def check_health(self, actions: Actions) -> ServiceHealth:
-        """Check health for Jira Service"""
-        try:
-            is_up = self.client.get_server_info(True) is not None
-        except requests.RequestException:
-            is_up = False
-
-        health: ServiceHealth = {
-            "up": is_up,
-            "all_projects_are_visible": is_up and self._all_projects_visible(actions),
-            "all_projects_have_permissions": is_up
-            and self._all_projects_permissions(actions),
-            "all_project_custom_components_exist": is_up
-            and self._all_project_custom_components_exist(actions),
-            "all_projects_issue_types_exist": is_up
-            and self._all_project_issue_types_exist(actions),
-            "pandoc_install": markdown_to_jira("- Test") == "* Test",
-        }
-        return health
-
-    def _all_projects_visible(self, actions: Actions) -> bool:
-        try:
-            visible_projects = self.fetch_visible_projects()
-        except requests.HTTPError:
-            logger.exception("Error fetching visible Jira projects")
-            return False
-
-        missing_projects = actions.configured_jira_projects_keys - set(visible_projects)
-        if missing_projects:
-            logger.error(
-                "Jira projects %s are not visible with configured credentials",
-                missing_projects,
-            )
-        return not missing_projects
-
-    def _all_projects_permissions(self, actions: Actions) -> bool:
-        """Fetches and validates that required permissions exist for the configured projects"""
-        try:
-            projects = self.client.permitted_projects(JIRA_REQUIRED_PERMISSIONS)
-        except requests.HTTPError:
-            logger.exception(
-                "Encountered error when trying to fetch permitted projects"
-            )
-            return False
-
-        projects_with_required_perms = {project["key"] for project in projects}
-        missing_perms = (
-            actions.configured_jira_projects_keys - projects_with_required_perms
-        )
-        if missing_perms:
-            logger.warning(
-                "Missing permissions for projects %s", ", ".join(missing_perms)
-            )
-            return False
-
-        return True
-
-    def _all_project_custom_components_exist(self, actions: Actions):
-        with concurrent.futures.ThreadPoolExecutor(max_workers=4) as executor:
-            futures = {
-                executor.submit(self._check_project_components, action): action
-                for action in actions
-                if action.parameters.jira_components.set_custom_components
-            }
-
-            success = True
-            for future in concurrent.futures.as_completed(futures):
-                success = success and future.result()
-        return success
-
-    def _check_project_components(self, action):
-        project_key = action.parameters.jira_project_key
-        specified_components = set(
-            action.parameters.jira_components.set_custom_components
-        )
-
-        try:
-            all_project_components = self.client.get_project_components(project_key)
-        except requests.HTTPError:
-            logger.exception("Error checking project components for %s", project_key)
-            return False
-
-        try:
-            all_components_names = set(comp["name"] for comp in all_project_components)
-        except KeyError:
-            logger.exception(
-                "Unexpected get_project_components response for %s",
-                action.whiteboard_tag,
-            )
-            return False
-
-        unknown = specified_components - all_components_names
-        if unknown:
-            logger.error(
-                "Jira project %s does not have components %s",
-                project_key,
-                unknown,
-            )
-            return False
-
-        return True
-
-    def _all_project_issue_types_exist(self, actions: Actions):
-        try:
-            paginated_project_response = self.client.paginated_projects(
-                expand="issueTypes", keys=actions.configured_jira_projects_keys
-            )
-        except requests.RequestException:
-            logger.exception("Couldn't fetch projects")
-            return False
-
-        projects = paginated_project_response["values"]
-        issue_types_by_project = {
-            project["key"]: {issue_type["name"] for issue_type in project["issueTypes"]}
-            for project in projects
-        }
-        missing_issue_types_by_project = {}
-        for action in actions:
-            action_issue_types = set(action.parameters.issue_type_map.values())
-            project_issue_types = issue_types_by_project.get(
-                action.jira_project_key, set()
-            )
-            if missing_issue_types := action_issue_types - project_issue_types:
-                missing_issue_types_by_project[
-                    action.jira_project_key
-                ] = missing_issue_types
-        if missing_issue_types_by_project:
-            logger.warning(
-                "Jira projects with missing issue types",
-                extra=missing_issue_types_by_project,
-            )
-            return False
-        return True
 
     def get_issue(self, context: ActionContext, issue_key):
         """Return the Jira issue fields or `None` if not found."""
@@ -520,3 +387,187 @@ def get_service():
     )
 
     return JiraService(client=client)
+
+
+@checks.register(name="jira.up")
+def check_jira_connection(service=None):
+    service = service or get_service()
+    try:
+        if service.client.get_server_info(True) is None:
+            return [checks.Error("Login fails", id="login.fail")]
+    except requests.RequestException:
+        return [checks.Error("Could not connect to server", id="jira.server.down")]
+    return []
+
+
+@checks.register(name="jira.all_projects_are_visible")
+def check_jira_all_projects_are_visible():
+    service = get_service()
+    actions = get_actions()
+
+    # Do not bother executing the rest of checks if connection fails.
+    if messages := check_jira_connection():
+        return messages
+
+    try:
+        visible_projects = service.fetch_visible_projects()
+    except requests.HTTPError:
+        return [
+            checks.Error(
+                "Error fetching visible Jira projects", id="jira.visible.error"
+            )
+        ]
+
+    missing_projects = actions.configured_jira_projects_keys - set(visible_projects)
+    if missing_projects:
+        return [
+            checks.Warning(
+                f"Jira projects {missing_projects} are not visible with configured credentials",
+                id="jira.projects.missing",
+            )
+        ]
+
+    return []
+
+
+@checks.register(name="jira.all_projects_have_permissions")
+def check_jira_all_projects_have_permissions(service=None, actions=None):
+    """Fetches and validates that required permissions exist for the configured projects"""
+    service = service or get_service()
+    actions = actions or get_actions()
+
+    # Do not bother executing the rest of checks if connection fails.
+    if messages := check_jira_connection():
+        return messages
+
+    try:
+        projects = service.client.permitted_projects(JIRA_REQUIRED_PERMISSIONS)
+    except requests.HTTPError:
+        return [
+            checks.Error(
+                "Error fetching permitted Jira projects", id="jira.permitted.error"
+            )
+        ]
+
+    projects_with_required_perms = {project["key"] for project in projects}
+    missing_perms = actions.configured_jira_projects_keys - projects_with_required_perms
+    if missing_perms:
+        missing = ", ".join(missing_perms)
+        return [
+            checks.Error(
+                f"Missing permissions for projects {missing}",
+                id="jira.permitted.missing",
+            )
+        ]
+
+    return []
+
+
+@checks.register(name="jira.all_project_custom_components_exist")
+def check_jira_all_project_custom_components_exist(service=None, actions=None):
+    service = service or get_service()
+    actions = actions or get_actions()
+
+    # Do not bother executing the rest of checks if connection fails.
+    if messages := check_jira_connection():
+        return messages
+
+    results = []
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=4) as executor:
+        futures = {
+            executor.submit(_check_project_components, service, action): action
+            for action in actions
+            if action.parameters.jira_components.set_custom_components
+        }
+        for future in concurrent.futures.as_completed(futures):
+            results.extend(future.result())
+    return results
+
+
+def _check_project_components(service, action):
+    project_key = action.parameters.jira_project_key
+    specified_components = set(action.parameters.jira_components.set_custom_components)
+
+    try:
+        all_project_components = service.client.get_project_components(project_key)
+    except requests.HTTPError:
+        return [
+            checks.Error(
+                f"Error checking project components for {project_key}",
+                id="jira.components.error",
+            )
+        ]
+
+    try:
+        all_components_names = set(comp["name"] for comp in all_project_components)
+    except KeyError:
+        return [
+            checks.Error(
+                f"Unexpected get_project_components response for {action.whiteboard_tag}",
+                id="jira.components.parsing",
+            )
+        ]
+
+    unknown = specified_components - all_components_names
+    if unknown:
+        return [
+            checks.Warning(
+                f"Jira project {project_key} does not have components {unknown}",
+                id="jira.components.missing",
+            )
+        ]
+
+    return []
+
+
+@checks.register(name="jira.all_project_issue_types_exist")
+def check_jira_all_project_issue_types_exist(service=None, actions=None):
+    actions = actions or get_actions()
+    service = service or get_service()
+
+    # Do not bother executing the rest of checks if connection fails.
+    if messages := check_jira_connection():
+        return messages
+
+    try:
+        paginated_project_response = service.client.paginated_projects(
+            expand="issueTypes", keys=actions.configured_jira_projects_keys
+        )
+    except requests.RequestException:
+        return [
+            checks.Error(
+                "Couldn't fetch projects",
+                id="jira.projects.error",
+            )
+        ]
+
+    projects = paginated_project_response["values"]
+    issue_types_by_project = {
+        project["key"]: {issue_type["name"] for issue_type in project["issueTypes"]}
+        for project in projects
+    }
+    missing_issue_types_by_project = {}
+    for action in actions:
+        action_issue_types = set(action.parameters.issue_type_map.values())
+        project_issue_types = issue_types_by_project.get(action.jira_project_key, set())
+        if missing_issue_types := action_issue_types - project_issue_types:
+            missing_issue_types_by_project[
+                action.jira_project_key
+            ] = missing_issue_types
+    if missing_issue_types_by_project:
+        return [
+            checks.Warning(
+                "Jira projects with missing issue types",
+                obj=missing_issue_types_by_project,
+                id="jira.types.missing",
+            )
+        ]
+    return []
+
+
+@checks.register(name="jira.pandoc_install")
+def check_jira_pandoc_install():
+    if markdown_to_jira("- Test") != "* Test":
+        return [checks.Error("Pandoc conversion failed", id="jira.pandoc")]
+    return []

--- a/jbi/jira/service.py
+++ b/jbi/jira/service.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import concurrent
 import json
 import logging
+import os
 from functools import lru_cache
 from typing import TYPE_CHECKING, Any, Iterable, Optional
 
@@ -38,6 +39,8 @@ JIRA_REQUIRED_PERMISSIONS = {
     "DELETE_ISSUES",
     "EDIT_ISSUES",
 }
+
+CPU_COUNT = len(os.sched_getaffinity(0))  # 0: pid of current process
 
 
 class JiraService:
@@ -474,7 +477,7 @@ def check_jira_all_project_custom_components_exist(service=None, actions=None):
 
     results = []
 
-    with concurrent.futures.ThreadPoolExecutor(max_workers=4) as executor:
+    with concurrent.futures.ThreadPoolExecutor(max_workers=CPU_COUNT) as executor:
         futures = {
             executor.submit(_check_project_components, service, action): action
             for action in actions

--- a/jbi/jira/service.py
+++ b/jbi/jira/service.py
@@ -454,7 +454,7 @@ def check_jira_all_projects_have_permissions(service=None, actions=None):
     if missing_perms:
         missing = ", ".join(missing_perms)
         return [
-            checks.Error(
+            checks.Warning(
                 f"Missing permissions for projects {missing}",
                 id="jira.permitted.missing",
             )

--- a/jbi/jira/service.py
+++ b/jbi/jira/service.py
@@ -8,7 +8,7 @@ import concurrent
 import json
 import logging
 from functools import lru_cache
-from typing import TYPE_CHECKING, Any, Iterable, Optional
+from typing import Any, Iterable, Optional
 
 import requests
 from dockerflow import checks
@@ -20,10 +20,6 @@ from jbi.jira.utils import markdown_to_jira
 from jbi.models import ActionContext
 
 from .client import JiraClient, JiraCreateError
-
-# https://docs.python.org/3.11/library/typing.html#typing.TYPE_CHECKING
-if TYPE_CHECKING:
-    pass
 
 settings = environment.get_settings()
 

--- a/jbi/jira/service.py
+++ b/jbi/jira/service.py
@@ -385,9 +385,8 @@ def get_service():
     return JiraService(client=client)
 
 
-@checks.register(name="jira.up")
-def check_jira_connection(service=None):
-    service = service or get_service()
+def check_jira_connection(_get_service):
+    service = _get_service()
     try:
         if service.client.get_server_info(True) is None:
             return [checks.Error("Login fails", id="login.fail")]
@@ -396,11 +395,18 @@ def check_jira_connection(service=None):
     return []
 
 
-def check_jira_all_projects_are_visible(actions, service=None):
-    service = service or get_service()
+checks.register_partial(
+    check_jira_connection,
+    get_service,
+    name="jira.up",
+)
+
+
+def check_jira_all_projects_are_visible(actions, _get_service):
+    service = _get_service()
 
     # Do not bother executing the rest of checks if connection fails.
-    if messages := check_jira_connection(service):
+    if messages := check_jira_connection(_get_service):
         return messages
 
     try:
@@ -427,16 +433,17 @@ def check_jira_all_projects_are_visible(actions, service=None):
 checks.register_partial(
     check_jira_all_projects_are_visible,
     ACTIONS,
+    get_service,
     name="jira.all_projects_are_visible",
 )
 
 
-def check_jira_all_projects_have_permissions(actions, service=None):
+def check_jira_all_projects_have_permissions(actions, _get_service):
     """Fetches and validates that required permissions exist for the configured projects"""
-    service = service or get_service()
+    service = _get_service()
 
     # Do not bother executing the rest of checks if connection fails.
-    if messages := check_jira_connection(service):
+    if messages := check_jira_connection(_get_service):
         return messages
 
     try:
@@ -465,15 +472,16 @@ def check_jira_all_projects_have_permissions(actions, service=None):
 checks.register_partial(
     check_jira_all_projects_have_permissions,
     ACTIONS,
+    get_service,
     name="jira.all_projects_have_permissions",
 )
 
 
-def check_jira_all_project_custom_components_exist(actions, service=None):
+def check_jira_all_project_custom_components_exist(actions, _get_service):
     # Do not bother executing the rest of checks if connection fails.
-    service = service or get_service()
+    service = _get_service()
 
-    if messages := check_jira_connection(service):
+    if messages := check_jira_connection(_get_service):
         return messages
 
     results = []
@@ -492,6 +500,7 @@ def check_jira_all_project_custom_components_exist(actions, service=None):
 checks.register_partial(
     check_jira_all_project_custom_components_exist,
     ACTIONS,
+    get_service,
     name="jira.all_project_custom_components_exist",
 )
 
@@ -532,11 +541,11 @@ def _check_project_components(service, action):
     return []
 
 
-def check_jira_all_project_issue_types_exist(actions, service=None):
+def check_jira_all_project_issue_types_exist(actions, _get_service):
     # Do not bother executing the rest of checks if connection fails.
-    service = service or get_service()
+    service = _get_service()
 
-    if messages := check_jira_connection(service):
+    if messages := check_jira_connection(_get_service):
         return messages
 
     try:
@@ -578,6 +587,7 @@ def check_jira_all_project_issue_types_exist(actions, service=None):
 checks.register_partial(
     check_jira_all_project_issue_types_exist,
     ACTIONS,
+    get_service,
     name="jira.all_project_issue_types_exist",
 )
 

--- a/jbi/jira/service.py
+++ b/jbi/jira/service.py
@@ -558,7 +558,7 @@ def check_jira_all_project_issue_types_exist(service=None, actions=None):
     if missing_issue_types_by_project:
         return [
             checks.Warning(
-                "Jira projects with missing issue types",
+                f"Jira projects {set(missing_issue_types_by_project.keys())} with missing issue types",
                 obj=missing_issue_types_by_project,
                 id="jira.types.missing",
             )

--- a/jbi/jira/service.py
+++ b/jbi/jira/service.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 import concurrent
 import json
 import logging
-import os
 from functools import lru_cache
 from typing import TYPE_CHECKING, Any, Iterable, Optional
 
@@ -39,8 +38,6 @@ JIRA_REQUIRED_PERMISSIONS = {
     "DELETE_ISSUES",
     "EDIT_ISSUES",
 }
-
-CPU_COUNT = len(os.sched_getaffinity(0))  # 0: pid of current process
 
 
 class JiraService:
@@ -477,7 +474,7 @@ def check_jira_all_project_custom_components_exist(service=None, actions=None):
 
     results = []
 
-    with concurrent.futures.ThreadPoolExecutor(max_workers=CPU_COUNT) as executor:
+    with concurrent.futures.ThreadPoolExecutor() as executor:
         futures = {
             executor.submit(_check_project_components, service, action): action
             for action in actions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ warn_return_any = true
 plugins = "pydantic.mypy"
 
 [[tool.mypy.overrides]]
-module = ["ruamel", "bugzilla", "atlassian", "atlassian.rest_client", "statsd.defaults.env"]
+module = ["ruamel", "bugzilla", "atlassian", "atlassian.rest_client", "statsd.defaults.env", "dockerflow"]
 ignore_missing_imports = true
 
 [[tool.mypy.overrides]]

--- a/tests/unit/jira/test_service.py
+++ b/tests/unit/jira/test_service.py
@@ -50,7 +50,7 @@ def test_jira_retries_failing_connections_in_health_check(
         url,
         body=ConnectionError(),
     )
-    results = check_jira_connection(jira_service)
+    results = check_jira_connection(lambda: jira_service)
     assert len(results) == 1
     assert results[0].id == "jira.server.down"
     assert len(mocked_responses.calls) == 4
@@ -110,7 +110,9 @@ def test_all_project_custom_components_exist(
         }
     )
     actions = Actions(root=[action])
-    result = check_jira_all_project_custom_components_exist(actions, jira_service)
+    result = check_jira_all_project_custom_components_exist(
+        actions, lambda: jira_service
+    )
     assert [msg.id for msg in result] == expected_result
 
 
@@ -123,7 +125,9 @@ def test_all_project_custom_components_exist_no_components_param(
         }
     )
     actions = Actions(root=[action])
-    result = check_jira_all_project_custom_components_exist(actions, jira_service)
+    result = check_jira_all_project_custom_components_exist(
+        actions, lambda: jira_service
+    )
     assert result == []
 
 
@@ -394,7 +398,7 @@ def test_all_project_issue_types_exist(
         json={"values": project_data},
     )
 
-    results = check_jira_all_project_issue_types_exist(actions, jira_service)
+    results = check_jira_all_project_issue_types_exist(actions, lambda: jira_service)
     assert [result.id for result in results] == expected_result
 
 
@@ -458,5 +462,5 @@ def test_all_projects_permissions(
         json={"projects": project_data},
     )
 
-    results = check_jira_all_projects_have_permissions(actions, jira_service)
+    results = check_jira_all_projects_have_permissions(actions, lambda: jira_service)
     assert [msg.id for msg in results] == expected_result

--- a/tests/unit/test_router.py
+++ b/tests/unit/test_router.py
@@ -364,7 +364,7 @@ def test_jira_heartbeat_unknown_issue_types(anon_client, mocked_jira):
     assert results["details"]["jira.all_project_issue_types_exist"] == {
         "level": 30,
         "messages": {
-            "jira.types.missing": "Jira projects with missing issue types",
+            "jira.types.missing": "Jira projects {'DevTest'} with missing issue types",
         },
         "status": "warning",
     }
@@ -410,6 +410,18 @@ def test_read_heartbeat_success(
             "details": {},
             "status": "ok",
         }
+
+
+def test_heartbeat_with_warning_only(anon_client, mocked_jira, mocked_bugzilla):
+    """/__heartbeat__ returns 200 when checks are only warning."""
+    mocked_bugzilla.logged_in.return_value = True
+    mocked_bugzilla.list_webhooks.return_value = []
+    mocked_jira.permitted_projects.return_value = [{"key": "DevTest"}]
+
+    resp = anon_client.get("__heartbeat__")
+
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "warning"
 
 
 @pytest.mark.parametrize("method", ["HEAD", "GET"])

--- a/tests/unit/test_router.py
+++ b/tests/unit/test_router.py
@@ -315,16 +315,14 @@ def test_jira_heartbeat_missing_permissions(anon_client, mocked_jira):
 
     resp = anon_client.get("/__heartbeat__")
 
-    assert resp.status_code == 500
     results = resp.json()
-    assert results["checks"]["jira.up"] == "ok"
-    assert results["checks"]["jira.all_projects_have_permissions"] == "error"
+    assert results["checks"]["jira.all_projects_have_permissions"] == "warning"
     assert results["details"]["jira.all_projects_have_permissions"] == {
-        "level": 40,
+        "level": 30,
         "messages": {
             "jira.permitted.missing": "Missing permissions for projects DevTest",
         },
-        "status": "error",
+        "status": "warning",
     }
 
 
@@ -416,7 +414,6 @@ def test_heartbeat_with_warning_only(anon_client, mocked_jira, mocked_bugzilla):
     """/__heartbeat__ returns 200 when checks are only warning."""
     mocked_bugzilla.logged_in.return_value = True
     mocked_bugzilla.list_webhooks.return_value = []
-    mocked_jira.permitted_projects.return_value = [{"key": "DevTest"}]
 
     resp = anon_client.get("__heartbeat__")
 


### PR DESCRIPTION
Fix #702

### What's changed:

- leverage `dockerflow` check system (body of heartbeat response has changed)
- return 200 when the status is warning only
- return warning from checks when only a portion of workflows are affected
- let dockerflow log messages and details

### Questions:

- A lot of testing code in `test_router.py` asserts the content of the heartbeat response body. Shall we only leave the bare minimum (eg. all success, one warning, one error) instead of testing all combinations?  
- This pattern to do injection in checks is not great:
```py
def check_jira_all_project_issue_types_exist(service=None, actions=None):
    actions = actions or get_actions()
    service = service or get_service()
    ...
```
What would you recommend instead?
(*Note: `configuration.get_actions()` is not cached*)


### Todo Next:

- Wait for https://github.com/mozilla-services/python-dockerflow/pull/81 to leverage FastAPI heartbeat view