### PR TITLE
Remove Jira 'Blocks' links when depends_on/blocks removed in Bugzilla

### DIFF
--- a/jbi/jira/client.py
+++ b/jbi/jira/client.py
@@ -75,8 +75,10 @@ class JiraClient(Jira):
     update_issue_field = instrumented_method(Jira.update_issue_field)
     set_issue_status = instrumented_method(Jira.set_issue_status)
     issue_add_comment = instrumented_method(Jira.issue_add_comment)
+    get_issue = instrumented_method(Jira.get_issue)
     create_issue = instrumented_method(Jira.create_issue)
     create_issue_link = instrumented_method(Jira.create_issue_link)
+    remove_issue_link = instrumented_method(Jira.remove_issue_link)
     get_project = instrumented_method(Jira.get_project)
 
     @instrumented_method

--- a/jbi/jira/service.py
+++ b/jbi/jira/service.py
@@ -466,6 +466,42 @@ class JiraService:
             else:
                 raise
 
+    def delete_issue_link_blocks(
+        self, context: ActionContext, blocking_issue: str, blocked_issue: str
+    ):
+        """Delete a 'Blocks' link between two Jira issues.
+
+        Fetches the blocked issue's links, finds the 'Blocks' link where
+        blocking_issue is the inward (blocker) issue, and deletes it by ID.
+
+        Args:
+            context: The action context
+            blocking_issue: The issue key that blocks (e.g., 'JBI-123')
+            blocked_issue: The issue key that is blocked (e.g., 'JBI-456')
+        """
+        issue = self.client.get_issue(blocked_issue, fields="issuelinks")
+        if not issue:
+            return
+        for link in issue.get("fields", {}).get("issuelinks", []):
+            if (
+                link.get("type", {}).get("name") == "Blocks"
+                and link.get("inwardIssue", {}).get("key") == blocking_issue
+            ):
+                self.client.remove_issue_link(link["id"])
+                logger.info(
+                    "Deleted link: %s blocks %s",
+                    blocking_issue,
+                    blocked_issue,
+                    extra=context.update(operation=Operation.LINK).model_dump(),
+                )
+                return
+        logger.info(
+            "No link found to delete: %s blocks %s",
+            blocking_issue,
+            blocked_issue,
+            extra=context.model_dump(),
+        )
+
     def lookup_jira_issues_for_bug(
         self, context: ActionContext, bug_id: int, bug_data: bugzilla_models.Bug
     ) -> list[str]:

