### PR TITLE
Map empty priority for PCF project

### DIFF
--- a/config/config.prod.yaml
+++ b/config/config.prod.yaml
@@ -383,6 +383,7 @@
     status_map: *basic-status-map
     resolution_map: *basic-resolution-map
     priority_map:
+      "": (none)
       P1: P1
       P2: P2
       P3: P3


### PR DESCRIPTION
The previous patch did not include a mapping for empty priorities in bugzilla.