### PR TITLE
Making the Jira character limit configurable and reducing for addons team per request

### DIFF
--- a/config/config.prod.yaml
+++ b/config/config.prod.yaml
@@ -6,6 +6,7 @@
   parameters:
     jira_project_key: WEBEXT
     labels_brackets: both
+    jira_char_limit: 10000
 
 - whiteboard_tag: fidedi
   bugzilla_user_id: tbd

--- a/jbi/jira/service.py
+++ b/jbi/jira/service.py
@@ -25,9 +25,6 @@ settings = environment.get_settings()
 
 logger = logging.getLogger(__name__)
 
-
-JIRA_DESCRIPTION_CHAR_LIMIT = 32667
-
 JIRA_REQUIRED_PERMISSIONS = {
     "ADD_COMMENTS",
     "CREATE_ISSUES",
@@ -79,7 +76,7 @@ class JiraService:
             "summary": bug.summary,
             "issuetype": {"name": issue_type},
             "description": markdown_to_jira(
-                description, max_length=JIRA_DESCRIPTION_CHAR_LIMIT
+                description, max_length=context.action.parameters.jira_char_limit
             ),
             "project": {"key": context.jira.project},
         }
@@ -134,7 +131,7 @@ class JiraService:
             prefix = f"*{commenter}* commented: \n"
             formatted_comment = prefix + markdown_to_jira(
                 comment.body,
-                max_length=JIRA_DESCRIPTION_CHAR_LIMIT - len(prefix),
+                max_length=context.action.parameters.jira_char_limit - len(prefix),
             )
 
         issue_key = context.jira.issue
@@ -317,11 +314,11 @@ class JiraService:
         """Update's an issue's summary with the description of an incoming bug"""
         truncated_summary = context.bug.summary or ""
 
-        if len(truncated_summary) > JIRA_DESCRIPTION_CHAR_LIMIT:
+        if len(truncated_summary) > context.action.parameters.jira_char_limit:
             # Truncate on last word.
-            truncated_summary = truncated_summary[:JIRA_DESCRIPTION_CHAR_LIMIT].rsplit(
-                maxsplit=1
-            )[0]
+            truncated_summary = truncated_summary[
+                : context.action.parameters.jira_char_limit
+            ].rsplit(maxsplit=1)[0]
 
         return self.update_issue_field(
             context, field="summary", value=truncated_summary

--- a/jbi/jira/service.py
+++ b/jbi/jira/service.py
@@ -26,7 +26,7 @@ settings = environment.get_settings()
 logger = logging.getLogger(__name__)
 
 
-JIRA_DESCRIPTION_CHAR_LIMIT = 32767
+JIRA_DESCRIPTION_CHAR_LIMIT = 32667
 
 JIRA_REQUIRED_PERMISSIONS = {
     "ADD_COMMENTS",

--- a/jbi/models.py
+++ b/jbi/models.py
@@ -87,6 +87,7 @@ class ActionParams(BaseModel, frozen=True):
 
     jira_project_key: str
     steps: ActionSteps = ActionSteps()
+    jira_char_limit: int = 32667
     jira_components: JiraComponents = JiraComponents()
     jira_cf_fx_points_field: str = "customfield_10037"
     jira_severity_field: str = "customfield_10319"


### PR DESCRIPTION
Making the jira character limit configurable and reducing to 10k for the addons team as requested.
[Link](https://mozilla.slack.com/archives/C016BTJKM9B/p1745869073069289?thread_ts=1745858899.387559&cid=C016BTJKM9B) to thread for context.