--- a/jbi/steps.py
+++ b/jbi/steps.py
@@ -547,59 +547,103 @@ def _update_issue_labels(
     return (StepStatus.SUCCESS, context)
 
 
+def _parse_changed_bug_ids(
+    changes: list, field: str, direction: str
+) -> list[int]:
+    """Parse bug IDs from a depends_on/blocks change event.
+
+    Args:
+        changes: list of WebhookEventChange objects
+        field: field name (e.g., "depends_on", "blocks")
+        direction: "removed" or "added"
+
+    Returns:
+        List of bug IDs parsed from the comma-separated change value
+    """
+    for change in changes:
+        if change.field == field:
+            value = getattr(change, direction)
+            if not value.strip():
+                return []
+            return [int(x.strip()) for x in value.split(",") if x.strip()]
+    return []
+
+
 def sync_depends_on_links(
     context: ActionContext,
     *,
     jira_service: JiraService,
     bugzilla_service: BugzillaService,
 ) -> StepResult:
-    """Create Jira 'Blocks' links for bugs that this bug depends on.
+    """Create and remove Jira 'Blocks' links for bugs that this bug depends on.
 
-    For each bug in depends_on, creates links where the dependency bug's Jira
-    issue(s) block the current bug's Jira issue.
+    For each bug added to depends_on, creates links where the dependency bug's
+    Jira issue(s) block the current bug's Jira issue. For each bug removed from
+    depends_on, deletes the corresponding Jira links.
 
     If bug A depends_on bug B, and B has Jira issues JBI-123 and FIDEFE-456,
     then both JBI-123 and FIDEFE-456 will block A's issue.
     """
-    if not context.bug.depends_on:
-        return (StepStatus.NOOP, context)
-
     # On UPDATE, only process if depends_on field changed
     if context.event.changes:
-        changed_fields = context.event.changed_fields()
-        if "depends_on" not in changed_fields:
+        if "depends_on" not in context.event.changed_fields():
             return (StepStatus.NOOP, context)
+    elif not context.bug.depends_on:
+        # CREATE with no depends_on
+        return (StepStatus.NOOP, context)
 
     if not context.jira.issue:
         raise ValueError("Jira issue unset in Action Context")
 
-    # Fetch all dependency bugs
-    bugs_by_id = bugzilla_service.get_bugs_by_ids(context.bug.depends_on)
+    links_changed = 0
 
-    links_created = 0
-    for bug_id, bug_data in bugs_by_id.items():
-        # Look up ALL Jira issues for this dependency bug
-        jira_keys = jira_service.lookup_jira_issues_for_bug(context, bug_id, bug_data)
+    # Handle removals (only on UPDATE)
+    if context.event.changes:
+        removed_ids = _parse_changed_bug_ids(context.event.changes, "depends_on", "removed")
+        if removed_ids:
+            bugs_by_id = bugzilla_service.get_bugs_by_ids(removed_ids)
+            for bug_id, bug_data in bugs_by_id.items():
+                jira_keys = jira_service.lookup_jira_issues_for_bug(context, bug_id, bug_data)
+                for jira_key in jira_keys:
+                    try:
+                        jira_service.delete_issue_link_blocks(
+                            context,
+                            blocking_issue=jira_key,
+                            blocked_issue=context.jira.issue,
+                        )
+                        links_changed += 1
+                    except requests_exceptions.HTTPError as e:
+                        logger.warning(
+                            "Failed to delete link from %s to %s: %s",
+                            jira_key,
+                            context.jira.issue,
+                            e,
+                            extra=context.model_dump(),
+                        )
 
-        for jira_key in jira_keys:
-            # Create reversed Blocks link: dependency blocks current bug
-            try:
-                jira_service.create_issue_link_blocks(
-                    context,
-                    blocking_issue=jira_key,
-                    blocked_issue=context.jira.issue,
-                )
-                links_created += 1
-            except requests_exceptions.HTTPError as e:
-                logger.warning(
-                    "Failed to create link from %s to %s: %s",
-                    jira_key,
-                    context.jira.issue,
-                    e,
-                    extra=context.model_dump(),
-                )
+    # Handle additions (create links for current depends_on)
+    if context.bug.depends_on:
+        bugs_by_id = bugzilla_service.get_bugs_by_ids(context.bug.depends_on)
+        for bug_id, bug_data in bugs_by_id.items():
+            jira_keys = jira_service.lookup_jira_issues_for_bug(context, bug_id, bug_data)
+            for jira_key in jira_keys:
+                try:
+                    jira_service.create_issue_link_blocks(
+                        context,
+                        blocking_issue=jira_key,
+                        blocked_issue=context.jira.issue,
+                    )
+                    links_changed += 1
+                except requests_exceptions.HTTPError as e:
+                    logger.warning(
+                        "Failed to create link from %s to %s: %s",
+                        jira_key,
+                        context.jira.issue,
+                        e,
+                        extra=context.model_dump(),
+                    )
 
-    if links_created > 0:
+    if links_changed > 0:
         return (StepStatus.SUCCESS, context)
     return (StepStatus.NOOP, context)
 
@@ -610,52 +654,74 @@ def sync_blocks_links(
     jira_service: JiraService,
     bugzilla_service: BugzillaService,
 ) -> StepResult:
-    """Create Jira 'Blocks' links for bugs that this bug blocks.
+    """Create and remove Jira 'Blocks' links for bugs that this bug blocks.
 
-    For each bug in blocks, creates links where the current bug's Jira issue
-    blocks the blocked bug's Jira issue(s).
+    For each bug added to blocks, creates links where the current bug's Jira
+    issue blocks the blocked bug's Jira issue(s). For each bug removed from
+    blocks, deletes the corresponding Jira links.
 
     If bug A blocks bug B, and B has Jira issues JBI-123 and FIDEFE-456,
     then A's issue will block both JBI-123 and FIDEFE-456.
     """
-    if not context.bug.blocks:
-        return (StepStatus.NOOP, context)
-
     # On UPDATE, only process if blocks field changed
     if context.event.changes:
-        changed_fields = context.event.changed_fields()
-        if "blocks" not in changed_fields:
+        if "blocks" not in context.event.changed_fields():
             return (StepStatus.NOOP, context)
+    elif not context.bug.blocks:
+        # CREATE with no blocks
+        return (StepStatus.NOOP, context)
 
     if not context.jira.issue:
         raise ValueError("Jira issue unset in Action Context")
 
-    # Fetch all blocked bugs
-    bugs_by_id = bugzilla_service.get_bugs_by_ids(context.bug.blocks)
+    links_changed = 0
 
-    links_created = 0
-    for bug_id, bug_data in bugs_by_id.items():
-        # Look up ALL Jira issues for this blocked bug
-        jira_keys = jira_service.lookup_jira_issues_for_bug(context, bug_id, bug_data)
+    # Handle removals (only on UPDATE)
+    if context.event.changes:
+        removed_ids = _parse_changed_bug_ids(context.event.changes, "blocks", "removed")
+        if removed_ids:
+            bugs_by_id = bugzilla_service.get_bugs_by_ids(removed_ids)
+            for bug_id, bug_data in bugs_by_id.items():
+                jira_keys = jira_service.lookup_jira_issues_for_bug(context, bug_id, bug_data)
+                for jira_key in jira_keys:
+                    try:
+                        jira_service.delete_issue_link_blocks(
+                            context,
+                            blocking_issue=context.jira.issue,
+                            blocked_issue=jira_key,
+                        )
+                        links_changed += 1
+                    except requests_exceptions.HTTPError as e:
+                        logger.warning(
+                            "Failed to delete link from %s to %s: %s",
+                            context.jira.issue,
+                            jira_key,
+                            e,
+                            extra=context.model_dump(),
+                        )
 
-        for jira_key in jira_keys:
-            # Create direct Blocks link: current bug blocks the other issue
-            try:
-                jira_service.create_issue_link_blocks(
-                    context,
-                    blocking_issue=context.jira.issue,
-                    blocked_issue=jira_key,
-                )
-                links_created += 1
-            except requests_exceptions.HTTPError as e:
-                logger.warning(
-                    "Failed to create link from %s to %s: %s",
-                    context.jira.issue,
-                    jira_key,
-                    e,
-                    extra=context.model_dump(),
-                )
+    # Handle additions (create links for current blocks)
+    if context.bug.blocks:
+        bugs_by_id = bugzilla_service.get_bugs_by_ids(context.bug.blocks)
+        for bug_id, bug_data in bugs_by_id.items():
+            jira_keys = jira_service.lookup_jira_issues_for_bug(context, bug_id, bug_data)
+            for jira_key in jira_keys:
+                try:
+                    jira_service.create_issue_link_blocks(
+                        context,
+                        blocking_issue=context.jira.issue,
+                        blocked_issue=jira_key,
+                    )
+                    links_changed += 1
+                except requests_exceptions.HTTPError as e:
+                    logger.warning(
+                        "Failed to create link from %s to %s: %s",
+                        context.jira.issue,
+                        jira_key,
+                        e,
+                        extra=context.model_dump(),
+                    )
 
-    if links_created > 0:
+    if links_changed > 0:
         return (StepStatus.SUCCESS, context)
     return (StepStatus.NOOP, context)

--- a/tests/unit/jira/test_service.py
+++ b/tests/unit/jira/test_service.py
@@ -611,3 +611,94 @@ def test_lookup_jira_issues_for_bug_returns_empty_when_no_see_also(
     result = jira_service.lookup_jira_issues_for_bug(context, 456, bug)
 
     assert result == []
+
+
+def test_delete_issue_link_blocks_deletes_correct_link(
+    jira_service, mocked_responses, settings, action_context_factory
+):
+    """Test that delete_issue_link_blocks identifies and deletes the matching link by ID."""
+    context = action_context_factory(jira__issue="JBI-123")
+
+    mocked_responses.add(
+        "GET",
+        f"{settings.jira_base_url}rest/api/2/issue/JBI-123",
+        json={
+            "fields": {
+                "issuelinks": [
+                    {
+                        "id": "99999",
+                        "type": {"name": "Blocks"},
+                        "inwardIssue": {"key": "JBI-000"},
+                    },
+                    {
+                        "id": "10001",
+                        "type": {"name": "Blocks"},
+                        "inwardIssue": {"key": "JBI-456"},
+                    },
+                ]
+            }
+        },
+        status=200,
+    )
+    mocked_responses.add(
+        "DELETE",
+        f"{settings.jira_base_url}rest/api/2/issueLink/10001",
+        status=204,
+    )
+
+    jira_service.delete_issue_link_blocks(
+        context, blocking_issue="JBI-456", blocked_issue="JBI-123"
+    )
+
+    assert len(mocked_responses.calls) == 2
+    assert mocked_responses.calls[1].request.url.endswith("/issueLink/10001")
+
+
+def test_delete_issue_link_blocks_no_op_when_link_not_found(
+    jira_service, mocked_responses, settings, action_context_factory
+):
+    """Test that delete_issue_link_blocks does nothing when no matching link exists."""
+    context = action_context_factory(jira__issue="JBI-123")
+
+    mocked_responses.add(
+        "GET",
+        f"{settings.jira_base_url}rest/api/2/issue/JBI-123",
+        json={"fields": {"issuelinks": []}},
+        status=200,
+    )
+
+    jira_service.delete_issue_link_blocks(
+        context, blocking_issue="JBI-456", blocked_issue="JBI-123"
+    )
+
+    assert len(mocked_responses.calls) == 1
+
+
+def test_delete_issue_link_blocks_skips_non_blocks_links(
+    jira_service, mocked_responses, settings, action_context_factory
+):
+    """Test that delete_issue_link_blocks ignores links of other types."""
+    context = action_context_factory(jira__issue="JBI-123")
+
+    mocked_responses.add(
+        "GET",
+        f"{settings.jira_base_url}rest/api/2/issue/JBI-123",
+        json={
+            "fields": {
+                "issuelinks": [
+                    {
+                        "id": "10002",
+                        "type": {"name": "Relates"},
+                        "inwardIssue": {"key": "JBI-456"},
+                    }
+                ]
+            }
+        },
+        status=200,
+    )
+
+    jira_service.delete_issue_link_blocks(
+        context, blocking_issue="JBI-456", blocked_issue="JBI-123"
+    )
+
+    assert len(mocked_responses.calls) == 1

--- a/tests/unit/test_steps.py
+++ b/tests/unit/test_steps.py
@@ -1879,15 +1879,15 @@ def test_sync_depends_on_links_handles_multiple_jira_issues(
     assert calls[0] == mock.call(
         data={
             "type": {"name": "Blocks"},
-            "inwardIssue": {"key": "JBI-123"},
-            "outwardIssue": {"key": "JBI-456"},
+            "inwardIssue": {"key": "JBI-456"},
+            "outwardIssue": {"key": "JBI-123"},
         }
     )
     assert calls[1] == mock.call(
         data={
             "type": {"name": "Blocks"},
-            "inwardIssue": {"key": "JBI-123"},
-            "outwardIssue": {"key": "FIDEFE-789"},
+            "inwardIssue": {"key": "FIDEFE-789"},
+            "outwardIssue": {"key": "JBI-123"},
         }
     )
 
@@ -2009,3 +2009,201 @@ def test_sync_blocks_links_noop_on_update_when_field_unchanged(
 
     assert result == steps.StepStatus.NOOP
     mocked_bugzilla.get_bug.assert_not_called()
+
+
+def test_sync_depends_on_links_removes_link_on_update(
+    action_context_factory,
+    bug_factory,
+    mocked_jira,
+    mocked_bugzilla,
+    webhook_event_change_factory,
+):
+    """Test sync_depends_on_links deletes link when bug removed from depends_on."""
+    # Bug 123 had depends_on=[456], now depends_on=[] after removing 456
+    action_context = action_context_factory(
+        operation=Operation.UPDATE,
+        jira__issue="JBI-123",
+        bug__depends_on=[],
+        event__changes=[
+            webhook_event_change_factory(field="depends_on", removed="456", added="")
+        ],
+    )
+
+    removed_bug = bug_factory(id=456, see_also=["http://mozilla.jira.com/browse/JBI-456"])
+    mocked_bugzilla.get_bug.return_value = removed_bug
+
+    mocked_jira.get_issue.return_value = {
+        "fields": {
+            "issuelinks": [
+                {
+                    "id": "10001",
+                    "type": {"name": "Blocks"},
+                    "inwardIssue": {"key": "JBI-456"},
+                }
+            ]
+        }
+    }
+
+    result, context = steps.sync_depends_on_links(
+        context=action_context,
+        jira_service=JiraService(mocked_jira),
+        bugzilla_service=BugzillaService(mocked_bugzilla),
+    )
+
+    assert result == steps.StepStatus.SUCCESS
+    mocked_jira.remove_issue_link.assert_called_once_with("10001")
+    mocked_jira.create_issue_link.assert_not_called()
+
+
+def test_sync_depends_on_links_removes_and_adds_on_update(
+    action_context_factory,
+    bug_factory,
+    mocked_jira,
+    mocked_bugzilla,
+    webhook_event_change_factory,
+):
+    """Test sync_depends_on_links handles simultaneous removal and addition."""
+    # Bug 123: remove depends_on 456, add depends_on 789
+    action_context = action_context_factory(
+        operation=Operation.UPDATE,
+        jira__issue="JBI-123",
+        bug__depends_on=[789],
+        event__changes=[
+            webhook_event_change_factory(field="depends_on", removed="456", added="789")
+        ],
+    )
+
+    def get_bug_side_effect(bug_id):
+        return bug_factory(
+            id=bug_id,
+            see_also=[f"http://mozilla.jira.com/browse/JBI-{bug_id}"],
+        )
+
+    mocked_bugzilla.get_bug.side_effect = get_bug_side_effect
+
+    mocked_jira.get_issue.return_value = {
+        "fields": {
+            "issuelinks": [
+                {
+                    "id": "10001",
+                    "type": {"name": "Blocks"},
+                    "inwardIssue": {"key": "JBI-456"},
+                }
+            ]
+        }
+    }
+
+    result, context = steps.sync_depends_on_links(
+        context=action_context,
+        jira_service=JiraService(mocked_jira),
+        bugzilla_service=BugzillaService(mocked_bugzilla),
+    )
+
+    assert result == steps.StepStatus.SUCCESS
+    mocked_jira.remove_issue_link.assert_called_once_with("10001")
+    mocked_jira.create_issue_link.assert_called_once_with(
+        data={
+            "type": {"name": "Blocks"},
+            "inwardIssue": {"key": "JBI-789"},
+            "outwardIssue": {"key": "JBI-123"},
+        }
+    )
+
+
+def test_sync_blocks_links_removes_link_on_update(
+    action_context_factory,
+    bug_factory,
+    mocked_jira,
+    mocked_bugzilla,
+    webhook_event_change_factory,
+):
+    """Test sync_blocks_links deletes link when bug removed from blocks."""
+    # Bug 123 had blocks=[456], now blocks=[] after removing 456
+    action_context = action_context_factory(
+        operation=Operation.UPDATE,
+        jira__issue="JBI-123",
+        bug__blocks=[],
+        event__changes=[
+            webhook_event_change_factory(field="blocks", removed="456", added="")
+        ],
+    )
+
+    removed_bug = bug_factory(id=456, see_also=["http://mozilla.jira.com/browse/JBI-456"])
+    mocked_bugzilla.get_bug.return_value = removed_bug
+
+    mocked_jira.get_issue.return_value = {
+        "fields": {
+            "issuelinks": [
+                {
+                    "id": "10001",
+                    "type": {"name": "Blocks"},
+                    "inwardIssue": {"key": "JBI-123"},
+                }
+            ]
+        }
+    }
+
+    result, context = steps.sync_blocks_links(
+        context=action_context,
+        jira_service=JiraService(mocked_jira),
+        bugzilla_service=BugzillaService(mocked_bugzilla),
+    )
+
+    assert result == steps.StepStatus.SUCCESS
+    mocked_jira.remove_issue_link.assert_called_once_with("10001")
+    mocked_jira.create_issue_link.assert_not_called()
+
+
+def test_sync_blocks_links_removes_and_adds_on_update(
+    action_context_factory,
+    bug_factory,
+    mocked_jira,
+    mocked_bugzilla,
+    webhook_event_change_factory,
+):
+    """Test sync_blocks_links handles simultaneous removal and addition."""
+    # Bug 123: remove blocks 456, add blocks 789
+    action_context = action_context_factory(
+        operation=Operation.UPDATE,
+        jira__issue="JBI-123",
+        bug__blocks=[789],
+        event__changes=[
+            webhook_event_change_factory(field="blocks", removed="456", added="789")
+        ],
+    )
+
+    def get_bug_side_effect(bug_id):
+        return bug_factory(
+            id=bug_id,
+            see_also=[f"http://mozilla.jira.com/browse/JBI-{bug_id}"],
+        )
+
+    mocked_bugzilla.get_bug.side_effect = get_bug_side_effect
+
+    mocked_jira.get_issue.return_value = {
+        "fields": {
+            "issuelinks": [
+                {
+                    "id": "10001",
+                    "type": {"name": "Blocks"},
+                    "inwardIssue": {"key": "JBI-123"},
+                }
+            ]
+        }
+    }
+
+    result, context = steps.sync_blocks_links(
+        context=action_context,
+        jira_service=JiraService(mocked_jira),
+        bugzilla_service=BugzillaService(mocked_bugzilla),
+    )
+
+    assert result == steps.StepStatus.SUCCESS
+    mocked_jira.remove_issue_link.assert_called_once_with("10001")
+    mocked_jira.create_issue_link.assert_called_once_with(
+        data={
+            "type": {"name": "Blocks"},
+            "inwardIssue": {"key": "JBI-123"},
+            "outwardIssue": {"key": "JBI-789"},
+        }
+    )


### PR DESCRIPTION
When a bug is removed from depends_on or blocks in Bugzilla, delete the corresponding 'Blocks' link in Jira. Previously only link creation was handled.

Also fixes incorrect inward/outward assertion in test_sync_depends_on_links_handles_multiple_jira_issues.