### PR TITLE
Enable component creation for FXDROID

### DIFF
--- a/config/config.prod.yaml
+++ b/config/config.prod.yaml
@@ -118,6 +118,7 @@
     jira_components:
       use_bug_component_with_product_prefix: true
       use_bug_component: false
+      create_components: true
     jira_project_key: FXDROID
     steps:
       new:


### PR DESCRIPTION
When we renamed the "Android" product on Bugzilla from `Fenix` to `Firefox for Android`, we accidentally broke the components JBI sync because the `Firefox for Andorid::xxxxx` components do not exist, and we did not enable component creation.

