### PR TITLE
Enable sync_see_also for FXPE, FP, and PCF projects

### DIFF
--- a/config/config.prod.yaml
+++ b/config/config.prod.yaml
@@ -235,6 +235,7 @@
         - sync_keywords_labels
         - sync_depends_on_links
         - sync_blocks_links
+        - sync_see_also
       existing:
         - update_issue_summary
         - maybe_update_components
@@ -248,6 +249,7 @@
         - sync_keywords_labels
         - sync_depends_on_links
         - sync_blocks_links
+        - sync_see_also
         - add_jira_comments_for_changes
       comment:
         - create_comment
@@ -280,6 +282,7 @@
         - sync_keywords_labels
         - sync_depends_on_links
         - sync_blocks_links
+        - sync_see_also
       existing:
         - update_issue_summary
         - maybe_update_components
@@ -293,6 +296,7 @@
         - sync_keywords_labels
         - sync_depends_on_links
         - sync_blocks_links
+        - sync_see_also
         - add_jira_comments_for_changes
       comment:
         - create_comment
@@ -478,6 +482,7 @@
         - sync_keywords_labels
         - sync_depends_on_links
         - sync_blocks_links
+        - sync_see_also
       existing:
         - update_issue_summary
         - maybe_assign_jira_user
@@ -490,6 +495,7 @@
         - sync_keywords_labels
         - sync_depends_on_links
         - sync_blocks_links
+        - sync_see_also
         - add_jira_comments_for_changes
       comment:
         - create_comment


### PR DESCRIPTION
- Adds `sync_see_also` to `new` and `existing` steps for FXPE, FP, and PCF projects