### PR TITLE
Adding type map for hnt, which only has tasks in Jira

### DIFF
--- a/config/config.prod.yaml
+++ b/config/config.prod.yaml
@@ -261,6 +261,10 @@
         - maybe_assign_jira_user
         - sync_whiteboard_labels
     labels_brackets: both
+    issue_type_map:
+      enhancement: Task
+      task: Task
+      defect: Task
 
 - whiteboard_tag: mv3
   bugzilla_user_id: tbd


### PR DESCRIPTION
Received this error for an HNT bug this morning. It looks like that project only has Task types in Jira.

```
{
  errorMessages: [],
  errors: {
    issuetype: "The issue type selected is invalid."
  }
}
```