### PR TITLE
 Fix #248: add `maybe_update_issue_points` step 

### DIFF
--- a/jbi/bugzilla/models.py
+++ b/jbi/bugzilla/models.py
@@ -74,6 +74,8 @@ class Bug(BaseModel, frozen=True):
     creator: Optional[str] = None
     assigned_to: Optional[str] = None
     comment: Optional[WebhookComment] = None
+    # Custom field Firefox for story points
+    cf_fx_points: Optional[str] = None
 
     @property
     def product_component(self) -> str:

--- a/jbi/models.py
+++ b/jbi/models.py
@@ -74,6 +74,7 @@ class ActionParams(BaseModel, frozen=True):
     jira_project_key: str
     steps: ActionSteps = ActionSteps()
     jira_components: JiraComponents = JiraComponents()
+    jira_cf_fx_points_field: str = "customfield_10037"
     jira_severity_field: str = "customfield_10716"
     jira_priority_field: str = "priority"
     jira_resolution_field: str = "resolution"
@@ -88,6 +89,18 @@ class ActionParams(BaseModel, frozen=True):
     }
     resolution_map: dict[str, str] = {}
     severity_map: dict[str, str] = {}
+    cf_fx_points_map: dict[str, int] = {
+        "?": 0,
+        "1": 1,
+        "2": 2,
+        "3": 3,
+        "5": 5,
+        "7": 7,
+        "8": 8,
+        "12": 12,
+        "13": 13,
+        "15": 15,
+    }
     issue_type_map: dict[str, str] = {"task": "Task", "defect": "Bug"}
 
 

--- a/jbi/steps.py
+++ b/jbi/steps.py
@@ -270,6 +270,17 @@ def maybe_update_issue_severity(
     )
 
 
+def maybe_update_issue_points(
+    context: ActionContext, *, parameters: ActionParams, jira_service: JiraService
+) -> StepResult:
+    """
+    Update the Jira issue story points
+    """
+    return _maybe_update_issue_mapped_field(
+        "cf_fx_points", context, parameters, jira_service
+    )
+
+
 def maybe_update_issue_status(
     context: ActionContext, *, parameters: ActionParams, jira_service: JiraService
 ) -> StepResult:

--- a/tests/unit/test_steps.py
+++ b/tests/unit/test_steps.py
@@ -897,6 +897,42 @@ def test_update_issue_points(
     )
 
 
+def test_update_issue_points_missing_in_map(
+    action_context_factory,
+    mocked_jira,
+    action_params_factory,
+    webhook_event_change_factory,
+    capturelogs,
+):
+    action_context = action_context_factory(
+        operation=Operation.UPDATE,
+        current_step="maybe_update_issue_points",
+        bug__see_also=["https://mozilla.atlassian.net/browse/JBI-234"],
+        jira__issue="JBI-234",
+        bug__cf_fx_points="42",
+        event__action="modify",
+        event__changes=[
+            webhook_event_change_factory(field="cf_fx_points", removed="?", added="42")
+        ],
+    )
+
+    params = action_params_factory(
+        jira_project_key=action_context.jira.project,
+    )
+
+    with capturelogs.for_logger("jbi.steps").at_level(logging.DEBUG):
+        result, _ = steps.maybe_update_issue_points(
+            action_context, parameters=params, jira_service=JiraService(mocked_jira)
+        )
+
+    assert result == steps.StepStatus.INCOMPLETE
+    mocked_jira.create_issue.assert_not_called()
+    mocked_jira.update_issue_field.assert_not_called()
+    assert capturelogs.messages == [
+        "Bug cf_fx_points '42' was not in the cf_fx_points map."
+    ]
+
+
 @pytest.mark.parametrize(
     "project_components,bug_component,config_components,expected_jira_components,expected_logs",
     [

--- a/tests/unit/test_steps.py
+++ b/tests/unit/test_steps.py
@@ -866,6 +866,37 @@ def test_update_issue_unknown_severity(
     assert capturelogs.messages == ["Bug severity 'S3' was not in the severity map."]
 
 
+def test_update_issue_points(
+    action_context_factory,
+    mocked_jira,
+    action_params_factory,
+    webhook_event_change_factory,
+):
+    action_context = action_context_factory(
+        operation=Operation.UPDATE,
+        current_step="maybe_update_issue_points",
+        bug__see_also=["https://mozilla.atlassian.net/browse/JBI-234"],
+        jira__issue="JBI-234",
+        bug__cf_fx_points="15",
+        event__action="modify",
+        event__changes=[
+            webhook_event_change_factory(field="cf_fx_points", removed="?", added="15")
+        ],
+    )
+
+    params = action_params_factory(
+        jira_project_key=action_context.jira.project,
+    )
+    steps.maybe_update_issue_points(
+        action_context, parameters=params, jira_service=JiraService(mocked_jira)
+    )
+
+    mocked_jira.create_issue.assert_not_called()
+    mocked_jira.update_issue_field.assert_called_with(
+        key="JBI-234", fields={"customfield_10037": 15}
+    )
+
+
 @pytest.mark.parametrize(
     "project_components,bug_component,config_components,expected_jira_components,expected_logs",
     [


### PR DESCRIPTION
* Requires #247 

```python
>>> [f for f in s.client.get_all_fields() if "points" in f["name"].lower()]
[
{'id': 'customfield_10678', 'key': 'customfield_10678', 'name': 'Points Remaining', 'untranslatedName': 'Points Remaining', 'custom': True, 'orderable': True, 'navigable': True, 'searchable': True, 'clauseNames': ['cf[10678]', 'Points Remaining', 'Points Remaining[Number]'], 'schema': {'type': 'number', 'custom': 'com.atlassian.jira.plugin.system.customfieldtypes:float', 'customId': 10678}}, 

{'id': 'customfield_10310', 'key': 'customfield_10310', 'name': 'Original Story Points', 'untranslatedName': 'Original Story Points', 'custom': True, 'orderable': True, 'navigable': True, 'searchable': True, 'clauseNames': ['cf[10310]', 'Original Story Points', 'Original Story Points[Number]'], 'schema': {'type': 'number', 'custom': 'com.atlassian.jira.plugin.system.customfieldtypes:float', 'customId': 10310}}, 

{'id': 'customfield_10037', 'key': 'customfield_10037', 'name': 'Story Points', 'untranslatedName': 'Story Points', 'custom': True, 'orderable': True, 'navigable': True, 'searchable': True, 'clauseNames': ['cf[10037]', 'Story Points', 'Story Points[Number]'], 'schema': {'type': 'number', 'custom': 'com.atlassian.jira.plugin.system.customfieldtypes:float', 'customId': 10037}}]

```

```python 
>>> s.client.update_issue_field(key="FIDEFE-4686", fields={"customfield_10037": 1})
>>>
```

<img width="305" alt="Screenshot 2024-03-05 at 18 28 24" src="https://github.com/mozilla/jira-bugzilla-integration/assets/546692/0a9cf60b-2c3d-45ee-a8f0-c8f2b0f9815a">
