### PR TITLE
fix: Pass global_id to make Bugzilla remote link idempotent

### DIFF
--- a/jbi/jira/service.py
+++ b/jbi/jira/service.py
@@ -232,6 +232,7 @@ class JiraService:
         icon_url = f"{settings.bugzilla_base_url}/favicon.ico"
         return self.client.create_or_update_issue_remote_links(
             issue_key=issue_key,
+            global_id=str(bug.id),
             link_url=bugzilla_url,
             title=bugzilla_url,
             icon_url=icon_url,

--- a/tests/unit/test_steps.py
+++ b/tests/unit/test_steps.py
@@ -283,6 +283,31 @@ def test_added_phabricator_attachment(
     )
 
 
+def test_add_link_to_bugzilla_is_idempotent(
+    action_context_factory, mocked_jira, action_params_factory, settings
+):
+    context = action_context_factory(
+        operation=Operation.CREATE,
+        jira__issue="JBI-234",
+        bug__id=654321,
+        current_step="add_link_to_bugzilla",
+    )
+
+    result, _ = steps.add_link_to_bugzilla(
+        context, jira_service=JiraService(mocked_jira)
+    )
+
+    assert result == steps.StepStatus.SUCCESS
+    mocked_jira.create_or_update_issue_remote_links.assert_called_once_with(
+        issue_key="JBI-234",
+        global_id="654321",
+        link_url=f"{settings.bugzilla_base_url}/show_bug.cgi?id=654321",
+        title=f"{settings.bugzilla_base_url}/show_bug.cgi?id=654321",
+        icon_url=f"{settings.bugzilla_base_url}/favicon.ico",
+        icon_title=f"{settings.bugzilla_base_url}/favicon.ico",
+    )
+
+
 def test_empty_comment_not_added(
     action_context_factory, mocked_jira, action_params_factory
 ):


### PR DESCRIPTION
- `add_link_to_bugzilla` called `create_or_update_issue_remote_links` without a `global_id`, causing each invocation to create a new remote link on the Jira issue rather than upserting the existing one.
- Pass `global_id=str(bug.id)` so the Jira API treats repeated calls (e.g. during a full field resync triggered by a whiteboard tag add) as updates to the same link.

**Note on existing data:** Links created before this fix have no `global_id`. The first call after this fix will create a second link for those issues; subsequent calls will then be idempotent. This one-time duplication was deemed acceptable.