### PR TITLE
Fix #971: raise if bug info cannot be fetched from Bugzilla

### DIFF
--- a/tests/unit/bugzilla/test_client.py
+++ b/tests/unit/bugzilla/test_client.py
@@ -126,7 +126,7 @@ def test_bugzilla_get_bug_raises_if_response_is_401_and_credentials_invalid(
         bugzilla_client.get_bug(42)
 
     assert (
-        "401 Client Error: Unauthorized for url: https://bugzilla.mozilla.org/rest/bug/42"
+        f"401 Client Error: Unauthorized for url: {settings.bugzilla_base_url}/rest/bug/42"
         in str(exc)
     )
 


### PR DESCRIPTION
Fix #971

Before we would ignore the event if the bug data could not be fetched from Bugzilla.
This could happen when:
- bug made private while event sitting in the queue
- bugzilla suddenly returning 5XX after sending webhook 
- bugzilla credentials invalid 


With these changes, we only ignore the event if the bug cannot be fetched because it's private 