### PR TITLE
Logging a warning when we try to remove a file but cannot find it

### DIFF
--- a/jbi/queue.py
+++ b/jbi/queue.py
@@ -184,8 +184,12 @@ class FileBackend(QueueBackend):
     async def remove(self, bug_id: int, identifier: str):
         bug_dir = self.location / f"{bug_id}"
         item_path = bug_dir / (identifier + ".json")
-        item_path.unlink(missing_ok=True)
-        logger.debug("Removed %s from queue for bug %s", identifier, bug_id)
+        try:
+            logger.debug("Removing %s from queue for bug %s", identifier, bug_id)
+            item_path.unlink()
+        except FileNotFoundError as exc:
+            logger.warning("Item at not found at path %s", str(item_path), exc)
+
         if not any(bug_dir.iterdir()):
             bug_dir.rmdir()
             logger.debug("Removed directory for bug %s", bug_id)

--- a/jbi/queue.py
+++ b/jbi/queue.py
@@ -188,7 +188,7 @@ class FileBackend(QueueBackend):
             logger.debug("Removing %s from queue for bug %s", identifier, bug_id)
             item_path.unlink()
         except FileNotFoundError as exc:
-            logger.warning("Item at not found at path %s", str(item_path), exc)
+            logger.warning("Could not delete missing item at path %s", str(item_path), exc)
 
         if not any(bug_dir.iterdir()):
             bug_dir.rmdir()


### PR DESCRIPTION
Adjusted `queue.remove` to log a warning when the file it's trying to remove cannot be found.
This could happen if we change the item model, specifically around the `identifier` property.