### PR TITLE
fix: Fully sync fields when whiteboard tag is added to a bug with an existing Jira issue

### DIFF
--- a/docs/actions.md
+++ b/docs/actions.md
@@ -48,6 +48,7 @@ Parameters are used by `step` functions to control what Bugzilla data is synced 
     - mapping [str, list[str]]
     - If defined, the specified steps are executed. The group of steps listed under `new` are executed when a Bugzilla event occurs on a ticket that is unknown to Jira. The steps under `existing`, when the Bugzilla ticket is already linked to a Jira issue. The steps under `comment` when a comment is posted on a linked Bugzilla ticket.
     If one of these groups is not specified, the default steps will be used.
+    - **Note:** When the whiteboard tag is added to a bug that already has a linked Jira issue (for example, when a tag is removed and later re-added, or when a `see_also` link to an existing Jira issue is added at the same time as the tag), the `new` steps are run instead of the `existing` steps. This performs a full resync of all current bug fields to the Jira issue, rather than only reacting to the fields that changed in that single event.
 - `jira_components` (optional)
    - object
    - Controls how Jira components are set on issues in the `maybe_update_components` step.

--- a/jbi/runner.py
+++ b/jbi/runner.py
@@ -35,6 +35,25 @@ logger = logging.getLogger(__name__)
 settings = get_settings()
 
 
