### PR TITLE
Enable component creation for FXP and FXPE projects

### DIFF
--- a/config/config.prod.yaml
+++ b/config/config.prod.yaml
@@ -154,6 +154,7 @@
     jira_components:
       use_bug_component: false
       use_bug_component_with_product_prefix: true
+      create_components: true
     steps:
       new:
         - create_issue
@@ -204,6 +205,7 @@
     jira_components:
       use_bug_component: false
       use_bug_component_with_product_prefix: true
+      create_components: true
     steps:
       new:
         - create_issue


### PR DESCRIPTION
This change adds `create_components: true` to the `jira_components` configuration for both the FXP (Performance Team) and FXPE (Performance Engineering Team) projects.

When enabled, the `maybe_update_components` step will automatically create components in Jira if they don't already exist, rather than silently skipping missing components.