### PR TITLE
Add priority syncing to FXP and FXPE projects

### DIFF
--- a/config/config.prod.yaml
+++ b/config/config.prod.yaml
@@ -164,6 +164,7 @@
         - maybe_update_components
         - maybe_update_issue_status
         - maybe_update_issue_resolution
+        - maybe_update_issue_priority
         - maybe_update_issue_severity
         - maybe_add_phabricator_link
         - sync_whiteboard_labels
@@ -174,6 +175,7 @@
         - maybe_assign_jira_user
         - maybe_update_issue_status
         - maybe_update_issue_resolution
+        - maybe_update_issue_priority
         - maybe_update_issue_severity
         - maybe_add_phabricator_link
         - sync_whiteboard_labels
@@ -216,6 +218,7 @@
         - maybe_update_components
         - maybe_update_issue_status
         - maybe_update_issue_resolution
+        - maybe_update_issue_priority
         - maybe_update_issue_severity
         - maybe_add_phabricator_link
         - sync_whiteboard_labels
@@ -226,6 +229,7 @@
         - maybe_assign_jira_user
         - maybe_update_issue_status
         - maybe_update_issue_resolution
+        - maybe_update_issue_priority
         - maybe_update_issue_severity
         - maybe_add_phabricator_link
         - sync_whiteboard_labels


### PR DESCRIPTION
Enable the maybe_update_issue_priority step for both the Performance Team (FXP) and Performance Engineering Team (FXPE) projects. This will sync the Bugzilla priority field (P1-P5) to the corresponding Jira priority field when creating or updating issues.