### PR TITLE
Fix #645: Switch log messages to INFO level

### DIFF
--- a/jbi/bugzilla/models.py
+++ b/jbi/bugzilla/models.py
@@ -98,7 +98,7 @@ class Bug(BaseModel, frozen=True):
                 parsed_url: ParseResult = urlparse(url=url)
                 host_parts = parsed_url.hostname.split(".")
             except (ValueError, AttributeError):
-                logger.debug(
+                logger.info(
                     "Bug %s `see_also` is not a URL: %s",
                     self.id,
                     url,

--- a/jbi/jira/service.py
+++ b/jbi/jira/service.py
@@ -50,10 +50,10 @@ class JiraService:
 
     def get_issue(self, context: ActionContext, issue_key):
         """Return the Jira issue fields or `None` if not found."""
-        logger.debug("Getting issue %s", issue_key, extra=context.model_dump())
+        logger.info("Getting issue %s", issue_key, extra=context.model_dump())
         try:
             response = self.client.get_issue(issue_key)
-            logger.debug(
+            logger.info(
                 "Received issue %s",
                 issue_key,
                 extra={"response": response, **context.model_dump()},
@@ -83,7 +83,7 @@ class JiraService:
             ),
             "project": {"key": context.jira.project},
         }
-        logger.debug(
+        logger.info(
             "Creating new Jira issue for Bug %s",
             bug.id,
             extra={"fields": fields, **context.model_dump()},
@@ -107,7 +107,7 @@ class JiraService:
         # Jira response can be of the form: List or Dictionary
         # if a list is returned, get the first item
         issue_data = response[0] if isinstance(response, list) else response
-        logger.debug(
+        logger.info(
             "Jira issue %s created for Bug %s",
             issue_data["key"],
             bug.id,
@@ -130,7 +130,7 @@ class JiraService:
             issue_key=issue_key,
             comment=formatted_comment,
         )
-        logger.debug(
+        logger.info(
             "User comment added to Jira issue %s",
             issue_key,
             extra=context.model_dump(),
@@ -159,7 +159,7 @@ class JiraService:
 
         jira_response_comments = []
         for i, comment in enumerate(comments):
-            logger.debug(
+            logger.info(
                 "Create comment #%s on Jira issue %s",
                 i + 1,
                 issue_key,
@@ -201,7 +201,7 @@ class JiraService:
         bug = context.bug
         issue_key = context.jira.issue
         bugzilla_url = f"{settings.bugzilla_base_url}/show_bug.cgi?id={bug.id}"
-        logger.debug(
+        logger.info(
             "Link %r on Jira issue %s",
             bugzilla_url,
             issue_key,
@@ -219,12 +219,12 @@ class JiraService:
     def clear_assignee(self, context: ActionContext):
         """Clear the assignee of the specified Jira issue."""
         issue_key = context.jira.issue
-        logger.debug("Clearing assignee", extra=context.model_dump())
+        logger.info("Clearing assignee", extra=context.model_dump())
         return self.client.update_issue_field(key=issue_key, fields={"assignee": None})
 
     def find_jira_user(self, context: ActionContext, email: str):
         """Lookup Jira users, raise an error if not exactly one found."""
-        logger.debug("Find Jira user with email %s", email, extra=context.model_dump())
+        logger.info("Find Jira user with email %s", email, extra=context.model_dump())
         users = self.client.user_find_by_user_string(query=email)
         if len(users) != 1:
             raise ValueError(f"User {email} not found")
@@ -255,7 +255,7 @@ class JiraService:
         issue_key = context.jira.issue
         assert issue_key  # Until we have more fine-grained typing of contexts
 
-        logger.debug(
+        logger.info(
             "Updating Jira status to %s",
             jira_status,
             extra=context.model_dump(),
@@ -270,7 +270,7 @@ class JiraService:
 
         bug = context.bug
         issue_key = context.jira.issue
-        logger.debug(
+        logger.info(
             "Update summary of Jira issue %s for Bug %s",
             issue_key,
             bug.id,
@@ -290,7 +290,7 @@ class JiraService:
         issue_key = context.jira.issue
         assert issue_key  # Until we have more fine-grained typing of contexts
 
-        logger.debug(
+        logger.info(
             "Updating resolution of Jira issue %s to %s",
             issue_key,
             jira_resolution,
@@ -300,7 +300,7 @@ class JiraService:
             key=issue_key,
             fields={"resolution": jira_resolution},
         )
-        logger.debug(
+        logger.info(
             "Updated resolution of Jira issue %s to %s",
             issue_key,
             jira_resolution,

--- a/jbi/runner.py
+++ b/jbi/runner.py
@@ -140,7 +140,7 @@ class Executor:
             if step_responses:
                 has_produced_request = True
             for response in step_responses:
-                logger.debug(
+                logger.info(
                     "Received %s",
                     response,
                     extra={
@@ -178,7 +178,7 @@ def execute_action(
         if bug.is_private:
             raise IgnoreInvalidRequestError("private bugs are not supported")
 
-        logger.debug(
+        logger.info(
             "Handling incoming request",
             extra=runner_context.model_dump(),
         )

--- a/jbi/steps.py
+++ b/jbi/steps.py
@@ -51,7 +51,7 @@ def create_comment(context: ActionContext, *, jira_service: JiraService) -> Step
     bug = context.bug
 
     if bug.comment is None:
-        logger.debug(
+        logger.info(
             "No matching comment found in payload",
             extra=context.model_dump(),
         )
@@ -92,7 +92,7 @@ def add_link_to_jira(
 ) -> StepResult:
     """Add the URL to the Jira issue in the `see_also` field on the Bugzilla ticket"""
     jira_url = f"{settings.jira_base_url}browse/{context.jira.issue}"
-    logger.debug(
+    logger.info(
         "Link %r on Bug %s",
         jira_url,
         context.bug.id,
@@ -178,7 +178,7 @@ def maybe_assign_jira_user(
             context.append_responses(resp)
             return (StepStatus.SUCCESS, context)
         except ValueError as exc:
-            logger.debug(str(exc), extra=context.model_dump())
+            logger.info(str(exc), extra=context.model_dump())
             return (StepStatus.INCOMPLETE, context)
 
     if context.operation == Operation.UPDATE:
@@ -191,7 +191,7 @@ def maybe_assign_jira_user(
             try:
                 resp = jira_service.assign_jira_user(context, bug.assigned_to)  # type: ignore
             except ValueError as exc:
-                logger.debug(str(exc), extra=context.model_dump())
+                logger.info(str(exc), extra=context.model_dump())
                 # If that failed then just fall back to clearing the assignee.
                 resp = jira_service.clear_assignee(context)
         context.append_responses(resp)
@@ -212,7 +212,7 @@ def maybe_update_issue_resolution(
     jira_resolution = parameters.resolution_map.get(bz_resolution)
 
     if jira_resolution is None:
-        logger.debug(
+        logger.info(
             "Bug resolution %r was not in the resolution map.",
             bz_resolution,
             extra=context.update(
@@ -246,7 +246,7 @@ def maybe_update_issue_status(
     jira_status = parameters.status_map.get(bz_status or "")
 
     if jira_status is None:
-        logger.debug(
+        logger.info(
             "Bug status %r was not in the status map.",
             bz_status,
             extra=context.update(

--- a/tests/unit/jira/test_service.py
+++ b/tests/unit/jira/test_service.py
@@ -162,7 +162,6 @@ def test_get_issue_handles_404(
     assert return_val is None
 
     before, after = capturelogs.records
-    assert before.levelno == logging.DEBUG
     assert before.message == "Getting issue JBI-234"
 
     assert after.levelno == logging.ERROR
@@ -180,7 +179,6 @@ def test_get_issue_reraises_other_erroring_status_codes(
             jira_service.get_issue(context=action_context, issue_key="JBI-234")
 
     [record] = capturelogs.records
-    assert record.levelno == logging.DEBUG
     assert record.message == "Getting issue JBI-234"
 
 
@@ -301,11 +299,9 @@ def test_create_jira_issue_when_list_is_returned(
 
     before, after = capturelogs.records
     assert before.message == f"Creating new Jira issue for Bug {context.bug.id}"
-    assert before.levelno == logging.DEBUG
     assert before.fields == issue_fields
 
     assert after.message == f"Jira issue JBI-234 created for Bug {context.bug.id}"
-    assert after.levelno == logging.DEBUG
     assert after.response == [mocked_issue_data]
 
 
@@ -336,7 +332,6 @@ def test_create_jira_issue_returns_errors(
 
     before, after = capturelogs.records
     assert before.message == f"Creating new Jira issue for Bug {context.bug.id}"
-    assert before.levelno == logging.DEBUG
     assert before.fields == issue_fields
 
     assert after.message == f"Failed to create issue for Bug {context.bug.id}"

--- a/tests/unit/jira/test_service.py
+++ b/tests/unit/jira/test_service.py
@@ -162,6 +162,7 @@ def test_get_issue_handles_404(
     assert return_val is None
 
     before, after = capturelogs.records
+    assert before.levelno == logging.DEBUG
     assert before.message == "Getting issue JBI-234"
 
     assert after.levelno == logging.ERROR
@@ -179,6 +180,7 @@ def test_get_issue_reraises_other_erroring_status_codes(
             jira_service.get_issue(context=action_context, issue_key="JBI-234")
 
     [record] = capturelogs.records
+    assert record.levelno == logging.DEBUG
     assert record.message == "Getting issue JBI-234"
 
 
@@ -299,9 +301,11 @@ def test_create_jira_issue_when_list_is_returned(
 
     before, after = capturelogs.records
     assert before.message == f"Creating new Jira issue for Bug {context.bug.id}"
+    assert before.levelno == logging.DEBUG
     assert before.fields == issue_fields
 
     assert after.message == f"Jira issue JBI-234 created for Bug {context.bug.id}"
+    assert after.levelno == logging.DEBUG
     assert after.response == [mocked_issue_data]
 
 
@@ -332,6 +336,7 @@ def test_create_jira_issue_returns_errors(
 
     before, after = capturelogs.records
     assert before.message == f"Creating new Jira issue for Bug {context.bug.id}"
+    assert before.levelno == logging.DEBUG
     assert before.fields == issue_fields
 
     assert after.message == f"Failed to create issue for Bug {context.bug.id}"

--- a/tests/unit/jira/test_service.py
+++ b/tests/unit/jira/test_service.py
@@ -162,7 +162,7 @@ def test_get_issue_handles_404(
     assert return_val is None
 
     before, after = capturelogs.records
-    assert before.levelno == logging.DEBUG
+    assert before.levelno == logging.INFO
     assert before.message == "Getting issue JBI-234"
 
     assert after.levelno == logging.ERROR
@@ -180,7 +180,7 @@ def test_get_issue_reraises_other_erroring_status_codes(
             jira_service.get_issue(context=action_context, issue_key="JBI-234")
 
     [record] = capturelogs.records
-    assert record.levelno == logging.DEBUG
+    assert record.levelno == logging.INFO
     assert record.message == "Getting issue JBI-234"
 
 
@@ -301,11 +301,11 @@ def test_create_jira_issue_when_list_is_returned(
 
     before, after = capturelogs.records
     assert before.message == f"Creating new Jira issue for Bug {context.bug.id}"
-    assert before.levelno == logging.DEBUG
+    assert before.levelno == logging.INFO
     assert before.fields == issue_fields
 
     assert after.message == f"Jira issue JBI-234 created for Bug {context.bug.id}"
-    assert after.levelno == logging.DEBUG
+    assert after.levelno == logging.INFO
     assert after.response == [mocked_issue_data]
 
 
@@ -336,7 +336,7 @@ def test_create_jira_issue_returns_errors(
 
     before, after = capturelogs.records
     assert before.message == f"Creating new Jira issue for Bug {context.bug.id}"
-    assert before.levelno == logging.DEBUG
+    assert before.levelno == logging.INFO
     assert before.fields == issue_fields
 
     assert after.message == f"Failed to create issue for Bug {context.bug.id}"


### PR DESCRIPTION
Fix #645

Debug level seemed like a good idea, because in the end, that's why we need those log messages, to debug stuff. 

But debug messages are not enabled in default deployment config, and do not seem to be collected in our Logging panel.

We could ask ops to reconfigure it the service/logging (for the second time), but I believe that using info is a reasonable fix to this problem.

The trafic is low enough, these messages are globally very concise compared to ridiculous amount of logs coming from k8s
