### PR TITLE
feat: Sync Bugzilla issue type changes to existing Jira issues

### DIFF
--- a/docs/actions.md
+++ b/docs/actions.md
@@ -160,6 +160,9 @@ linked Jira issue status to "Closed". If the bug changes to a status not listed 
 - `maybe_update_issue_status`
 - `maybe_update_issue_points`
    **Requirements**: ``customfield_10037`` field must be present on issue forms (or configure `jira_cf_fx_points_field`).
+- `maybe_update_issue_type`:
+  Updates the Jira issue type when the Bugzilla bug `type` field changes, using the `issue_type_map` parameter (the same mapping `create_issue` uses on creation). Unmapped types fall back to `Task`. Runs on UPDATE events only — the issue type is set at creation time by `create_issue`; add this step to the `existing` steps to keep the type in sync afterwards.
+  **Requirements**: The target Jira project must permit changing an issue's type (Jira may reject some transitions, e.g. to/from sub-tasks or across incompatible screen schemes).
 - `create_comment`
 - `sync_keywords_labels`
 - `sync_whiteboard_labels`:

--- a/jbi/steps.py
+++ b/jbi/steps.py
@@ -379,6 +379,27 @@ def maybe_update_issue_status(
     return (StepStatus.NOOP, context)
 
 
+def maybe_update_issue_type(
+    context: ActionContext, *, parameters: ActionParams, jira_service: JiraService
+) -> StepResult:
+    """Update the Jira issue type when the Bugzilla bug type changes."""
+    # The issue type is set at creation time by `create_issue`. This step only
+    # reacts to subsequent changes of the bug `type` field on existing issues.
+    if context.operation != Operation.UPDATE:
+        return (StepStatus.NOOP, context)
+    if "type" not in context.event.changed_fields():
+        return (StepStatus.NOOP, context)
+
+    # Fall back to "Task" for unmapped types, mirroring `create_issue`.
+    issue_type = parameters.issue_type_map.get(context.bug.type or "", "Task")
+
+    resp = jira_service.update_issue_field(
+        context, "issuetype", issue_type, wrap_value="name"
+    )
+    context.append_responses(resp)
+    return (StepStatus.SUCCESS, context)
+
+
 def maybe_update_components(
     context: ActionContext, *, parameters: ActionParams, jira_service: JiraService
 ) -> StepResult:

--- a/tests/unit/test_steps.py
+++ b/tests/unit/test_steps.py
@@ -918,6 +918,128 @@ def test_update_issue_unknown_priority(
     assert capturelogs.messages == ["Bug priority 'P1' was not in the priority map."]
 
 
+def test_update_issue_type(
+    action_context_factory,
+    mocked_jira,
+    action_params_factory,
+    webhook_event_change_factory,
+):
+    action_context = action_context_factory(
+        operation=Operation.UPDATE,
+        current_step="maybe_update_issue_type",
+        jira__issue="JBI-234",
+        bug__type="enhancement",
+        event__action="modify",
+        event__changes=[
+            webhook_event_change_factory(
+                field="type", removed="defect", added="enhancement"
+            )
+        ],
+    )
+
+    params = action_params_factory(
+        jira_project_key=action_context.jira.project,
+        issue_type_map={"defect": "Bug", "enhancement": "Improvement"},
+    )
+
+    result, _ = steps.maybe_update_issue_type(
+        action_context, parameters=params, jira_service=JiraService(mocked_jira)
+    )
+
+    assert result == steps.StepStatus.SUCCESS
+    mocked_jira.update_issue_field.assert_called_with(
+        key="JBI-234", fields={"issuetype": {"name": "Improvement"}}
+    )
+
+
+def test_update_issue_type_unmapped_falls_back_to_task(
+    action_context_factory,
+    mocked_jira,
+    action_params_factory,
+    webhook_event_change_factory,
+):
+    action_context = action_context_factory(
+        operation=Operation.UPDATE,
+        current_step="maybe_update_issue_type",
+        jira__issue="JBI-234",
+        bug__type="enhancement",
+        event__action="modify",
+        event__changes=[
+            webhook_event_change_factory(
+                field="type", removed="defect", added="enhancement"
+            )
+        ],
+    )
+
+    params = action_params_factory(
+        jira_project_key=action_context.jira.project,
+        issue_type_map={"defect": "Bug"},
+    )
+
+    result, _ = steps.maybe_update_issue_type(
+        action_context, parameters=params, jira_service=JiraService(mocked_jira)
+    )
+
+    assert result == steps.StepStatus.SUCCESS
+    mocked_jira.update_issue_field.assert_called_with(
+        key="JBI-234", fields={"issuetype": {"name": "Task"}}
+    )
+
+
+def test_update_issue_type_noop_when_type_unchanged(
+    action_context_factory,
+    mocked_jira,
+    action_params_factory,
+    webhook_event_change_factory,
+):
+    action_context = action_context_factory(
+        operation=Operation.UPDATE,
+        current_step="maybe_update_issue_type",
+        jira__issue="JBI-234",
+        bug__type="enhancement",
+        event__action="modify",
+        event__changes=[
+            webhook_event_change_factory(field="summary", removed="", added="new")
+        ],
+    )
+
+    params = action_params_factory(
+        jira_project_key=action_context.jira.project,
+        issue_type_map={"defect": "Bug", "enhancement": "Improvement"},
+    )
+
+    result, _ = steps.maybe_update_issue_type(
+        action_context, parameters=params, jira_service=JiraService(mocked_jira)
+    )
+
+    assert result == steps.StepStatus.NOOP
+    mocked_jira.update_issue_field.assert_not_called()
+
+
+def test_update_issue_type_noop_on_create(
+    action_context_factory,
+    mocked_jira,
+    action_params_factory,
+):
+    action_context = action_context_factory(
+        operation=Operation.CREATE,
+        current_step="maybe_update_issue_type",
+        bug__type="enhancement",
+    )
+
+    params = action_params_factory(
+        jira_project_key=action_context.jira.project,
+        issue_type_map={"defect": "Bug", "enhancement": "Improvement"},
+    )
+
+    result, _ = steps.maybe_update_issue_type(
+        action_context, parameters=params, jira_service=JiraService(mocked_jira)
+    )
+
+    assert result == steps.StepStatus.NOOP
+    mocked_jira.update_issue_field.assert_not_called()
+
+
 def test_update_issue_severity(
     action_context_factory,
     mocked_jira,


### PR DESCRIPTION
`issue_type_map` was only consulted when **creating** a Jira issue (the `create_issue` step). Once an issue existed, a later change to the Bugzilla bug's `type` field never propagated to the linked Jira issue.

This adds a new **opt-in** step, `maybe_update_issue_type`, that on `UPDATE` events — when the `type` field actually changed — maps `bug.type` through `issue_type_map` (falling back to `"Task"`, mirroring `create_issue`) and updates the Jira issue type via the existing `update_issue_field` helper.

The step is NOOP on create (creation still owns the initial type) and NOOP when `type` didn't change. It is **not** wired into the defaults or any action config — teams opt in by adding it to their `existing` steps.