### PR TITLE
Fix #247 #464: add `maybe_update_issue_priority` and `maybe_update_issue_severity` steps

### DIFF
--- a/docs/actions.md
+++ b/docs/actions.md
@@ -149,7 +149,9 @@ linked Jira issue status to "Closed". If the bug changes to a status not listed 
 - `update_issue`
 - `add_jira_comments_for_changes`
 - `maybe_assign_jira_user`
+- `maybe_update_issue_priority`
 - `maybe_update_issue_resolution`
+- `maybe_update_issue_severity`
 - `maybe_update_issue_status`
 - `create_comment`
 - `sync_keywords_labels`

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -152,6 +152,7 @@ linked Jira issue status to "Closed". If the bug changes to a status not listed 
 - `maybe_update_issue_resolution`
 - `maybe_update_issue_status`
 - `create_comment`
+- `sync_keywords_labels`
 - `sync_whiteboard_labels`
 - `maybe_update_components`: looks at the component that's set on the bug (if any) and any components added to the project configuration with the `jira_components` parameter (see above). If those components are available on the Jira side as well, they're added to the Jira issue
 

--- a/jbi/jira/service.py
+++ b/jbi/jira/service.py
@@ -310,7 +310,9 @@ class JiraService:
 
     def update_issue_resolution(self, context: ActionContext, jira_resolution: str):
         """Update the resolution of the Jira issue."""
