### PR TITLE
Account for ignorable payloads in retry script, try to prevent them in runner

### DIFF
--- a/jbi/runner.py
+++ b/jbi/runner.py
@@ -217,6 +217,13 @@ def execute_action(
         if bug.is_private:
             raise IgnoreInvalidRequestError("private bugs are not supported")
 
+        try:
+            action = lookup_action(bug, actions)
+        except ActionNotFoundError as err:
+            raise IgnoreInvalidRequestError(
+                f"no bug whiteboard matching action tags: {err}"
+            ) from err
+
         logger.info(
             "Handling incoming request",
             extra=runner_context.model_dump(),
@@ -229,12 +236,7 @@ def execute_action(
             raise IgnoreInvalidRequestError(str(err)) from err
 
         runner_context = runner_context.update(bug=bug)
-        try:
-            action = lookup_action(bug, actions)
-        except ActionNotFoundError as err:
-            raise IgnoreInvalidRequestError(
-                f"no bug whiteboard matching action tags: {err}"
-            ) from err
+
         runner_context = runner_context.update(action=action)
 
         linked_issue_key: Optional[str] = bug.extract_from_see_also(

--- a/tests/unit/test_retry.py
+++ b/tests/unit/test_retry.py
@@ -116,7 +116,6 @@ async def test_retry_remove_expired(
         len(mock_queue.done.call_args_list) == 2
     ), "both items should have been marked as done"
     assert caplog.text.count("failed to reprocess event") == 0
-    assert caplog.text.count("skipping events") == 0
     assert caplog.text.count("removing expired event") == 1
     mock_executor.assert_called_once()  # only one item should have been attempted to be processed
     assert metrics == {
@@ -139,7 +138,6 @@ async def test_retry_bug_failed(caplog, mock_queue, mock_executor, queue_item_fa
     mock_queue.retrieve.assert_called_once()
     mock_queue.done.assert_called_once()  # one item should have been marked as done
     assert caplog.text.count("failed to reprocess event") == 0
-    assert caplog.text.count("skipping events") == 0
     assert caplog.text.count("removing expired event") == 0
     assert caplog.text.count("failed to parse events for bug") == 1
     mock_executor.assert_called_once()  # only one item should have been attempted to be processed

--- a/tests/unit/test_retry.py
+++ b/tests/unit/test_retry.py
@@ -1,5 +1,5 @@
 from datetime import UTC, datetime, timedelta
-from unittest.mock import MagicMock
+from unittest import mock
 
 import pytest
 
@@ -7,11 +7,11 @@ from jbi.retry import RETRY_TIMEOUT_DAYS, retry_failed
 from jbi.runner import execute_action
 
 
-def iter_error():
-    mock = MagicMock()
-    mock.__aiter__.return_value = None
-    mock.__aiter__.side_effect = Exception("Throwing an exception")
-    return mock
+def mock_aiter_error():
+    _mock = mock.MagicMock()
+    _mock.__aiter__.return_value = None
+    _mock.__aiter__.side_effect = Exception("Throwing an exception")
+    return _mock
 
 
 async def aiter_sync(iterable):
@@ -20,8 +20,8 @@ async def aiter_sync(iterable):
 
 
 @pytest.fixture
-def mock_executor():
-    return MagicMock(spec=execute_action)
+def mock_executor(mocker):
+    return mocker.MagicMock(spec=execute_action)
 
 
 @pytest.mark.asyncio
@@ -131,7 +131,7 @@ async def test_retry_remove_expired(
 async def test_retry_bug_failed(caplog, mock_queue, mock_executor, queue_item_factory):
     mock_queue.retrieve.return_value = {
         1: aiter_sync([queue_item_factory(payload__bug__id=1)]),
-        2: iter_error(),
+        2: mock_aiter_error(),
     }
 
     metrics = await retry_failed(item_executor=mock_executor, queue=mock_queue)

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -160,7 +160,6 @@ def test_execution_logging_for_ignored_requests(
             execute_action(request=webhook, actions=actions)
 
     assert capturelogs.messages == [
-        "Handling incoming request",
         "Ignore incoming request: no bug whiteboard matching action tags: devtest",
     ]
 


### PR DESCRIPTION
Somehow, some payloads that we'd normally ignore ended up in our Dead Letter Queue. This PR:
- accounts for such payloads in the retry script when trying to process items in the queue
- tries to prevent such items from making in into the queue by moving the guard to check if the bug has a matching a whiteboard tag before we refresh the bug data