### PR TITLE
Add severity syncing to FXP and FXPE projects

### DIFF
--- a/config/config.prod.yaml
+++ b/config/config.prod.yaml
@@ -164,6 +164,7 @@
         - maybe_update_components
         - maybe_update_issue_status
         - maybe_update_issue_resolution
+        - maybe_update_issue_severity
         - maybe_add_phabricator_link
         - sync_whiteboard_labels
         - sync_keywords_labels
@@ -173,6 +174,7 @@
         - maybe_assign_jira_user
         - maybe_update_issue_status
         - maybe_update_issue_resolution
+        - maybe_update_issue_severity
         - maybe_add_phabricator_link
         - sync_whiteboard_labels
         - sync_keywords_labels
@@ -214,6 +216,7 @@
         - maybe_update_components
         - maybe_update_issue_status
         - maybe_update_issue_resolution
+        - maybe_update_issue_severity
         - maybe_add_phabricator_link
         - sync_whiteboard_labels
         - sync_keywords_labels
@@ -223,6 +226,7 @@
         - maybe_assign_jira_user
         - maybe_update_issue_status
         - maybe_update_issue_resolution
+        - maybe_update_issue_severity
         - maybe_add_phabricator_link
         - sync_whiteboard_labels
         - sync_keywords_labels


### PR DESCRIPTION
Enable the maybe_update_issue_severity step for both the Performance Team (FXP) and Performance Engineering Team (FXPE) projects. This will sync the Bugzilla severity field (S1-S4) to the corresponding Jira severity custom field when creating or updating issues.