### PR TITLE
Fixes #989 - remove markdown conversion for summary field

### DIFF
--- a/jbi/jira/service.py
+++ b/jbi/jira/service.py
@@ -292,7 +292,7 @@ class JiraService:
 
     def update_issue_summary(self, context: ActionContext):
         """Update's an issue's summary with the description of an incoming bug"""
-        truncated_summary = context.bug.summary
+        truncated_summary = context.bug.summary or ""
 
         if len(truncated_summary) > JIRA_DESCRIPTION_CHAR_LIMIT:
             # Truncate on last word.

--- a/jbi/jira/service.py
+++ b/jbi/jira/service.py
@@ -292,9 +292,14 @@ class JiraService:
 
     def update_issue_summary(self, context: ActionContext):
         """Update's an issue's summary with the description of an incoming bug"""
-        truncated_summary = markdown_to_jira(
-            context.bug.summary or "", max_length=JIRA_DESCRIPTION_CHAR_LIMIT
-        )
+        truncated_summary = context.bug.summary
+
+        if len(truncated_summary) > JIRA_DESCRIPTION_CHAR_LIMIT:
+            # Truncate on last word.
+            truncated_summary = truncated_summary[:JIRA_DESCRIPTION_CHAR_LIMIT].rsplit(
+                maxsplit=1
+            )[0]
+
         return self.update_issue_field(
             context, field="summary", value=truncated_summary
         )

--- a/jbi/queue.py
+++ b/jbi/queue.py
@@ -188,7 +188,9 @@ class FileBackend(QueueBackend):
             logger.debug("Removing %s from queue for bug %s", identifier, bug_id)
             item_path.unlink()
         except FileNotFoundError as exc:
-            logger.warning("Could not delete missing item at path %s", str(item_path), exc)
+            logger.warning(
+                "Could not delete missing item at path %s", str(item_path), exc
+            )
 
         if not any(bug_dir.iterdir()):
             bug_dir.rmdir()

--- a/tests/unit/test_steps.py
+++ b/tests/unit/test_steps.py
@@ -150,11 +150,11 @@ def test_modified_public(
     action_context = action_context_factory(
         operation=Operation.UPDATE,
         bug__see_also=["https://mozilla.atlassian.net/browse/JBI-234"],
-        bug__summary="JBI [Test](http://test.com)",
+        bug__summary="[JBI] (Test)",
         jira__issue="JBI-234",
         event__changes=[
             webhook_event_change_factory(
-                field="summary", removed="", added="JBI [Test](http://test.com)"
+                field="summary", removed="", added="[JBI] (Test)"
             )
         ],
     )
@@ -171,7 +171,7 @@ def test_modified_public(
 
     mocked_jira.update_issue_field.assert_called_once_with(
         key="JBI-234",
-        fields={"summary": "JBI [Test|http://test.com]"},
+        fields={"summary": "[JBI] (Test)"},
     )
 
 


### PR DESCRIPTION
Fixes #989 by removing the markdown conversion for the summary field. Updated associated unit test.

The summary field is a plain text field in bugzilla and won't render markdown formatting in it. So this was an unnecessary conversion afaict.