### PR TITLE
Ref #984: Simple comment when attachment is added to bug

### DIFF
--- a/jbi/__init__.py
+++ b/jbi/__init__.py
@@ -19,6 +19,7 @@ class Operation(str, Enum):
     UPDATE = "update"
     DELETE = "delete"
     COMMENT = "comment"
+    ATTACHMENT = "attachment"
     LINK = "link"
 
 

--- a/jbi/jira/service.py
+++ b/jbi/jira/service.py
@@ -121,10 +121,11 @@ class JiraService:
 
         if context.event.target == "attachment":
             routing_key = (
-                context.event.routing_key or ".modified"
-            )  # only for type checking.
+                context.event.routing_key or ".modify"  # only to please type checking.
+            )
             _, verb = routing_key.rsplit(".", 1)
-            formatted_comment = f"*{commenter}* {verb}d an attachment"
+            past_verb = {"modify": "modified"}.get(verb, f"{verb}d")
+            formatted_comment = f"*{commenter}* {past_verb} an attachment"
         else:
             comment = context.bug.comment
             assert comment  # See jbi.steps.create_comment()

--- a/jbi/jira/service.py
+++ b/jbi/jira/service.py
@@ -118,14 +118,22 @@ class JiraService:
         """Publish a comment on the specified Jira issue"""
         context = context.update(operation=Operation.COMMENT)
         commenter = context.event.user.login if context.event.user else "unknown"
-        comment = context.bug.comment
-        assert comment  # See jbi.steps.create_comment()
-        assert comment.body  # Also see jbi.steps.create_comment()
+
+        if context.event.target == "attachment":
+            routing_key = (
+                context.event.routing_key or ".modified"
+            )  # only for type checking.
+            _, verb = routing_key.rsplit(".", 1)
+            formatted_comment = f"*{commenter}* {verb}d an attachment"
+        else:
+            comment = context.bug.comment
+            assert comment  # See jbi.steps.create_comment()
+            assert comment.body  # Also see jbi.steps.create_comment()
+            formatted_comment = (
+                f"*{commenter}* commented: \n{markdown_to_jira(comment.body)}"
+            )
 
         issue_key = context.jira.issue
-        formatted_comment = (
-            f"*{commenter}* commented: \n{markdown_to_jira(comment.body)}"
-        )
         jira_response = self.client.issue_add_comment(
             issue_key=issue_key,
             comment=formatted_comment,

--- a/jbi/models.py
+++ b/jbi/models.py
@@ -43,6 +43,9 @@ class ActionSteps(BaseModel, frozen=True):
     comment: list[str] = [
         "create_comment",
     ]
+    attachment: list[str] = [
+        "create_comment",
+    ]
 
     @field_validator("*")
     @classmethod

--- a/jbi/runner.py
+++ b/jbi/runner.py
@@ -37,6 +37,7 @@ GROUP_TO_OPERATION = {
     "new": Operation.CREATE,
     "existing": Operation.UPDATE,
     "comment": Operation.COMMENT,
+    "attachment": Operation.ATTACHMENT,
 }
 
 
@@ -287,6 +288,9 @@ def execute_action(
 
             elif event.target == "comment":
                 action_context = action_context.update(operation=Operation.COMMENT)
+
+            elif event.target == "attachment":
+                action_context = action_context.update(operation=Operation.ATTACHMENT)
 
         if action_context.operation == Operation.IGNORE:
             raise IgnoreInvalidRequestError(

--- a/jbi/steps.py
+++ b/jbi/steps.py
@@ -50,19 +50,20 @@ def create_comment(context: ActionContext, *, jira_service: JiraService) -> Step
     """Create a Jira comment using `context.bug.comment`"""
     bug = context.bug
 
-    if bug.comment is None:
-        logger.info(
-            "No matching comment found in payload",
-            extra=context.model_dump(),
-        )
-        return (StepStatus.NOOP, context)
+    if context.event.target == "comment":
+        if bug.comment is None:
+            logger.info(
+                "No matching comment found in payload",
+                extra=context.model_dump(),
+            )
+            return (StepStatus.NOOP, context)
 
-    if not bug.comment.body:
-        logger.info(
-            "Comment message is empty",
-            extra=context.model_dump(),
-        )
-        return (StepStatus.NOOP, context)
+        if not bug.comment.body:
+            logger.info(
+                "Comment message is empty",
+                extra=context.model_dump(),
+            )
+            return (StepStatus.NOOP, context)
 
     jira_response = jira_service.add_jira_comment(context)
     context = context.append_responses(jira_response)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -165,6 +165,18 @@ def context_comment_example(action_context_factory) -> ActionContext:
     )
 
 
+@pytest.fixture
+def context_attachment_example(action_context_factory) -> ActionContext:
+    return action_context_factory(
+        operation=Operation.ATTACHMENT,
+        bug__see_also=["https://mozilla.atlassian.net/browse/JBI-234"],
+        event__target="attachment",
+        event__routed_key="attachment.create",
+        event__user__login="phab-bot@bmo.tld",
+        jira__issue="JBI-234",
+    )
+
+
 @pytest.fixture(autouse=True)
 def sleepless(monkeypatch):
     # https://stackoverflow.com/a/54829577

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -588,6 +588,20 @@ def test_counter_is_incremented_for_comment(
     mocked.incr.assert_any_call("jbi.operation.comment.count")
 
 
+def test_counter_is_incremented_for_attachment(
+    actions, webhook_request_factory, mocked_bugzilla, mocked_jira
+):
+    webhook_payload = webhook_request_factory(
+        event__target="attachment",
+        bug__see_also=["https://mozilla.atlassian.net/browse/JBI-234"],
+    )
+    mocked_bugzilla.get_bug.return_value = webhook_payload.bug
+    mocked_jira.get_issue.return_value = {"fields": {"project": {"key": "JBI"}}}
+    with mock.patch("jbi.runner.statsd") as mocked:
+        execute_action(request=webhook_payload, actions=actions)
+    mocked.incr.assert_any_call("jbi.operation.attachment.count")
+
+
 @pytest.mark.parametrize(
     "whiteboard",
     [

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -386,8 +386,7 @@ def test_default_invalid_init():
 def test_unspecified_groups_come_from_default_steps(action_params_factory):
     action = Executor(action_params_factory(steps={"comment": ["create_comment"]}))
 
-    assert len(action.steps) == 3
-    assert action.steps
+    assert len(action.steps) == 4
 
 
 def test_default_returns_callable_without_data(action_params):

--- a/tests/unit/test_steps.py
+++ b/tests/unit/test_steps.py
@@ -234,6 +234,21 @@ def test_added_comment(
     )
 
 
+def test_added_attachment(
+    context_attachment_example: ActionContext, mocked_jira, action_params_factory
+):
+    callable_object = Executor(
+        action_params_factory(jira_project_key=context_attachment_example.jira.project)
+    )
+
+    callable_object(context=context_attachment_example)
+
+    mocked_jira.issue_add_comment.assert_called_once_with(
+        issue_key="JBI-234",
+        comment="*phab-bot@bmo.tld* created an attachment",
+    )
+
+
 def test_empty_comment_not_added(
     action_context_factory, mocked_jira, action_params_factory
 ):


### PR DESCRIPTION
Ref #984 

**Note**: will require changes in our Webhook. Attachment events must be enabled (see Bugzilla non prod)