### PR TITLE
Update nimbus configuration; add nimbus-sdk tag

### DIFF
--- a/config/config.prod.yaml
+++ b/config/config.prod.yaml
@@ -279,11 +279,58 @@
     labels_brackets: both
 
 - whiteboard_tag: nimbus
-  bugzilla_user_id: 624105
-  description: Nimbus whiteboard tag
+  bugzilla_user_id: 529428
+  description: Nimbus Desktop Client whiteboard tag
   parameters:
     jira_project_key: EXP
     labels_brackets: both
+    jira_components:
+      set_custom_components:
+        - "Desktop"
+    steps: &nimbus_steps
+      new:
+        - create_issue
+        - maybe_delete_duplicate
+        - add_link_to_bugzilla
+        - add_link_to_jira
+        - sync_whiteboard_labels
+        - maybe_assign_jira_user
+        - maybe_update_issue_status
+      existing:
+        - update_issue_summary
+        - sync_whiteboard_labels
+        - add_jira_comments_for_changes
+        - maybe_assign_jira_user
+        - maybe_update_issue_status
+      changes:
+        - create_comment
+    status_map: &nimbus_status_map
+      UNCONFIRMED: New
+      NEW: To Do
+      ASSIGNED: In Progress
+      REOPENED: In Progress
+      RESOLVED: Done
+      VERIFIED: Done
+      FIXED: Done
+      INVALID: Cancelled
+      WONTFIX: Cancelled
+      INACTIVE: Cancelled
+      DUPLICATE: Cancelled
+      WORKSFORME: Cancelled
+      INCOMPLETE: Cancelled
+      MOVED: Cancelled
+
+- whiteboard_tag: nimbus-sdk
+  bugzilla_user_id: 529428
+  description: Nimbus SDK whiteboard tag
+  parameters:
+    jira_project_key: EXP
+    labels_brackets: both
+    jira_components:
+      set_custom_components:
+        - "SDK"
+    steps: *nimbus_steps
+    status_map: *nimbus_status_map
 
 - whiteboard_tag: omc
   bugzilla_user_id: 711631


### PR DESCRIPTION
This patch also updates the bugzilla user ID for the nimbus project because (a) the formerly listed user no longer works here and (b) I am the triage owner of both of these components.