### PR TITLE
Fix #1055: Add comment and resolution when setting status to Cancelled

### DIFF
--- a/jbi/jira/service.py
+++ b/jbi/jira/service.py
@@ -290,6 +290,13 @@ class JiraService:
         issue_key = context.jira.issue
         assert issue_key  # Until we have more fine-grained typing of contexts
 
+        kwargs = {}
+        if jira_status == "Cancelled":
+            kwargs["fields"] = {
+                "comment": "Issue was cancelled.",
+                "resolution": {"name": "Invalid"},
+            }
+
         logger.info(
             "Updating Jira status to %s",
             jira_status,
@@ -298,6 +305,7 @@ class JiraService:
         return self.client.set_issue_status(
             issue_key,
             jira_status,
+            **kwargs,
         )
 
     def update_issue_summary(self, context: ActionContext):


### PR DESCRIPTION
Fix #1055

According to [Jira support](https://mozilla-hub.atlassian.net/servicedesk/customer/portal/4/SDD-26417), `comment` is required by default when setting status to `Cancelled`.

As for resolution, either we oblige consumers to have `maybe_update_issue_resolution` before `maybe_update_issue_status` or we add something that forces the field value when switching to `Cancelled`