### PR TITLE
Fixes #1090 - Removing a point value from bugzilla should set jira's point value to 0

### DIFF
--- a/jbi/models.py
+++ b/jbi/models.py
@@ -100,6 +100,7 @@ class ActionParams(BaseModel, frozen=True):
         "S4": "S4",
     }
     cf_fx_points_map: dict[str, int] = {
+        "---": 0,
         "": 0,
         "?": 0,
         "1": 1,

--- a/jbi/queue.py
+++ b/jbi/queue.py
@@ -104,7 +104,7 @@ class QueueItem(BaseModel, frozen=True):
     @computed_field  # type: ignore
     @property
     def identifier(self) -> str:
-        return f"{self.payload.event.time}-{self.payload.bug.id}-{self.payload.event.action}-{"error" if self.error else "postponed"}"
+        return f"{self.payload.event.time}-{self.payload.bug.id}-{self.payload.event.action}-{'error' if self.error else 'postponed'}"
 
 
 @lru_cache(maxsize=1)

--- a/tests/unit/test_retry.py
+++ b/tests/unit/test_retry.py
@@ -113,9 +113,9 @@ async def test_retry_remove_expired(
 
     metrics = await retry_failed(item_executor=mock_executor, queue=mock_queue)
     mock_queue.retrieve.assert_called_once()
-    assert (
-        len(mock_queue.done.call_args_list) == 2
-    ), "both items should have been marked as done"
+    assert len(mock_queue.done.call_args_list) == 2, (
+        "both items should have been marked as done"
+    )
     assert caplog.text.count("failed to reprocess event") == 0
     assert caplog.text.count("removing expired event") == 1
     mock_executor.assert_called_once()  # only one item should have been attempted to be processed
@@ -140,9 +140,9 @@ async def test_retry_remove_invalid(
         mock.DEFAULT,
     ]
     metrics = await retry_failed(item_executor=mock_executor, queue=mock_queue)
-    assert (
-        len(mock_queue.done.call_args_list) == 2
-    ), "both items should have been marked as done"
+    assert len(mock_queue.done.call_args_list) == 2, (
+        "both items should have been marked as done"
+    )
     assert caplog.text.count("removing invalid event") == 1
     assert metrics == {
         "bug_count": 1,


### PR DESCRIPTION
Resolves #1090 by converting the `---` value from bugzilla to `0` for point values. 
Added unit test to cover this scenario in the future.

Also ran format which adjusted some quotes and commas in unrelated files that I keep seeing get complained about on PRs and it's bugging me.