### PR TITLE
Add FOG Migration mirroring to JIRA

### DIFF
--- a/config/config.prod.yaml
+++ b/config/config.prod.yaml
@@ -672,3 +672,30 @@
       enhancement: Story
       task: Task
       defect: Bug
+
+- whiteboard_tag: fog-migration
+  bugzilla_user_id: 248036
+  description: FOG Migration
+  parameters:
+    jira_project_key: DENG
+    steps:
+      new:
+        - create_issue
+        - maybe_delete_duplicate
+        - add_link_to_bugzilla
+        - add_link_to_jira
+        - maybe_assign_jira_user
+      existing:
+        - update_issue_summary
+        - add_jira_comments_for_changes
+        - maybe_assign_jira_user
+        - maybe_update_issue_resolution
+        - maybe_update_issue_status
+        - sync_keywords_labels
+        - sync_whiteboard_labels
+      comment:
+        - create_comment
+    issue_type_map:
+      enhancement: Story
+      task: Task
+      defect: Bug


### PR DESCRIPTION
This should look for bugs with the [fog-migration] whiteboard tag and mirror them to JIRA.