### PR TITLE
fix: Correct inward/outward direction for Jira 'Blocks' issue links

### DIFF
--- a/jbi/jira/service.py
+++ b/jbi/jira/service.py
@@ -444,8 +444,8 @@ class JiraService:
             self.client.create_issue_link(
                 data={
                     "type": {"name": "Blocks"},
-                    "inwardIssue": {"key": blocked_issue},
-                    "outwardIssue": {"key": blocking_issue},
+                    "inwardIssue": {"key": blocking_issue},
+                    "outwardIssue": {"key": blocked_issue},
                 }
             )
             logger.info(

--- a/tests/unit/jira/test_service.py
+++ b/tests/unit/jira/test_service.py
@@ -539,8 +539,8 @@ def test_create_issue_link_blocks_creates_link(
 
     data = json.loads(request_body)
     assert data["type"]["name"] == "Blocks"
-    assert data["outwardIssue"]["key"] == "JBI-456"
-    assert data["inwardIssue"]["key"] == "JBI-123"
+    assert data["inwardIssue"]["key"] == "JBI-456"
+    assert data["outwardIssue"]["key"] == "JBI-123"
 
 
 def test_create_issue_link_blocks_handles_duplicate_link(

--- a/tests/unit/test_steps.py
+++ b/tests/unit/test_steps.py
@@ -1730,8 +1730,8 @@ def test_sync_depends_on_links_create_with_dependency(
     mocked_jira.create_issue_link.assert_called_once_with(
         data={
             "type": {"name": "Blocks"},
-            "inwardIssue": {"key": "JBI-123"},
-            "outwardIssue": {"key": "JBI-456"},
+            "inwardIssue": {"key": "JBI-456"},
+            "outwardIssue": {"key": "JBI-123"},
         }
     )
 
@@ -1956,8 +1956,8 @@ def test_sync_blocks_links_create_with_blocked_bug(
     mocked_jira.create_issue_link.assert_called_once_with(
         data={
             "type": {"name": "Blocks"},
-            "inwardIssue": {"key": "JBI-456"},
-            "outwardIssue": {"key": "JBI-123"},
+            "inwardIssue": {"key": "JBI-123"},
+            "outwardIssue": {"key": "JBI-456"},
         }
     )
 


### PR DESCRIPTION
Jira's REST API treats inwardIssue as the blocker (the issue that "blocks"), not outwardIssue as the documentation suggests. The original code had these reversed, causing Jira to display the link in the wrong direction (e.g. FXP-4414 blocking FXP-4820 instead of the other way around).

Swap inwardIssue and outwardIssue in create_issue_link_blocks so that the blocking issue is correctly set as inwardIssue, and update tests to match.