### PR TITLE
Bug 1884727 - Make omc config update issue points

### DIFF
--- a/config/config.prod.yaml
+++ b/config/config.prod.yaml
@@ -263,6 +263,21 @@
   description: Firefox Messaging System whiteboard tag
   parameters:
     jira_project_key: OMC
+    steps:
+      new:
+        - create_issue
+        - maybe_delete_duplicate
+        - add_link_to_bugzilla
+        - add_link_to_jira
+        - sync_whiteboard_labels
+        - maybe_update_issue_points
+      existing:
+        - update_issue_summary
+        - sync_whiteboard_labels
+        - add_jira_comments_for_changes
+        - maybe_update_issue_points
+      changes:
+        - create_comment
     labels_brackets: both
     issue_type_map:
       defect: Task


### PR DESCRIPTION
The OMC team would like to add the syncing of story points without changing anything else.  Our [current configuration](https://github.com/mozilla/jira-bugzilla-integration/blob/07cb9b1fad7d82bacb7f14884b08921d4b360794/config/config.prod.yaml#L261-L271) doesn't have a `steps` stanza, and so is presumably just using the defaults (is that correct?).

In any case, I couldn't see a way to say "use the defaults except with these two changes", which was the semantics I really wanted, so I cloned the defaults from the code itself, which (I think) should get me almost the same thing, except that it doesn't continue to get new defaults as steps get added to the defaults over time.  Correct?

Assuming those things are correct, I'd love to get this reviewed...

CC @aminomancer

