### PR TITLE
Show method + URL on Jira exceptions

### DIFF
--- a/jbi/jira/client.py
+++ b/jbi/jira/client.py
@@ -64,7 +64,7 @@ class JiraClient(Jira):
                 extra={"body": response.text},
             )
             # Set the exception message so that its str version contains details.
-            msg = f"HTTP {exc.response.status_code}: {exc}"
+            msg = f"{request.method} {request.path_url} -> HTTP {response.status_code}: {exc}"
             exc.args = (msg,) + exc.args[1:]
             raise
 

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -375,7 +375,10 @@ async def test_execute_or_queue_http_error_details(
 
     items = (await dl_queue.retrieve())[bug.id]
     [item] = [i async for i in items]
-    assert item.error.description == "HTTP 400: Field 'resolution' cannot be set."
+    assert (
+        item.error.description
+        == "POST /rest/api/2/issue/TEST-1/remotelink -> HTTP 400: Field 'resolution' cannot be set."
+    )
 
 
 def test_default_invalid_init():


### PR DESCRIPTION

<img width="688" alt="Screenshot 2025-01-29 at 16 06 27" src="https://github.com/user-attachments/assets/96ab4c9a-6e1c-415c-8a09-6df2c2f015fb" />


Current troubleshooting steps:

- open Sentry
- inspect stack trace
- get bugzilla ticket or jira issue
- (look at logs using `jsonPayload.Fields.bug.id=XXX`)

With this change, we see the Jira issue number right in the request path...

