### PR TITLE
Add new priority and severity sync steps to FXCM project.

### DIFF
--- a/config/config.nonprod.yaml
+++ b/config/config.nonprod.yaml
@@ -14,6 +14,7 @@
         - add_link_to_bugzilla
         - add_link_to_jira
         - maybe_assign_jira_user
+        - maybe_update_issue_priority
         - maybe_update_issue_resolution
         - maybe_update_issue_status
         - sync_whiteboard_labels
@@ -21,6 +22,7 @@
       existing:
         - update_issue_summary
         - maybe_assign_jira_user
+        - maybe_update_issue_priority
         - maybe_update_issue_resolution
         - maybe_update_issue_status
         - sync_whiteboard_labels

--- a/config/config.nonprod.yaml
+++ b/config/config.nonprod.yaml
@@ -41,12 +41,14 @@
         - add_link_to_jira
         - maybe_assign_jira_user
         - maybe_update_issue_resolution
+        - maybe_update_issue_severity
         - maybe_update_issue_status
         - sync_whiteboard_labels
       existing:
         - update_issue_summary
         - maybe_assign_jira_user
         - maybe_update_issue_resolution
+        - maybe_update_issue_severity
         - maybe_update_issue_status
         - sync_whiteboard_labels
     labels_brackets: both

--- a/config/config.nonprod.yaml
+++ b/config/config.nonprod.yaml
@@ -14,7 +14,6 @@
         - add_link_to_bugzilla
         - add_link_to_jira
         - maybe_assign_jira_user
-        - maybe_update_issue_priority
         - maybe_update_issue_resolution
         - maybe_update_issue_status
         - sync_whiteboard_labels
@@ -22,7 +21,6 @@
       existing:
         - update_issue_summary
         - maybe_assign_jira_user
-        - maybe_update_issue_priority
         - maybe_update_issue_resolution
         - maybe_update_issue_status
         - sync_whiteboard_labels
@@ -42,6 +40,7 @@
         - add_link_to_bugzilla
         - add_link_to_jira
         - maybe_assign_jira_user
+        - maybe_update_issue_priority
         - maybe_update_issue_resolution
         - maybe_update_issue_severity
         - maybe_update_issue_status
@@ -49,6 +48,7 @@
       existing:
         - update_issue_summary
         - maybe_assign_jira_user
+        - maybe_update_issue_priority
         - maybe_update_issue_resolution
         - maybe_update_issue_severity
         - maybe_update_issue_status

--- a/config/config.prod.yaml
+++ b/config/config.prod.yaml
@@ -72,6 +72,7 @@
         - add_link_to_bugzilla
         - add_link_to_jira
         - maybe_assign_jira_user
+        - maybe_update_issue_priority
         - maybe_update_issue_resolution
         - maybe_update_issue_severity
         - maybe_update_issue_status
@@ -79,6 +80,7 @@
       existing:
         - update_issue_summary
         - maybe_assign_jira_user
+        - maybe_update_issue_priority
         - maybe_update_issue_resolution
         - maybe_update_issue_severity
         - maybe_update_issue_status

--- a/config/config.prod.yaml
+++ b/config/config.prod.yaml
@@ -73,12 +73,14 @@
         - add_link_to_jira
         - maybe_assign_jira_user
         - maybe_update_issue_resolution
+        - maybe_update_issue_severity
         - maybe_update_issue_status
         - sync_whiteboard_labels
       existing:
         - update_issue_summary
         - maybe_assign_jira_user
         - maybe_update_issue_resolution
+        - maybe_update_issue_severity
         - maybe_update_issue_status
         - sync_whiteboard_labels
     labels_brackets: both


### PR DESCRIPTION
Added `maybe_update_issue_priority` and `maybe_update_issue_severity` to FXCM project in both nonprod and prod configs.