### PR TITLE
Remove `maybe_update_issue_resolution` and `maybe_update_issue_status` where no mapping in config

### DIFF
--- a/config/config.nonprod.yaml
+++ b/config/config.nonprod.yaml
@@ -14,14 +14,12 @@
         - add_link_to_bugzilla
         - add_link_to_jira
         - maybe_assign_jira_user
-        - maybe_update_issue_resolution
         - maybe_update_issue_status
         - sync_whiteboard_labels
         - sync_keywords_labels
       existing:
         - update_issue_summary
         - maybe_assign_jira_user
-        - maybe_update_issue_resolution
         - maybe_update_issue_status
         - sync_whiteboard_labels
         - sync_keywords_labels
@@ -41,14 +39,12 @@
         - add_link_to_jira
         - maybe_assign_jira_user
         - maybe_update_issue_priority
-        - maybe_update_issue_resolution
         - maybe_update_issue_status
         - sync_whiteboard_labels
       existing:
         - update_issue_summary
         - maybe_assign_jira_user
         - maybe_update_issue_priority
-        - maybe_update_issue_resolution
         - maybe_update_issue_status
         - sync_whiteboard_labels
     labels_brackets: both
@@ -115,7 +111,6 @@
         - add_link_to_jira
         - maybe_assign_jira_user
         - maybe_update_components
-        - maybe_update_issue_resolution
         - maybe_update_issue_status
         - sync_whiteboard_labels
         - sync_keywords_labels
@@ -123,7 +118,6 @@
         - update_issue_summary
         - maybe_assign_jira_user
         - maybe_update_components
-        - maybe_update_issue_resolution
         - maybe_update_issue_status
         - sync_whiteboard_labels
         - sync_keywords_labels
@@ -159,7 +153,6 @@
         - add_link_to_jira
         - maybe_assign_jira_user
         - maybe_update_components
-        - maybe_update_issue_resolution
         - maybe_update_issue_status
         - sync_whiteboard_labels
         - sync_keywords_labels
@@ -167,7 +160,6 @@
         - update_issue_summary
         - maybe_assign_jira_user
         - maybe_update_components
-        - maybe_update_issue_resolution
         - maybe_update_issue_status
         - sync_whiteboard_labels
         - sync_keywords_labels
@@ -206,12 +198,10 @@
         - add_link_to_bugzilla
         - add_link_to_jira
         - maybe_assign_jira_user
-        - maybe_update_issue_resolution
         - maybe_update_issue_status
       existing:
         - update_issue_summary
         - maybe_assign_jira_user
-        - maybe_update_issue_resolution
         - maybe_update_issue_status
       comment:
         - create_comment
@@ -248,12 +238,10 @@
         - add_link_to_bugzilla
         - add_link_to_jira
         - maybe_assign_jira_user
-        - maybe_update_issue_resolution
         - maybe_update_issue_status
       existing:
         - update_issue_summary
         - maybe_assign_jira_user
-        - maybe_update_issue_resolution
         - maybe_update_issue_status
       comment:
         - create_comment

--- a/config/config.prod.yaml
+++ b/config/config.prod.yaml
@@ -27,7 +27,6 @@
         - add_link_to_bugzilla
         - add_link_to_jira
         - maybe_assign_jira_user
-        - maybe_update_issue_resolution
         - maybe_update_issue_status
         - maybe_update_issue_priority
         - maybe_update_issue_severity
@@ -36,7 +35,6 @@
       existing:
         - update_issue_summary
         - maybe_assign_jira_user
-        - maybe_update_issue_resolution
         - maybe_update_issue_status
         - maybe_update_issue_priority
         - maybe_update_issue_severity
@@ -73,14 +71,12 @@
         - add_link_to_jira
         - maybe_assign_jira_user
         - maybe_update_issue_priority
-        - maybe_update_issue_resolution
         - maybe_update_issue_status
         - sync_whiteboard_labels
       existing:
         - update_issue_summary
         - maybe_assign_jira_user
         - maybe_update_issue_priority
-        - maybe_update_issue_resolution
         - maybe_update_issue_status
         - sync_whiteboard_labels
     labels_brackets: both
@@ -193,6 +189,7 @@
       WORKSFORME: "Cannot Reproduce"
       INCOMPLETE: Incomplete
       MOVED: Moved
+
 - whiteboard_tag: fxsync
   bugzilla_user_id: 624105
   description: Firefox Sync Team whiteboard tag
@@ -226,13 +223,11 @@
         - add_link_to_bugzilla
         - add_link_to_jira
         - maybe_assign_jira_user
-        - maybe_update_issue_resolution
         - maybe_update_issue_status
         - sync_whiteboard_labels
       existing:
         - update_issue_summary
         - maybe_assign_jira_user
-        - maybe_update_issue_resolution
         - maybe_update_issue_status
         - sync_whiteboard_labels
     labels_brackets: both
@@ -356,13 +351,11 @@
         - add_link_to_bugzilla
         - add_link_to_jira
         - maybe_assign_jira_user
-        - maybe_update_issue_resolution
         - maybe_update_issue_status
         - sync_whiteboard_labels
       existing:
         - update_issue_summary
         - maybe_assign_jira_user
-        - maybe_update_issue_resolution
         - maybe_update_issue_status
         - sync_whiteboard_labels
     labels_brackets: both
@@ -485,12 +478,10 @@
         - add_link_to_bugzilla
         - add_link_to_jira
         - maybe_assign_jira_user
-        - maybe_update_issue_resolution
         - maybe_update_issue_status
       existing:
         - update_issue_summary
         - maybe_assign_jira_user
-        - maybe_update_issue_resolution
         - maybe_update_issue_status
       comment:
         - create_comment


### PR DESCRIPTION
if `status_map` or `resolution_map` aren't set, their default value is `{}` and the steps are no-op, and can thus be removed without impact.

