### PR TITLE
Unset priority using real `null` value

### DIFF
--- a/config/config.prod.yaml
+++ b/config/config.prod.yaml
@@ -387,7 +387,7 @@
     status_map: *basic-status-map
     resolution_map: *basic-resolution-map
     priority_map:
-      "": (none)
+      "--": (None)
       P1: P1
       P2: P2
       P3: P3

--- a/jbi/models.py
+++ b/jbi/models.py
@@ -97,7 +97,8 @@ class ActionParams(BaseModel, frozen=True):
     labels_brackets: Literal["yes", "no", "both"] = "no"
     status_map: dict[str, str] = {}
     priority_map: dict[str, str] = {
-        "": "(none)",
+        "": "(None)",
+        "--": "(None)",
         "P1": "P1",
         "P2": "P2",
         "P3": "P3",
@@ -107,6 +108,7 @@ class ActionParams(BaseModel, frozen=True):
     resolution_map: dict[str, str] = {}
     severity_map: dict[str, str] = {
         "": "N/A",
+        "--": "N/A",
         "S1": "S1",
         "S2": "S2",
         "S3": "S3",

--- a/jbi/steps.py
+++ b/jbi/steps.py
@@ -280,6 +280,11 @@ def _maybe_update_issue_mapped_field(
         )
         return (StepStatus.INCOMPLETE, context)
 
+    # Special handling for clearing fields in Jira.
+    if target_value == "(None)":
+        target_value = None
+        wrap_value = None
+
     resp = jira_service.update_issue_field(
         context,
         target_field,

--- a/tests/unit/test_steps.py
+++ b/tests/unit/test_steps.py
@@ -825,10 +825,10 @@ def test_update_issue_remove_priority(
     action_context = action_context_factory(
         operation=Operation.UPDATE,
         jira__issue="JBI-234",
-        bug__priority=None,
+        bug__priority="--",
         current_step="maybe_update_issue_priority",
         event__changes=[
-            webhook_event_change_factory(field="priority", removed="P1", added="--")
+            webhook_event_change_factory(field="priority", removed="P1", added="")
         ],
     )
     params = action_params_factory(
@@ -841,7 +841,7 @@ def test_update_issue_remove_priority(
 
     assert result == steps.StepStatus.SUCCESS
     mocked_jira.update_issue_field.assert_called_with(
-        key="JBI-234", fields={"priority": {"name": "(none)"}}
+        key="JBI-234", fields={"priority": None}
     )
 
 


### PR DESCRIPTION
When field is set to `--` on bugzilla, the event sends `added: ""` and the bug field has `--`.

<img width="1164" height="660" alt="Screenshot 2025-10-17 at 16 37 13" src="https://github.com/user-attachments/assets/1d4614ca-05a0-4bf1-84a0-792c2732c075" />

From what I can see online, setting `priority: {name: "(none)"}}` won't work. We have to set the field to `null` (None in python).
This PR should handle this situation.

Related #899 