### PR TITLE
Add Firefox Profiler project configuration

### DIFF
--- a/config/config.prod.yaml
+++ b/config/config.prod.yaml
@@ -242,6 +242,47 @@
     status_map: *basic-status-map
     resolution_map: *basic-resolution-map
 
+- whiteboard_tag: fp
+  bugzilla_user_id: 396948
+  description: Firefox Profiler
+  parameters:
+    jira_project_key: FP
+    jira_components:
+      use_bug_component: false
+      use_bug_component_with_product_prefix: true
+      create_components: true
+    steps:
+      new:
+        - create_issue
+        - maybe_delete_duplicate
+        - add_link_to_bugzilla
+        - add_link_to_jira
+        - maybe_assign_jira_user
+        - maybe_update_components
+        - maybe_update_issue_status
+        - maybe_update_issue_resolution
+        - maybe_update_issue_priority
+        - maybe_update_issue_severity
+        - maybe_add_phabricator_link
+        - sync_whiteboard_labels
+        - sync_keywords_labels
+      existing:
+        - update_issue_summary
+        - maybe_update_components
+        - maybe_assign_jira_user
+        - maybe_update_issue_status
+        - maybe_update_issue_resolution
+        - maybe_update_issue_priority
+        - maybe_update_issue_severity
+        - maybe_add_phabricator_link
+        - sync_whiteboard_labels
+        - sync_keywords_labels
+        - add_jira_comments_for_changes
+      comment:
+        - create_comment
+    status_map: *basic-status-map
+    resolution_map: *basic-resolution-map
+
 - whiteboard_tag: fxsync
   bugzilla_user_id: 624105
   description: Firefox Sync Team whiteboard tag


### PR DESCRIPTION
This adds configuration for syncing Firefox Profiler [fp] related bugs to the Firefox Profiler (FP) Jira space.