### PR TITLE
Update priority and severity for PCF project

### DIFF
--- a/config/config.prod.yaml
+++ b/config/config.prod.yaml
@@ -364,6 +364,8 @@
         - maybe_assign_jira_user
         - maybe_update_issue_status
         - maybe_update_issue_resolution
+        - maybe_update_issue_priority
+        - maybe_update_issue_severity
         - sync_whiteboard_labels
         - sync_keywords_labels
       existing:
@@ -371,6 +373,8 @@
         - maybe_assign_jira_user
         - maybe_update_issue_status
         - maybe_update_issue_resolution
+        - maybe_update_issue_priority
+        - maybe_update_issue_severity
         - sync_whiteboard_labels
         - sync_keywords_labels
         - add_jira_comments_for_changes
@@ -378,6 +382,12 @@
         - create_comment
     status_map: *basic-status-map
     resolution_map: *basic-resolution-map
+    priority_map:
+      P1: P1
+      P2: P2
+      P3: P3
+      P4: P4
+      P5: P5
 
 - whiteboard_tag: proton
   bugzilla_user_id: tbd


### PR DESCRIPTION
This is an attempt to update priority and severity for the PerfCompare (PCF) project. I'm waiting on a couple of service desk requests before this can be merged, and I have a question about the default priority map (I'll add this to the relevant line in the PR).

- [x] Add severity custom field to PerfComare (PCF) issue forms ([SDD-37128](https://mozilla-hub.atlassian.net/servicedesk/customer/portal/4/SDD-37128)).
- [x] Add P5 option for Priority field ([SDD-37129](https://mozilla-hub.atlassian.net/servicedesk/customer/portal/4/SDD-37129)).