### PR TITLE
Remove `sha-` prefix from image tags

### DIFF
--- a/.github/workflows/build-publish.yaml
+++ b/.github/workflows/build-publish.yaml
@@ -40,7 +40,7 @@ jobs:
           tags: |
             type=semver,pattern={{raw}}
             type=raw,value=latest,enable={{is_default_branch}}
-            type=sha,enable={{is_default_branch}}
+            type=sha,prefix=,enable={{is_default_branch}}
 
       - name: Login to Docker Hub
         if: github.event_name != 'pull_request'


### PR DESCRIPTION
See: https://github.com/docker/metadata-action?tab=readme-ov-file#typesha

We're doing this so that we can associate deployments with a specific git ref (which is easier to do without having to strip off the `sha-` prefix)