### PR TITLE
Enable sync_see_also for FXP project

### DIFF
--- a/config/config.prod.yaml
+++ b/config/config.prod.yaml
@@ -174,6 +174,7 @@
         - sync_keywords_labels
         - sync_depends_on_links
         - sync_blocks_links
+        - sync_see_also
       existing:
         - update_issue_summary
         - maybe_update_components
@@ -187,6 +188,7 @@
         - sync_keywords_labels
         - sync_depends_on_links
         - sync_blocks_links
+        - sync_see_also
         - add_jira_comments_for_changes
       comment:
         - create_comment


### PR DESCRIPTION
- Adds `sync_see_also` to the `existing` steps for the FXP project in prod config
- This syncs Bugzilla `see_also` link changes to Jira as 'Relates' issue links