### PR TITLE
Fix #1238 - Allow attachment.flags.id to be nullable

### DIFF
--- a/jbi/bugzilla/models.py
+++ b/jbi/bugzilla/models.py
@@ -82,7 +82,7 @@ class WebhookComment(BaseModel, frozen=True):
 class AttachmentFlag(BaseModel, frozen=True):
     """Flag object associated with a Bugzilla attachment."""
 
-    id: int
+    id: int | None
     name: str
     value: str
 

--- a/tests/unit/bugzilla/test_models.py
+++ b/tests/unit/bugzilla/test_models.py
@@ -5,6 +5,12 @@ def test_attachments_flags(bug_factory):
             {"id": 2302739, "name": "approval-mozilla-beta", "value": "?"}
         ],
     )
+    bug_factory.build(
+        with_attachment=True,
+        attachment__flags=[
+            {"id": None, "name": "approval-mozilla-beta", "value": "?"}
+        ],
+    )
     # not raising is a success
 
 


### PR DESCRIPTION
Fixes #1238 by allowing `attachment.flags.id` to be nullable.