### PR TITLE
Add token permissions for build-publish workflow

### DIFF
--- a/.github/workflows/build-publish.yaml
+++ b/.github/workflows/build-publish.yaml
@@ -13,6 +13,9 @@ on:
 jobs:
   build-and-publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: 'read'
+      id-token: 'write'
     env:
       TEST_TAG: ${{ github.repository }}:test
       TEST_CONTAINER_NAME: jbi-healthcheck


### PR DESCRIPTION
See: https://github.com/mozilla/jira-bugzilla-integration/actions/runs/12240286031/job/34142724788