### PR TITLE
Updating hnt jira project key

### DIFF
--- a/config/config.prod.yaml
+++ b/config/config.prod.yaml
@@ -255,23 +255,12 @@
         - add_link_to_bugzilla
         - add_link_to_jira
         - maybe_assign_jira_user
-        - maybe_update_issue_status
         - sync_whiteboard_labels
       existing:
         - update_issue_summary
         - maybe_assign_jira_user
-        - maybe_update_issue_status
         - sync_whiteboard_labels
     labels_brackets: both
-    status_map:
-      ASSIGNED: In Progress
-      FIXED: Closed
-      WONTFIX: Closed
-      DUPLICATE: Closed
-      INVALID: Closed
-      INCOMPLETE: Closed
-      WORKSFORME: Closed
-      REOPENED: In Progress
 
 - whiteboard_tag: mv3
   bugzilla_user_id: tbd

--- a/config/config.prod.yaml
+++ b/config/config.prod.yaml
@@ -247,7 +247,7 @@
   bugzilla_user_id: 462407
   description: Homepage New Tab Engineering
   parameters:
-    jira_project_key: HNTENG
+    jira_project_key: HNT
     steps:
       new:
         - create_issue


### PR DESCRIPTION
Updating HNT Jira project key and remove status update per [request](https://mozilla.slack.com/archives/C016BTJKM9B/p1746715172893259).