### PR TITLE
Fix duplicate Relates links by normalising key order

### DIFF
--- a/jbi/jira/service.py
+++ b/jbi/jira/service.py
@@ -560,12 +560,17 @@ class JiraService:
     ):
         """Create a 'Relates' link between two Jira issues.
 
+        Key order is normalized (sorted) so that both (A, B) and (B, A) produce
+        the same Jira link, preventing duplicates when both sides of a Bugzilla
+        see_also relationship trigger webhook events.
+
         Args:
             context: The action context
             source_issue: The issue key to link from (e.g., 'JBI-123')
             related_issue: The issue key to link to (e.g., 'JBI-456')
         """
-        self._create_issue_link(context, "Relates", source_issue, related_issue)
+        inward, outward = sorted([source_issue, related_issue])
+        self._create_issue_link(context, "Relates", inward, outward)
 
     def delete_issue_link_relates_to(
         self, context: ActionContext, source_issue: str, related_issue: str

--- a/tests/unit/jira/test_service.py
+++ b/tests/unit/jira/test_service.py
@@ -723,8 +723,31 @@ def test_create_issue_link_relates_to_creates_link(
 
     data = json.loads(mocked_responses.calls[0].request.body)
     assert data["type"]["name"] == "Relates"
-    assert data["inwardIssue"]["key"] == "JBI-123"
-    assert data["outwardIssue"]["key"] == "FXP-456"
+    # Keys are sorted to normalise order: "FXP-456" < "JBI-123"
+    assert data["inwardIssue"]["key"] == "FXP-456"
+    assert data["outwardIssue"]["key"] == "JBI-123"
+
+
+def test_create_issue_link_relates_to_normalises_key_order(
+    jira_service, mocked_responses, settings, action_context_factory
+):
+    context = action_context_factory(jira__issue="JBI-123")
+
+    mocked_responses.add(
+        "POST",
+        f"{settings.jira_base_url}rest/api/2/issueLink",
+        json={},
+        status=201,
+    )
+
+    # Reverse order should produce the same inward/outward assignment
+    jira_service.create_issue_link_relates_to(context, "FXP-456", "JBI-123")
+
+    import json
+
+    data = json.loads(mocked_responses.calls[0].request.body)
+    assert data["inwardIssue"]["key"] == "FXP-456"
+    assert data["outwardIssue"]["key"] == "JBI-123"
 
 
 def test_create_issue_link_relates_to_handles_400(

--- a/tests/unit/test_steps.py
+++ b/tests/unit/test_steps.py
@@ -2275,8 +2275,8 @@ def test_sync_see_also_creates_link_for_added_jira_url(
     mocked_jira.create_issue_link.assert_called_once_with(
         data={
             "type": {"name": "Relates"},
-            "inwardIssue": {"key": "JBI-123"},
-            "outwardIssue": {"key": "FXP-456"},
+            "inwardIssue": {"key": "FXP-456"},
+            "outwardIssue": {"key": "JBI-123"},
         }
     )
 
@@ -2339,8 +2339,8 @@ def test_sync_see_also_creates_link_for_added_bugzilla_url(
     mocked_jira.create_issue_link.assert_called_once_with(
         data={
             "type": {"name": "Relates"},
-            "inwardIssue": {"key": "JBI-123"},
-            "outwardIssue": {"key": "FXP-789"},
+            "inwardIssue": {"key": "FXP-789"},
+            "outwardIssue": {"key": "JBI-123"},
         }
     )
 


### PR DESCRIPTION
- Bugzilla mirrors `see_also` links bidirectionally: adding Bug B to Bug A's `see_also` automatically adds Bug A to Bug B's `see_also`, firing two webhook events
- Both events tried to create a 'Relates' link — `(FXP-1, FXP-2)` and `(FXP-2, FXP-1)` — which Jira stores as two separate links
- Fix: sort the issue keys before calling the Jira API so both events produce the identical request; Jira returns 400 on the second (duplicate), which is already handled