### PR TITLE
Fix GHA labeler config

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,5 +1,7 @@
 configuration:
-- config/*
+- changed-files:
+  - any-glob-to-any-file: 'config/*'
 
 documentation:
-- '**/*.md'
+- changed-files:
+  - any-glob-to-any-file: '**/*.md'


### PR DESCRIPTION
See https://github.com/actions/labeler?tab=readme-ov-file#updating-major-version-of-the-labeler

> When submitting a pull request that includes updates of the labeler action version and associated configuration files, using the pull_request_target event may result in a failed workflow. This is due to the nature of pull_request_target, which uses the code from the base branch rather than the branch linked to the pull request — so, potentially outdated configuration files may not be compatible with the updated labeler action.