### PR TITLE
Rename genai/GENAI to aife/AIFE

### DIFF
--- a/config/config.prod.yaml
+++ b/config/config.prod.yaml
@@ -716,11 +716,11 @@
   parameters:
     jira_project_key: JB
 
-- whiteboard_tag: genai
+- whiteboard_tag: aife
   bugzilla_user_id: tbd
   description: Firefox GenAI - Frontend
   parameters:
-    jira_project_key: GENAI
+    jira_project_key: AIFE
     steps:
       new:
         - create_issue


### PR DESCRIPTION
not sure what's the best timing/sequencing but we should be able to rename the project just after this merges