+def _tag_added_to_whiteboard(
+    action: Action, event: bugzilla_models.WebhookEvent
+) -> bool:
+    """Return True when the whiteboard change added this action's project tag."""
+    if not event.changes:
+        return False
+    for change in event.changes:
+        if change.field == "whiteboard":
+            search_string = r"\[" + action.whiteboard_tag + r"(-[^\]]*)*\]"
+            removed_had_tag = bool(
+                re.search(search_string, change.removed or "", re.IGNORECASE)
+            )
+            added_has_tag = bool(
+                re.search(search_string, change.added or "", re.IGNORECASE)
+            )
+            return not removed_had_tag and added_has_tag
+    return False
+
+
 GROUP_TO_OPERATION = {
     "new": Operation.CREATE,
     "existing": Operation.UPDATE,
@@ -326,13 +345,21 @@ def do_execute_actions(
                 )
 
             if event.target == "bug":
-                action_context = action_context.update(
-                    operation=Operation.UPDATE,
-                    extra={
-                        "changed_fields": ", ".join(event.changed_fields()),
-                        **action_context.extra,
-                    },
-                )
+                if _tag_added_to_whiteboard(action, event):
+                    # Tag was added to a bug that already has a linked Jira issue.
+                    # Use CREATE so that steps sync all current field values
+                    # unconditionally, rather than only reacting to the fields
+                    # that changed in this single event. create_issue detects
+                    # the existing issue and updates the summary instead.
+                    action_context = action_context.update(operation=Operation.CREATE)
+                else:
+                    action_context = action_context.update(
+                        operation=Operation.UPDATE,
+                        extra={
+                            "changed_fields": ", ".join(event.changed_fields()),
+                            **action_context.extra,
+                        },
+                    )
 
             elif event.target == "comment":
                 action_context = action_context.update(operation=Operation.COMMENT)

--- a/jbi/steps.py
+++ b/jbi/steps.py
@@ -78,6 +78,14 @@ def create_issue(
     bugzilla_service: BugzillaService,
 ) -> StepResult:
     """Create the Jira issue with the first comment as the description."""
+    if context.jira.issue is not None:
+        # Jira issue already exists (tag added to an already-linked bug). CREATE
+        # is used so steps sync all fields unconditionally; update the title here
+        # and let the remaining new steps handle all other fields.
+        jira_response = jira_service.update_issue_summary(context)
+        context = context.append_responses(jira_response)
+        return (StepStatus.SUCCESS, context)
+
     bug = context.bug
     issue_type = parameters.issue_type_map.get(bug.type or "", "Task")
     # In the payload of a bug creation, the `comment` field is `null`.

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -14,6 +14,7 @@ from jbi.models import ActionContext
 from jbi.runner import (
     Actions,
     Executor,
+    _tag_added_to_whiteboard,
     execute_action,
     execute_or_queue,
     lookup_actions,
@@ -794,3 +795,79 @@ def test_request_triggers_multiple_update_actions(
     assert len(actions) == len(details)
     assert "devtest" in details
     assert "other" in details
+
+
+# --- _tag_added_to_whiteboard tests ---
+
+
+@pytest.mark.parametrize(
+    "removed,added,expected",
+    [
+        # Tag absent in removed, present in added → newly added
+        ("", "[devtest]", True),
+        ("[other]", "[other][devtest]", True),
+        ("[other]", "[devtest][other]", True),
+        # Tag already present in removed → not newly added
+        ("[devtest]", "[devtest][other]", False),
+        ("[devtest-sprint1]", "[devtest]", False),
+    ],
+)
+def test_tag_added_to_whiteboard(
+    removed, added, expected, action_factory, webhook_event_change_factory
+):
+    action = action_factory(whiteboard_tag="devtest")
+    event = mock.MagicMock()
+    event.changes = [
+        webhook_event_change_factory(field="whiteboard", removed=removed, added=added)
+    ]
+    assert _tag_added_to_whiteboard(action, event) is expected
+
+
+def test_tag_added_to_whiteboard_no_whiteboard_change(action_factory, webhook_event_change_factory):
+    action = action_factory(whiteboard_tag="devtest")
+    event = mock.MagicMock()
+    event.changes = [
+        webhook_event_change_factory(field="summary", removed="old", added="new")
+    ]
+    assert _tag_added_to_whiteboard(action, event) is False
+
+
+def test_tag_added_to_whiteboard_no_changes(action_factory):
+    action = action_factory(whiteboard_tag="devtest")
+    event = mock.MagicMock()
+    event.changes = None
+    assert _tag_added_to_whiteboard(action, event) is False
+
+
+def test_tag_added_to_bug_with_linked_issue_triggers_resync(
+    actions,
+    webhook_request_factory,
+    webhook_event_change_factory,
+    mocked_bugzilla,
+    mocked_jira,
+    settings,
+):
+    """When a whiteboard tag is added to a bug that already has a linked Jira issue,
+    the runner should run CREATE steps (full field resync) rather than UPDATE steps."""
+    jira_url = f"{settings.jira_base_url}browse/JBI-234"
+    webhook = webhook_request_factory(
+        bug__whiteboard="[devtest]",
+        bug__see_also=[jira_url],
+        event__changes=[
+            webhook_event_change_factory(
+                field="whiteboard", removed="", added="[devtest]"
+            )
+        ],
+    )
+    mocked_bugzilla.get_bug.return_value = webhook.bug
+    mocked_jira.get_issue.return_value = {"fields": {"project": {"key": "JBI"}}}
+    mocked_jira.create_issue.return_value = {"key": "JBI-234"}
+
+    execute_action(request=webhook, actions=actions)
+
+    # create_issue must NOT have been called (issue already exists)
+    mocked_jira.create_issue.assert_not_called()
+    # update_issue_field IS called to sync the title (via update_issue_summary)
+    mocked_jira.update_issue_field.assert_any_call(
+        key="JBI-234", fields={"summary": mock.ANY}
+    )

--- a/tests/unit/test_steps.py
+++ b/tests/unit/test_steps.py
@@ -3369,3 +3369,33 @@ def test_sync_regressions_both_fields_changed(
 
     assert result == steps.StepStatus.SUCCESS
     assert mocked_jira.create_issue_link.call_count == 2
+
+
+def test_create_issue_skips_creation_when_issue_exists(
+    action_context_factory,
+    action_params_factory,
+    mocked_jira,
+    mocked_bugzilla,
+):
+    """When a tag is added to a bug that already has a linked Jira issue,
+    create_issue must update the existing issue's title rather than creating
+    a new one."""
+    context = action_context_factory(
+        operation=Operation.CREATE,
+        jira__issue="JBI-234",
+        current_step="create_issue",
+    )
+    params = action_params_factory(jira_project_key=context.jira.project)
+
+    result, _ = steps.create_issue(
+        context,
+        parameters=params,
+        jira_service=JiraService(mocked_jira),
+        bugzilla_service=BugzillaService(mocked_bugzilla),
+    )
+
+    assert result == steps.StepStatus.SUCCESS
+    mocked_jira.create_issue.assert_not_called()
+    mocked_jira.update_issue_field.assert_called_once_with(
+        key="JBI-234", fields={"summary": mock.ANY}
+    )


### PR DESCRIPTION
- When a whiteboard tag is added to a bug that already has a linked Jira issue in `see_also`, the runner previously ran `existing` (UPDATE) steps, which only react to the fields changed in that single webhook event — leaving all other fields stale.
- This covers two cases: a tag that was removed and later restored, and a tag added simultaneously with a `see_also` link to connect an existing bug to an existing Jira issue.
- Adds `_tag_added_to_whiteboard()` to detect when the whiteboard change transitions the project tag from absent to present, and sets `operation=CREATE` so all `new` steps run and sync all current bug field values unconditionally.
- Modifies `create_issue` to handle an already-linked issue: updates the summary and returns early rather than creating a duplicate. All other `new` steps then resync their respective fields via their normal CREATE-mode logic.