### PR TITLE
Update the default priority map now that Jira has options for P4 and P5 values

### DIFF
--- a/config/config.prod.yaml
+++ b/config/config.prod.yaml
@@ -434,14 +434,6 @@
         - create_comment
     status_map: *basic-status-map
     resolution_map: *basic-resolution-map
-    priority_map:
-      "": None
-      "--": None
-      P1: P1
-      P2: P2
-      P3: P3
-      P4: P4
-      P5: P5
 
 - whiteboard_tag: proton
   bugzilla_user_id: tbd

--- a/jbi/models.py
+++ b/jbi/models.py
@@ -103,8 +103,8 @@ class ActionParams(BaseModel, frozen=True):
         "P1": "P1",
         "P2": "P2",
         "P3": "P3",
-        "P4": "Low",
-        "P5": "Lowest",
+        "P4": "P4",
+        "P5": "P5",
     }
     resolution_map: dict[str, str] = {}
     severity_map: dict[str, str] = {


### PR DESCRIPTION
This also removes the priority map override used by the PCF project as it now matches the default. This fixes https://github.com/mozilla/jira-bugzilla-integration/issues/1261 and was previously discussed in https://github.com/mozilla/jira-bugzilla-integration/pull/1207#pullrequestreview-3340544494.