### PR TITLE
Send a custom User-Agent on Bugzilla and Jira requests

### DIFF
--- a/jbi/bugzilla/client.py
+++ b/jbi/bugzilla/client.py
@@ -4,6 +4,7 @@ import requests
 
 from jbi import environment
 from jbi.common.instrument import instrument
+from jbi.common.net import USER_AGENT
 
 from .models import (
     ApiResponse,
@@ -43,6 +44,7 @@ class BugzillaClient:
         self.base_url = base_url
         self.api_key = api_key
         self._client = requests.Session()
+        self._client.headers["User-Agent"] = USER_AGENT
 
     def _call(self, verb, url, *args, **kwargs):
         """Send HTTP requests with API key in querystring parameters."""

--- a/jbi/common/net.py
+++ b/jbi/common/net.py
@@ -1,0 +1,4 @@
+"""Helpers for outgoing HTTP requests to Bugzilla and Jira."""
+
+# Lets Bugzilla/Jira operators identify JBI's traffic in their logs.
+USER_AGENT = "jira-bmo-integration/1.0 (+https://github.com/mozilla/jira-bugzilla-integration)"

--- a/jbi/jira/service.py
+++ b/jbi/jira/service.py
@@ -16,6 +16,7 @@ from requests import exceptions as requests_exceptions
 
 from jbi import Operation, environment
 from jbi.bugzilla import models as bugzilla_models
+from jbi.common.net import USER_AGENT
 from jbi.jira.utils import markdown_to_jira
 from jbi.models import ActionContext
 
@@ -870,11 +871,14 @@ class JiraService:
 @lru_cache(maxsize=1)
 def get_service():
     """Get atlassian Jira Service"""
+    session = requests.Session()
+    session.headers["User-Agent"] = USER_AGENT
     client = JiraClient(
         url=settings.jira_base_url,
         username=settings.jira_username,
         password=settings.jira_api_key,  # package calls this param 'password' but actually expects an api key
         cloud=True,  # we run against an instance of Jira cloud
+        session=session,
     )
 
     return JiraService(client=client)


### PR DESCRIPTION
## Summary
- Sends a custom `User-Agent: jira-bmo-integration/1.0 (+https://github.com/mozilla/jira-bugzilla-integration)` header on every outgoing Bugzilla and Jira API request.
- Lets Bugzilla/Jira operators identify JBI's traffic in their access logs (came up as an alternative to allowlisting JBI's egress IP range, which is shared with other services and not stable).

## Changes
- Added `jbi/common/net.py` with a `USER_AGENT` constant.
- `BugzillaClient.__init__` now sets it on its `requests.Session`.
- `jira.service.get_service()` now builds its `JiraClient` with a pre-configured `requests.Session` carrying the header (the underlying `atlassian-python-api` client only adds auth headers on top of a passed-in session, so the custom UA survives).

## Test plan
- [x] `uv run pytest tests/unit/bugzilla/test_client.py tests/unit/jira/test_client.py tests/unit/jira/test_service.py` — all passing
- [x] Manually verified both `BugzillaClient` and `jira.service.get_service()` set the header as expected
- [x] `ruff check`/`mypy` pass on the changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)