### PR TITLE
fix: Jira.create_component called with project_key and should be just project

### DIFF
--- a/jbi/jira/service.py
+++ b/jbi/jira/service.py
@@ -380,7 +380,7 @@ class JiraService:
 
             for comp_name in missing_components:
                 new_comp = self.client.create_component(
-                    project_key=context.jira.project,
+                    project=context.jira.project,
                     name=comp_name,
                 )
                 jira_components.append({"id": new_comp["id"]})

--- a/tests/unit/test_steps.py
+++ b/tests/unit/test_steps.py
@@ -1378,7 +1378,7 @@ def test_maybe_update_components_create_components_normal_component(
     )
 
     mocked_jira.create_component.assert_called_once_with(
-        project_key=action_context.jira.project,
+        project=action_context.jira.project,
         name="NewComponent",
     )
     mocked_jira.update_issue_field.assert_called_with(
@@ -1419,7 +1419,7 @@ def test_maybe_update_components_create_components_prefix_component(
     )
 
     mocked_jira.create_component.assert_called_once_with(
-        project_key=action_context.jira.project,
+        project=action_context.jira.project,
         name="Firefox::NewComponent",
     )
     mocked_jira.update_issue_field.assert_called_with(


### PR DESCRIPTION
The param `project_key` should be `project`. Misread the docs somewhere else and instead should have consulted https://jira.readthedocs.io/api.html#jira.client.JIRA.create_component. Of course didn't catch this until the change was used by my config steps.