### PR TITLE
Add dependency sync steps to FXPE, FP, and PCF project configurations

### DIFF
--- a/config/config.prod.yaml
+++ b/config/config.prod.yaml
@@ -231,6 +231,8 @@
         - maybe_add_phabricator_link
         - sync_whiteboard_labels
         - sync_keywords_labels
+        - sync_depends_on_links
+        - sync_blocks_links
       existing:
         - update_issue_summary
         - maybe_update_components
@@ -242,6 +244,8 @@
         - maybe_add_phabricator_link
         - sync_whiteboard_labels
         - sync_keywords_labels
+        - sync_depends_on_links
+        - sync_blocks_links
         - add_jira_comments_for_changes
       comment:
         - create_comment
@@ -272,6 +276,8 @@
         - maybe_add_phabricator_link
         - sync_whiteboard_labels
         - sync_keywords_labels
+        - sync_depends_on_links
+        - sync_blocks_links
       existing:
         - update_issue_summary
         - maybe_update_components
@@ -283,6 +289,8 @@
         - maybe_add_phabricator_link
         - sync_whiteboard_labels
         - sync_keywords_labels
+        - sync_depends_on_links
+        - sync_blocks_links
         - add_jira_comments_for_changes
       comment:
         - create_comment
@@ -466,6 +474,8 @@
         - maybe_add_phabricator_link
         - sync_whiteboard_labels
         - sync_keywords_labels
+        - sync_depends_on_links
+        - sync_blocks_links
       existing:
         - update_issue_summary
         - maybe_assign_jira_user
@@ -476,6 +486,8 @@
         - maybe_add_phabricator_link
         - sync_whiteboard_labels
         - sync_keywords_labels
+        - sync_depends_on_links
+        - sync_blocks_links
         - add_jira_comments_for_changes
       comment:
         - create_comment


### PR DESCRIPTION
- Adds `sync_depends_on_links` and `sync_blocks_links` steps to the FXPE, FP, and PCF project configurations 
- Steps are added to both `new` (issue creation) and `existing` (issue update) step lists, consistent with the FXP configuration added in #1283