### PR TITLE
Follow-up of #1212: set value to 'None' when unset

### DIFF
--- a/config/config.prod.yaml
+++ b/config/config.prod.yaml
@@ -389,7 +389,8 @@
     status_map: *basic-status-map
     resolution_map: *basic-resolution-map
     priority_map:
-      "--": (None)
+      "": None
+      "--": None
       P1: P1
       P2: P2
       P3: P3

--- a/jbi/models.py
+++ b/jbi/models.py
@@ -97,8 +97,8 @@ class ActionParams(BaseModel, frozen=True):
     labels_brackets: Literal["yes", "no", "both"] = "no"
     status_map: dict[str, str] = {}
     priority_map: dict[str, str] = {
-        "": "(None)",
-        "--": "(None)",
+        "": "None",
+        "--": "None",
         "P1": "P1",
         "P2": "P2",
         "P3": "P3",

--- a/jbi/steps.py
+++ b/jbi/steps.py
@@ -280,11 +280,6 @@ def _maybe_update_issue_mapped_field(
         )
         return (StepStatus.INCOMPLETE, context)
 
-    # Special handling for clearing fields in Jira.
-    if target_value == "(None)":
-        target_value = None
-        wrap_value = None
-
     resp = jira_service.update_issue_field(
         context,
         target_field,

--- a/tests/unit/test_steps.py
+++ b/tests/unit/test_steps.py
@@ -841,7 +841,7 @@ def test_update_issue_remove_priority(
 
     assert result == steps.StepStatus.SUCCESS
     mocked_jira.update_issue_field.assert_called_with(
-        key="JBI-234", fields={"priority": None}
+        key="JBI-234", fields={"priority": {"name": "None"}}
     )
 
 


### PR DESCRIPTION
I was able to reproduce the error locally:

```
>>> s.client.update_issue_field(key="RMST-212", fields={"priority":"None"})
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
 ...
  File "/Users/mathieu/Code/Mozilla/jira-bugzilla-integration/jbi/jira/client.py", line 53, in raise_for_status
    return super().raise_for_status(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mathieu/Code/Mozilla/jira-bugzilla-integration/.venv/lib/python3.12/site-packages/atlassian/rest_client.py", line 999, in raise_for_status
    raise HTTPError(error_msg, response=response)
requests.exceptions.HTTPError: PUT /rest/api/2/issue/RMST-212?notifyUsers=true -> HTTP 400: Specify the Priority (id or name) in the string format
```


```
>>> s.client.update_issue_field(key="RMST-212", fields={"priority":{"name": "None"}})
>>> s.client.update_issue_field(key="RMST-212", fields={"priority":{"name": "P1"}})
>>>
```
<img width="555" height="359" alt="Screenshot 2025-10-29 at 17 44 34" src="https://github.com/user-attachments/assets/2f7f6cf5-3585-4f33-9a5b-d4a4f377310b" />
