### PR TITLE
Publish to GAR along with Dockerhub

### DIFF
--- a/.github/workflows/build-publish.yaml
+++ b/.github/workflows/build-publish.yaml
@@ -16,13 +16,20 @@ jobs:
     env:
       TEST_TAG: ${{ github.repository }}:test
       TEST_CONTAINER_NAME: jbi-healthcheck
+      GAR_LOCATION: us
+      GAR_REPOSITORY: jbi-prod
+      GCP_PROJECT_ID: moz-fx-jbi-prod
+      IMAGE: jbi
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Fetch everything (tags)
+          fetch-tags: true
+      
       - name: Set tag version
         run: echo "JBI_TAG=$(git describe --tags --abbrev=4)" >> $GITHUB_ENV
+      
       - name: Build `version.json` file
         run: |
           printf '{\n    "commit": "%s",\n    "version": "%s",\n    "source": "%s",\n    "build": "%s"\n}\n' \
@@ -35,12 +42,23 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ github.repository }}
+          images: 
+            ${{ github.repository }}
+            ${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.GCP_PROJECT_ID }}/${{ env.GAR_REPOSITORY }}/${{ env.IMAGE }}
           # https://github.com/marketplace/actions/docker-metadata-action#tags-input
           tags: |
             type=semver,pattern={{raw}}
             type=raw,value=latest,enable={{is_default_branch}}
             type=sha,prefix=,enable={{is_default_branch}}
+
+      - id: gcp_auth
+        name: Log into GCP
+        uses: google-github-actions/auth@v2
+        if: github.event_name != 'pull_request'
+        with:
+          token_format: access_token
+          service_account: artifact-writer@${{ env.GCP_PROJECT_ID }}.iam.gserviceaccount.com
+          workload_identity_provider: ${{ vars.GCPV2_GITHUB_WORKLOAD_IDENTITY_PROVIDER }}
 
       - name: Login to Docker Hub
         if: github.event_name != 'pull_request'
@@ -49,6 +67,9 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Build and export to Docker
         uses: docker/build-push-action@v6
         with:
@@ -56,6 +77,8 @@ jobs:
           load: true
           push: false
           tags: ${{ env.TEST_TAG }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Spin up container
         run: |
@@ -80,3 +103,5 @@ jobs:
           context: .
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/build-publish.yaml
+++ b/.github/workflows/build-publish.yaml
@@ -60,6 +60,14 @@ jobs:
           service_account: artifact-writer@${{ env.GCP_PROJECT_ID }}.iam.gserviceaccount.com
           workload_identity_provider: ${{ vars.GCPV2_GITHUB_WORKLOAD_IDENTITY_PROVIDER }}
 
+      - name: Login to GAR
+        uses: docker/login-action@v3
+        if: github.event_name != 'pull_request'
+        with:
+          registry: ${{ env.GAR_LOCATION }}-docker.pkg.dev
+          username: oauth2accesstoken
+          password: ${{ steps.gcp_auth.outputs.access_token }}
+
       - name: Login to Docker Hub
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v3


### PR DESCRIPTION
This will also require setting a `GCPV2_GITHUB_WORKLOAD_IDENTITY_PROVIDER` [repository variable](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables#creating-configuration-variables-for-a-repository).