### PR TITLE
Fixes #1096 - Ignores '---' values for mapped fields on create

### DIFF
--- a/jbi/steps.py
+++ b/jbi/steps.py
@@ -220,7 +220,7 @@ def _maybe_update_issue_mapped_field(
     target_value = getattr(parameters, f"{source_field}_map").get(source_value)
 
     # If field is empty on create, or update is about another field, then nothing to do.
-    if (context.operation == Operation.CREATE and source_value == "") or (
+    if (context.operation == Operation.CREATE and source_value in ["", "---"]) or (
         context.operation == Operation.UPDATE
         and source_field not in context.event.changed_fields()
     ):

--- a/tests/unit/test_steps.py
+++ b/tests/unit/test_steps.py
@@ -1015,7 +1015,7 @@ def test_update_issue_points_removed(
     )
 
 
-def test_emptyupdate_issue_points_ignored(
+def test_empty_issue_points_ignored_on_create(
     action_context_factory,
     mocked_jira,
     action_params_factory,

--- a/tests/unit/test_steps.py
+++ b/tests/unit/test_steps.py
@@ -1015,6 +1015,30 @@ def test_update_issue_points_removed(
     )
 
 
+def test_emptyupdate_issue_points_ignored(
+    action_context_factory,
+    mocked_jira,
+    action_params_factory,
+    webhook_event_change_factory,
+):
+    action_context = action_context_factory(
+        operation=Operation.CREATE,
+        current_step="maybe_update_issue_points",
+        bug__see_also=["https://mozilla.atlassian.net/browse/JBI-234"],
+        jira__issue="JBI-234",
+        bug__cf_fx_points="---",
+    )
+
+    params = action_params_factory(
+        jira_project_key=action_context.jira.project,
+    )
+    steps.maybe_update_issue_points(
+        action_context, parameters=params, jira_service=JiraService(mocked_jira)
+    )
+
+    mocked_jira.update_issue_field.assert_not_called()
+
+
 def test_update_issue_points_missing_in_map(
     action_context_factory,
     mocked_jira,


### PR DESCRIPTION
Fixes #1096 by ignoring `---` values for create steps in `_maybe_update_issue_mapped_field`.

Need to add unit test still.