-        return self.update_issue_named_field(context, field="resolution", value=jira_resolution)
+        return self.update_issue_named_field(
+            context, field="resolution", value=jira_resolution
+        )
 
     def update_issue_components(
         self,

--- a/jbi/models.py
+++ b/jbi/models.py
@@ -78,23 +78,9 @@ class ActionParams(BaseModel, frozen=True):
     jira_resolution_field: str = "resolution"
     labels_brackets: Literal["yes", "no", "both"] = "no"
     status_map: dict[str, str] = {}
-    priority_map: dict[str, str] = {
-        "P1": "1",
-        "P2": "2",
-        "P3": "3",
-        "P4": "4",
-        "P5": "5",
-        "--": "10000",
-    }
+    priority_map: dict[str, str] = {}
     resolution_map: dict[str, str] = {}
-    severity_map: dict[str, str] = {
-        "S1": "1",
-        "S2": "2",
-        "S3": "3",
-        "S4": "4",
-        "N/A": "--",
-        "--": "--",
-    }
+    severity_map: dict[str, str] = {}
     issue_type_map: dict[str, str] = {"task": "Task", "defect": "Bug"}
 
 

--- a/jbi/models.py
+++ b/jbi/models.py
@@ -73,6 +73,9 @@ class ActionParams(BaseModel, frozen=True):
     jira_project_key: str
     steps: ActionSteps = ActionSteps()
     jira_components: JiraComponents = JiraComponents()
+    jira_severity_field: str = "severity"
+    jira_priority_field: str = "priority"
+    jira_resolution_field: str = "resolution"
     labels_brackets: Literal["yes", "no", "both"] = "no"
     status_map: dict[str, str] = {}
     priority_map: dict[str, str] = {

--- a/jbi/models.py
+++ b/jbi/models.py
@@ -75,7 +75,23 @@ class ActionParams(BaseModel, frozen=True):
     jira_components: JiraComponents = JiraComponents()
     labels_brackets: Literal["yes", "no", "both"] = "no"
     status_map: dict[str, str] = {}
+    priority_map: dict[str, str] = {
+        "P1": "1",
+        "P2": "2",
+        "P3": "3",
+        "P4": "4",
+        "P5": "5",
+        "--": "10000",
+    }
     resolution_map: dict[str, str] = {}
+    severity_map: dict[str, str] = {
+        "S1": "1",
+        "S2": "2",
+        "S3": "3",
+        "S4": "4",
+        "N/A": "--",
+        "--": "--",
+    }
     issue_type_map: dict[str, str] = {"task": "Task", "defect": "Bug"}
 
 

--- a/jbi/models.py
+++ b/jbi/models.py
@@ -74,7 +74,7 @@ class ActionParams(BaseModel, frozen=True):
     jira_project_key: str
     steps: ActionSteps = ActionSteps()
     jira_components: JiraComponents = JiraComponents()
-    jira_severity_field: str = "severity"
+    jira_severity_field: str = "customfield_10716"
     jira_priority_field: str = "priority"
     jira_resolution_field: str = "resolution"
     labels_brackets: Literal["yes", "no", "both"] = "no"

--- a/jbi/models.py
+++ b/jbi/models.py
@@ -79,7 +79,13 @@ class ActionParams(BaseModel, frozen=True):
     jira_resolution_field: str = "resolution"
     labels_brackets: Literal["yes", "no", "both"] = "no"
     status_map: dict[str, str] = {}
-    priority_map: dict[str, str] = {}
+    priority_map: dict[str, str] = {
+        "P1": "P1",
+        "P2": "P2",
+        "P3": "P3",
+        "P4": "Low",
+        "P5": "Lowest",
+    }
     resolution_map: dict[str, str] = {}
     severity_map: dict[str, str] = {}
     issue_type_map: dict[str, str] = {"task": "Task", "defect": "Bug"}

--- a/jbi/steps.py
+++ b/jbi/steps.py
@@ -220,28 +220,20 @@ def _maybe_update_issue_mapped_field(
         )
         return (StepStatus.INCOMPLETE, context)
 
-    if context.operation == Operation.CREATE:
-        resp = jira_service.update_issue_field(
-            context,
-            target_field,
-            target_value,
-            wrap_value,
-        )
-        context.append_responses(resp)
-        return (StepStatus.SUCCESS, context)
+    if (
+        context.operation == Operation.UPDATE
+        and source_field not in context.event.changed_fields()
+    ):
+        return (StepStatus.NOOP, context)
 
-    if context.operation == Operation.UPDATE:
-        if source_field in context.event.changed_fields():
-            resp = jira_service.update_issue_field(
-                context,
-                target_field,
-                target_value,
-                wrap_value,
-            )
-            context.append_responses(resp)
-            return (StepStatus.SUCCESS, context)
-
-    return (StepStatus.NOOP, context)
+    resp = jira_service.update_issue_field(
+        context,
+        target_field,
+        target_value,
+        wrap_value,
+    )
+    context.append_responses(resp)
+    return (StepStatus.SUCCESS, context)
 
 
 def maybe_update_issue_priority(

--- a/jbi/steps.py
+++ b/jbi/steps.py
@@ -220,17 +220,32 @@ def _maybe_update_issue_mapped_field(
         return (StepStatus.INCOMPLETE, context)
 
     if context.operation == Operation.CREATE:
-        resp = jira_service.update_issue_named_field(context, target_field, target_value)
+        resp = jira_service.update_issue_named_field(
+            context, target_field, target_value
+        )
         context.append_responses(resp)
         return (StepStatus.SUCCESS, context)
 
     if context.operation == Operation.UPDATE:
         if source_field in context.event.changed_fields():
-            resp = jira_service.update_issue_named_field(context, target_field, target_value)
+            resp = jira_service.update_issue_named_field(
+                context, target_field, target_value
+            )
             context.append_responses(resp)
             return (StepStatus.SUCCESS, context)
 
     return (StepStatus.NOOP, context)
+
+
+def maybe_update_issue_priority(
+    context: ActionContext, *, parameters: ActionParams, jira_service: JiraService
+) -> StepResult:
+    """
+    Update the Jira issue priority
+    """
+    return _maybe_update_issue_mapped_field(
+        "priority", "priority", context, parameters, jira_service
+    )
 
 
 def maybe_update_issue_resolution(
@@ -242,6 +257,17 @@ def maybe_update_issue_resolution(
     """
     return _maybe_update_issue_mapped_field(
         "resolution", "resolution", context, parameters, jira_service
+    )
+
+
+def maybe_update_issue_severity(
+    context: ActionContext, *, parameters: ActionParams, jira_service: JiraService
+) -> StepResult:
+    """
+    Update the Jira issue severity
+    """
+    return _maybe_update_issue_mapped_field(
+        "severity", "severity", context, parameters, jira_service
     )
 
 

--- a/jbi/steps.py
+++ b/jbi/steps.py
@@ -209,7 +209,7 @@ def _maybe_update_issue_mapped_field(
 ) -> StepResult:
     source_value = getattr(context.bug, source_field, None) or ""
     target_field = getattr(parameters, f"jira_{source_field}_field")
-    target_value = getattr(parameters, f"{target_field}_map").get(source_value)
+    target_value = getattr(parameters, f"{source_field}_map").get(source_value)
     if target_value is None:
         logger.info(
             f"Bug {source_field} %r was not in the {source_field} map.",
@@ -274,7 +274,7 @@ def maybe_update_issue_severity(
     Update the Jira issue severity
     """
     return _maybe_update_issue_mapped_field(
-        "severity", context, parameters, jira_service, wrap_value="name"
+        "severity", context, parameters, jira_service, wrap_value="value"
     )
 
 

--- a/tests/unit/jira/test_service.py
+++ b/tests/unit/jira/test_service.py
@@ -203,7 +203,9 @@ def test_update_issue_resolution(
         jira_service.update_issue_resolution(context=context, jira_resolution="DONEZO")
 
     before, after = capturelogs.messages
-    assert before == "Updating resolution of Jira issue JBI-234 to DONEZO for Bug 654321"
+    assert (
+        before == "Updating resolution of Jira issue JBI-234 to DONEZO for Bug 654321"
+    )
     assert after == "Updated resolution of Jira issue JBI-234 to DONEZO for Bug 654321"
 
 
@@ -230,7 +232,9 @@ def test_update_issue_resolution_raises(
             )
 
     [message] = capturelogs.messages
-    assert message == "Updating resolution of Jira issue JBI-234 to DONEZO for Bug 654321"
+    assert (
+        message == "Updating resolution of Jira issue JBI-234 to DONEZO for Bug 654321"
+    )
 
 
 def test_create_jira_issue(

--- a/tests/unit/jira/test_service.py
+++ b/tests/unit/jira/test_service.py
@@ -203,8 +203,8 @@ def test_update_issue_resolution(
         jira_service.update_issue_resolution(context=context, jira_resolution="DONEZO")
 
     before, after = capturelogs.messages
-    assert before == "Updating resolution of Jira issue JBI-234 to DONEZO"
-    assert after == "Updated resolution of Jira issue JBI-234 to DONEZO"
+    assert before == "Updating resolution of Jira issue JBI-234 to DONEZO for Bug 654321"
+    assert after == "Updated resolution of Jira issue JBI-234 to DONEZO for Bug 654321"
 
 
 def test_update_issue_resolution_raises(
@@ -230,7 +230,7 @@ def test_update_issue_resolution_raises(
             )
 
     [message] = capturelogs.messages
-    assert message == "Updating resolution of Jira issue JBI-234 to DONEZO"
+    assert message == "Updating resolution of Jira issue JBI-234 to DONEZO for Bug 654321"
 
 
 def test_create_jira_issue(

--- a/tests/unit/test_steps.py
+++ b/tests/unit/test_steps.py
@@ -757,7 +757,7 @@ def test_update_issue_priority(
     )
 
     mocked_jira.create_issue.assert_not_called()
-    mocked_jira.update_issue_field(
+    mocked_jira.update_issue_field.assert_called_with(
         key="JBI-234", fields={"priority": {"name": "Urgent"}}
     )
 
@@ -782,7 +782,7 @@ def test_update_issue_severity(
 
     params = action_params_factory(
         jira_project_key=action_context.jira.project,
-        status_map={
+        severity_map={
             "S3": "Moderate",
         },
     )
@@ -791,8 +791,8 @@ def test_update_issue_severity(
     )
 
     mocked_jira.create_issue.assert_not_called()
-    mocked_jira.update_issue_field(
-        key="JBI-234", fields={"severity": {"name": "Moderate"}}
+    mocked_jira.update_issue_field.assert_called_with(
+        key="JBI-234", fields={"customfield_10716": {"value": "Moderate"}}
     )
 
 

--- a/tests/unit/test_steps.py
+++ b/tests/unit/test_steps.py
@@ -728,6 +728,74 @@ def test_change_to_unknown_resolution_with_resolution_map(
     ]
 
 
+def test_update_issue_priority(
+    action_context_factory,
+    mocked_jira,
+    action_params_factory,
+    webhook_event_change_factory,
+):
+    action_context = action_context_factory(
+        operation=Operation.UPDATE,
+        current_step="maybe_update_issue_priority",
+        bug__see_also=["https://mozilla.atlassian.net/browse/JBI-234"],
+        jira__issue="JBI-234",
+        bug__priority="P1",
+        event__action="modify",
+        event__changes=[
+            webhook_event_change_factory(field="priority", removed="--", added="P1")
+        ],
+    )
+
+    params = action_params_factory(
+        jira_project_key=action_context.jira.project,
+        priority_map={
+            "P1": "Urgent",
+        },
+    )
+    steps.maybe_update_issue_priority(
+        action_context, parameters=params, jira_service=JiraService(mocked_jira)
+    )
+
+    mocked_jira.create_issue.assert_not_called()
+    mocked_jira.update_issue_field(
+        key="JBI-234", fields={"priority": {"name": "Urgent"}}
+    )
+
+
+def test_update_issue_severity(
+    action_context_factory,
+    mocked_jira,
+    action_params_factory,
+    webhook_event_change_factory,
+):
+    action_context = action_context_factory(
+        operation=Operation.UPDATE,
+        current_step="maybe_update_issue_severity",
+        bug__see_also=["https://mozilla.atlassian.net/browse/JBI-234"],
+        jira__issue="JBI-234",
+        bug__severity="S3",
+        event__action="modify",
+        event__changes=[
+            webhook_event_change_factory(field="severity", removed="--", added="S3")
+        ],
+    )
+
+    params = action_params_factory(
+        jira_project_key=action_context.jira.project,
+        status_map={
+            "S3": "Moderate",
+        },
+    )
+    steps.maybe_update_issue_severity(
+        action_context, parameters=params, jira_service=JiraService(mocked_jira)
+    )
+
+    mocked_jira.create_issue.assert_not_called()
+    mocked_jira.update_issue_field(
+        key="JBI-234", fields={"severity": {"name": "Moderate"}}
+    )
+
+
 @pytest.mark.parametrize(
     "project_components,bug_component,config_components,expected_jira_components,expected_logs",
     [

--- a/tests/unit/test_steps.py
+++ b/tests/unit/test_steps.py
@@ -762,6 +762,41 @@ def test_update_issue_priority(
     )
 
 
+def test_update_issue_unknown_priority(
+    action_context_factory,
+    mocked_jira,
+    action_params_factory,
+    webhook_event_change_factory,
+    capturelogs,
+):
+    action_context = action_context_factory(
+        operation=Operation.UPDATE,
+        current_step="maybe_update_issue_priority",
+        bug__see_also=["https://mozilla.atlassian.net/browse/JBI-234"],
+        jira__issue="JBI-234",
+        bug__priority="P1",
+        event__action="modify",
+        event__changes=[
+            webhook_event_change_factory(field="priority", removed="--", added="P1")
+        ],
+    )
+
+    params = action_params_factory(
+        jira_project_key=action_context.jira.project,
+        priority_map={
+            "P5": "Later",
+        },
+    )
+    with capturelogs.for_logger("jbi.steps").at_level(logging.DEBUG):
+        result, _ = steps.maybe_update_issue_priority(
+            action_context, parameters=params, jira_service=JiraService(mocked_jira)
+        )
+
+    assert result == steps.StepStatus.INCOMPLETE
+    mocked_jira.update_issue_field.assert_not_called()
+    assert capturelogs.messages == ["Bug priority 'P1' was not in the priority map."]
+
+
 def test_update_issue_severity(
     action_context_factory,
     mocked_jira,
@@ -794,6 +829,41 @@ def test_update_issue_severity(
     mocked_jira.update_issue_field.assert_called_with(
         key="JBI-234", fields={"customfield_10716": {"value": "Moderate"}}
     )
+
+
+def test_update_issue_unknown_severity(
+    action_context_factory,
+    mocked_jira,
+    action_params_factory,
+    webhook_event_change_factory,
+    capturelogs,
+):
+    action_context = action_context_factory(
+        operation=Operation.UPDATE,
+        current_step="maybe_update_issue_severity",
+        bug__see_also=["https://mozilla.atlassian.net/browse/JBI-234"],
+        jira__issue="JBI-234",
+        bug__severity="S3",
+        event__action="modify",
+        event__changes=[
+            webhook_event_change_factory(field="severity", removed="--", added="S3")
+        ],
+    )
+
+    params = action_params_factory(
+        jira_project_key=action_context.jira.project,
+        severity_map={
+            "S1": "High",
+        },
+    )
+    with capturelogs.for_logger("jbi.steps").at_level(logging.DEBUG):
+        result, _ = steps.maybe_update_issue_severity(
+            action_context, parameters=params, jira_service=JiraService(mocked_jira)
+        )
+
+    assert result == steps.StepStatus.INCOMPLETE
+    mocked_jira.update_issue_field.assert_not_called()
+    assert capturelogs.messages == ["Bug severity 'S3' was not in the severity map."]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fix #247 #464 

* [x] Basic code
* [x] Test manually against real server

See https://developer.atlassian.com/server/jira/platform/jira-rest-api-examples/#creating-an-issue-using-custom-fields

### Priority

The `priority` is not custom, and take the text value coming from the mapping as a `name` subfield:

```python
>>> s.client.update_issue_field(key="SE-3850", fields={"priority": {"name": "High"}})
>>>
```
<img width="292" alt="Screenshot 2024-03-05 at 17 12 02" src="https://github.com/mozilla/jira-bugzilla-integration/assets/546692/204ad874-e882-4b5c-b949-8be38ded4d2a">

### Severity

There are two severity fields (one with trailing space 🙄), but both are defined with the same type and take the mapped value as a `value` subfield:

```python
>>> [f for f in s.client.get_all_fields() if "severity" in f["name"].lower()]
[
{'id': 'customfield_10716', 'key': 'customfield_10716', 'name': 'Severity', 'untranslatedName': 'Severity', 'custom': True, 'orderable': True, 'navigable': True, 'searchable': True, 'clauseNames': ['cf[10716]', 'Severity', 'Severity[Dropdown]'], 'schema': {'type': 'option', 'custom': 'com.atlassian.jira.plugin.system.customfieldtypes:select', 'customId': 10716}}, 

{'id': 'customfield_10319', 'key': 'customfield_10319', 'name': 'Severity ', 'untranslatedName': 'Severity ', 'custom': True, 'orderable': True, 'navigable': True, 'searchable': True, 'clauseNames': ['cf[10319]', 'Severity ', 'Severity [Dropdown]'], 'schema': {'type': 'option', 'custom': 'com.atlassian.jira.plugin.system.customfieldtypes:select', 'customId': 10319}}
>>>
```
```

```python
>>> s.client.update_issue_field(key="FIDEFE-4686", fields={"customfield_10319": {"value": "S2"}})
>>>
```

Note, that in order to synchronize this severity field, the following parameter will have to be put in the config file:
```yaml
  parameters:
    jira_project_key: FIDEFE
    jira_severity_field = customfield_10319
```
because navigating the API to guess the proper severity field depending on the configured update screen seems fragile and complicated.
