### PR TITLE
Specify non-default severity field for GENAI

### DIFF
--- a/config/config.prod.yaml
+++ b/config/config.prod.yaml
@@ -599,6 +599,7 @@
   description: Firefox GenAI
   parameters:
     jira_project_key: GENAI
+    jira_severity_field: customfield_10319
     steps:
       new:
         - create_issue


### PR DESCRIPTION
See also: 6ea4c84fabde3b0d1b5c27407b4a12b021d9e384 (#901).

For both projects that specify severity, both set this custom field. Perhaps this needs to become the new default.