### PR TITLE
Switching fx-vpn to use the basic-status-map

### DIFF
--- a/config/config.prod.yaml
+++ b/config/config.prod.yaml
@@ -696,12 +696,4 @@
   parameters:
     jira_project_key: FXVPN2
     labels_brackets: both
-    status_map:
-      ASSIGNED: In Progress
-      FIXED: Done
-      WONTFIX: Cancelled
-      DUPLICATE: Cancelled
-      INVALID: Cancelled
-      INCOMPLETE: Done
-      WORKSFORME: Cancelled
-      REOPENED: In Progress
+    status_map: *basic-status-map


### PR DESCRIPTION
From [slack convo](https://mozilla.slack.com/archives/C016BTJKM9B/p1751394733255419). Can use normal status map for fx-vpn config.