### PR TITLE
Fix #983: use `operation=handle` in log context when fetching Jira issue

### DIFF
--- a/jbi/runner.py
+++ b/jbi/runner.py
@@ -256,7 +256,8 @@ def execute_action(
         else:
             # Check that issue exists (and is readable)
             jira_issue = jira.get_service().get_issue(
-                action_context, action_context.jira.issue
+                action_context.update(operation=Operation.HANDLE),
+                action_context.jira.issue,
             )
             if not jira_issue:
                 raise IgnoreInvalidRequestError(


### PR DESCRIPTION
Fix #983

-----
<img width="999" alt="Screenshot 2024-04-30 at 16 38 14" src="https://github.com/mozilla/jira-bugzilla-integration/assets/546692/57541716-9f13-4c5d-9bae-d30a9f07c049">

-----
<img width="1028" alt="Screenshot 2024-04-30 at 16 38 28" src="https://github.com/mozilla/jira-bugzilla-integration/assets/546692/959dc778-5bac-4c1b-90a2-478f548c39bd">


-----
<img width="947" alt="Screenshot 2024-04-30 at 16 38 45" src="https://github.com/mozilla/jira-bugzilla-integration/assets/546692/b2dc74d9-8a42-4d4f-a29e-68841423477c">


-----
<img width="951" alt="Screenshot 2024-04-30 at 16 38 52" src="https://github.com/mozilla/jira-bugzilla-integration/assets/546692/49c3818b-bc27-4fd3-bc67-2168ef6517c1">
