### PR TITLE
Reducing jira char limit by 100 so Jira doesn't overrun this when closing tags

### DIFF
--- a/jbi/jira/service.py
+++ b/jbi/jira/service.py
@@ -26,7 +26,7 @@ settings = environment.get_settings()
 logger = logging.getLogger(__name__)
 
 
-JIRA_DESCRIPTION_CHAR_LIMIT = 32767
+JIRA_DESCRIPTION_CHAR_LIMIT = 32667
 
 JIRA_REQUIRED_PERMISSIONS = {
     "ADD_COMMENTS",


### PR DESCRIPTION
We ran into an issue today with a code block getting truncated when writing to Jira. Jira then tried to close the code block out with thee more characters to make the markdown valid, which then exceeded the character limit. 

If we're already truncating we can cut off a few more characters to allow for this to happen without exceeding the limit.

[Link to alert thread](https://mozilla.slack.com/archives/C016BTJKM9B/p1745858899387559).