### PR TITLE
Sync issue type changes to existing issues for performance projects

### DIFF
--- a/config/config.prod.yaml
+++ b/config/config.prod.yaml
@@ -185,6 +185,7 @@
         - update_issue_summary
         - maybe_update_components
         - maybe_assign_jira_user
+        - maybe_update_issue_type
         - maybe_update_issue_status
         - maybe_update_issue_resolution
         - maybe_update_issue_priority
@@ -251,6 +252,7 @@
         - update_issue_summary
         - maybe_update_components
         - maybe_assign_jira_user
+        - maybe_update_issue_type
         - maybe_update_issue_status
         - maybe_update_issue_resolution
         - maybe_update_issue_priority
@@ -303,6 +305,7 @@
         - update_issue_summary
         - maybe_update_components
         - maybe_assign_jira_user
+        - maybe_update_issue_type
         - maybe_update_issue_status
         - maybe_update_issue_resolution
         - maybe_update_issue_priority
@@ -554,6 +557,7 @@
       existing:
         - update_issue_summary
         - maybe_assign_jira_user
+        - maybe_update_issue_type
         - maybe_update_issue_status
         - maybe_update_issue_resolution
         - maybe_update_issue_priority


### PR DESCRIPTION
Add `maybe_update_issue_type` to the existing steps for FXP, FXPE, FP, and PCF so that Bugzilla bug type changes are reflected on the linked Jira issue, using the `issue_type_map` already configured for these projects.