### PR TITLE
Removing UTC from time checks as bugzilla times are not tz aware

### DIFF
--- a/jbi/retry.py
+++ b/jbi/retry.py
@@ -1,7 +1,7 @@
 import asyncio
 import logging
 import sys
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta
 from os import getenv
 from time import sleep
 
@@ -23,7 +23,7 @@ logger.addHandler(lsh)
 
 
 async def retry_failed(item_executor=runner.execute_action, queue=get_dl_queue()):
-    min_event_timestamp = datetime.now(UTC) - timedelta(days=int(RETRY_TIMEOUT_DAYS))
+    min_event_timestamp = datetime.now() - timedelta(days=int(RETRY_TIMEOUT_DAYS))
 
     # load all bugs from DLQ
     bugs = await queue.retrieve()

--- a/jbi/retry.py
+++ b/jbi/retry.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 from datetime import UTC, datetime, timedelta
+from dockerflow.logging import JsonLogFormatter
 from os import getenv
 from time import sleep
 
@@ -13,7 +14,10 @@ RETRY_TIMEOUT_DAYS = getenv("DL_QUEUE_RETRY_TIMEOUT_DAYS", 7)
 CONSTANT_RETRY_SLEEP = getenv("DL_QUEUE_CONSTANT_RETRY_SLEEP", 5)
 
 logger = logging.getLogger(__name__)
-
+logger.setLevel(logging.INFO)
+lsh=logging.StreamHandler()
+lsh.setFormatter(JsonLogFormatter(logger_name=__name__))
+logger.addHandler(lsh)
 
 async def retry_failed(item_executor=runner.execute_action, queue=get_dl_queue()):
     min_event_timestamp = datetime.now(UTC) - timedelta(days=int(RETRY_TIMEOUT_DAYS))

--- a/jbi/retry.py
+++ b/jbi/retry.py
@@ -1,9 +1,10 @@
 import asyncio
 import logging
 from datetime import UTC, datetime, timedelta
-from dockerflow.logging import JsonLogFormatter
 from os import getenv
 from time import sleep
+
+from dockerflow.logging import JsonLogFormatter
 
 import jbi.runner as runner
 from jbi.configuration import ACTIONS
@@ -15,9 +16,10 @@ CONSTANT_RETRY_SLEEP = getenv("DL_QUEUE_CONSTANT_RETRY_SLEEP", 5)
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
-lsh=logging.StreamHandler()
+lsh = logging.StreamHandler()
 lsh.setFormatter(JsonLogFormatter(logger_name=__name__))
 logger.addHandler(lsh)
+
 
 async def retry_failed(item_executor=runner.execute_action, queue=get_dl_queue()):
     min_event_timestamp = datetime.now(UTC) - timedelta(days=int(RETRY_TIMEOUT_DAYS))

--- a/jbi/retry.py
+++ b/jbi/retry.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import sys
 from datetime import UTC, datetime, timedelta
 from os import getenv
 from time import sleep
@@ -16,7 +17,7 @@ CONSTANT_RETRY_SLEEP = getenv("DL_QUEUE_CONSTANT_RETRY_SLEEP", 5)
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
-lsh = logging.StreamHandler()
+lsh = logging.StreamHandler(sys.stdout)
 lsh.setFormatter(JsonLogFormatter(logger_name=__name__))
 logger.addHandler(lsh)
 

--- a/tests/fixtures/factories.py
+++ b/tests/fixtures/factories.py
@@ -115,7 +115,7 @@ class WebhookEventFactory(PydanticFactory):
     changes = None
     routing_key = "bug.create"
     target = "bug"
-    time = factory.LazyFunction(lambda: datetime.now(UTC))
+    time = factory.LazyFunction(lambda: datetime.now())
     user = factory.SubFactory(WebhookUserFactory)
 
 

--- a/tests/fixtures/factories.py
+++ b/tests/fixtures/factories.py
@@ -1,4 +1,4 @@
-from datetime import UTC, datetime
+from datetime import datetime
 
 import factory
 

--- a/tests/fixtures/test_retry_file.json
+++ b/tests/fixtures/test_retry_file.json
@@ -1,0 +1,55 @@
+{
+  "payload": {
+    "webhook_id": 1,
+    "webhook_name": "JBI-test",
+    "event": {
+      "action": "modify",
+      "time": "2024-04-18T12:46:54",
+      "user": {
+        "id": 1,
+        "login": "test@foo.tld",
+        "real_name": "Nobody"
+      },
+      "changes": [
+        {
+          "field": "status",
+          "removed": "NEW",
+          "added": "RESOLVED"
+        },
+        {
+          "field": "resolution",
+          "removed": "",
+          "added": "FIXED"
+        }
+      ],
+      "target": "bug",
+      "routing_key": "bug.modify:status,resolution"
+    },
+    "bug": {
+      "id": 1,
+      "is_private": false,
+      "type": "enhancement",
+      "product": "Test",
+      "component": "Test",
+      "whiteboard": "[test]",
+      "keywords": [],
+      "flags": [],
+      "groups": null,
+      "status": "RESOLVED",
+      "resolution": "FIXED",
+      "see_also": [],
+      "summary": "",
+      "severity": "--",
+      "priority": "",
+      "creator": "test@foo.tld",
+      "assigned_to": "test@foo.tld",
+      "comment": null,
+      "cf_fx_points": ""
+    }
+  },
+  "error": {
+    "type": "HTTPError",
+    "description": "",
+    "details": "Error details..."
+  }
+}

--- a/tests/unit/test_retry.py
+++ b/tests/unit/test_retry.py
@@ -1,12 +1,11 @@
 from datetime import datetime, timedelta
 from unittest.mock import MagicMock
 
-import os
 import pytest
 
+from jbi.queue import QueueItem
 from jbi.retry import RETRY_TIMEOUT_DAYS, retry_failed
 from jbi.runner import execute_action
-from jbi.queue import QueueItem
 
 
 def iter_error():


### PR DESCRIPTION
- Removing UTC from time checks as bugzilla times are not tz aware.
- Adjusted unit tests.
- Added test file for retry tests.