### PR TITLE
feat: Add linked_project_excludes to prevent link syncing to certain Jira projects

### DIFF
--- a/config/config.prod.yaml
+++ b/config/config.prod.yaml
@@ -1057,6 +1057,7 @@
   description: Bugs affecting Firefox components
   parameters:
     jira_project_key: BZFFX
+    linked_project_excludes: []
     jira_components:
       use_bug_component_with_product_prefix: true
       use_bug_component: false
@@ -1103,6 +1104,7 @@
   description: Bugs affecting Core components
   parameters:
     jira_project_key: BZFFX
+    linked_project_excludes: []
     jira_components:
       use_bug_component_with_product_prefix: true
       use_bug_component: false

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -79,6 +79,9 @@ Parameters are used by `step` functions to control what Bugzilla data is synced 
 - `issue_type_map` (optional)
     - mapping [str, str]
     - If defined, map the Bugzilla type to Jira issue type (default: ``Bug`` if ``defect`` else ``Task``)
+- `linked_project_excludes` (optional)
+    - list[str]
+    - Project keys to exclude from Jira issue link syncing (default: `["BZFFX"]`).
 
 Minimal configuration:
 ```yaml

--- a/jbi/jira/service.py
+++ b/jbi/jira/service.py
@@ -529,7 +529,8 @@ class JiraService:
         """Find all Jira issue keys for a Bugzilla bug ID.
 
         Uses bug_data.extract_from_see_also(project_key=None) to get all issues,
-        supporting cross-project linking.
+        supporting cross-project linking. Excludes issues from projects in
+        context.action.parameters.linked_project_excludes.
 
         Args:
             context: The action context
@@ -548,6 +549,10 @@ class JiraService:
                 extra=context.model_dump(),
             )
             return []
+
+        excluded = context.action.parameters.linked_project_excludes
+        if excluded:
+            jira_keys = [k for k in jira_keys if k.split("-")[0] not in excluded]
 
         logger.info(
             "Found Jira issues %s for bug %s",

--- a/jbi/models.py
+++ b/jbi/models.py
@@ -131,6 +131,7 @@ class ActionParams(BaseModel, frozen=True):
         "15": 15,
     }
     issue_type_map: dict[str, str] = {"task": "Task", "defect": "Bug"}
+    linked_project_excludes: list[str] = ["BZFFX"]
 
 
 class Action(BaseModel, frozen=True):

--- a/tests/unit/jira/test_service.py
+++ b/tests/unit/jira/test_service.py
@@ -613,6 +613,48 @@ def test_lookup_jira_issues_for_bug_returns_empty_when_no_see_also(
     assert result == []
 
 
+def test_lookup_jira_issues_for_bug_excludes_configured_projects(
+    jira_service, action_context_factory, bug_factory
+):
+    """Test that lookup_jira_issues_for_bug filters out keys from excluded projects."""
+    context = action_context_factory(
+        jira__issue="JBI-123",
+        action__parameters__linked_project_excludes=["BZFFX"],
+    )
+    bug = bug_factory(
+        id=456,
+        see_also=[
+            "http://mozilla.jira.com/browse/JBI-789",
+            "http://mozilla.jira.com/browse/BZFFX-123",
+        ],
+    )
+
+    result = jira_service.lookup_jira_issues_for_bug(context, 456, bug)
+
+    assert result == ["JBI-789"]
+
+
+def test_lookup_jira_issues_for_bug_empty_excludes_returns_all(
+    jira_service, action_context_factory, bug_factory
+):
+    """Test that lookup_jira_issues_for_bug returns all keys when excludes is empty."""
+    context = action_context_factory(
+        jira__issue="JBI-123",
+        action__parameters__linked_project_excludes=[],
+    )
+    bug = bug_factory(
+        id=456,
+        see_also=[
+            "http://mozilla.jira.com/browse/JBI-789",
+            "http://mozilla.jira.com/browse/BZFFX-123",
+        ],
+    )
+
+    result = jira_service.lookup_jira_issues_for_bug(context, 456, bug)
+
+    assert result == ["JBI-789", "BZFFX-123"]
+
+
 def test_delete_issue_link_blocks_deletes_correct_link(
     jira_service, mocked_responses, settings, action_context_factory
 ):


### PR DESCRIPTION
Adds a `linked_project_excludes` parameter to `ActionParams` (defaulting to `["BZFFX"]`) that filters out issue keys from the specified projects when resolving linked bug Jira issues. This prevents link-syncing steps from creating noisy cross-project links to projects like BZFFX that create Jira issues without visible Bugzilla whiteboard tags or see_also links.

The BZFFX project configs are set to `linked_project_excludes: []` so they continue to link to their own tickets.

Closes #1347