### PR TITLE
feat: Enable comprehensive sync for CRINGE crash ingestion project

### DIFF
--- a/config/config.prod.yaml
+++ b/config/config.prod.yaml
@@ -1054,17 +1054,53 @@
   description: Crash Ingestion
   parameters:
     jira_project_key: CRINGE
+    jira_components:
+      use_bug_component: false
+      use_bug_component_with_product_prefix: true
+      create_components: false
     steps:
       new:
         - create_issue
         - maybe_delete_duplicate
-        - maybe_update_components
         - add_link_to_bugzilla
         - add_link_to_jira
+        - maybe_assign_jira_user
+        - maybe_update_components
+        - maybe_update_issue_status
+        - maybe_update_issue_resolution
+        - maybe_update_issue_priority
+        - maybe_update_issue_severity
+        - maybe_add_phabricator_link
+        - sync_whiteboard_labels
+        - sync_keywords_labels
+        - sync_dependencies
+        - sync_see_also
+        - sync_regressions
       existing:
         - update_issue_summary
+        - maybe_update_components
+        - maybe_assign_jira_user
+        - maybe_update_issue_type
+        - maybe_update_issue_status
+        - maybe_update_issue_resolution
+        - maybe_update_issue_priority
+        - maybe_update_issue_severity
+        - maybe_add_phabricator_link
+        - sync_whiteboard_labels
+        - sync_keywords_labels
+        - sync_dependencies
+        - sync_see_also
+        - sync_duplicates
+        - sync_regressions
+        - add_jira_comments_for_changes
       comment:
         - create_comment
+    issue_type_map:
+      task: Story
+      defect: Bug
+      enhancement: Story
+    status_map: *basic-status-map
+    resolution_map: *basic-resolution-map
     labels_brackets: both
 
 - whiteboard_tag: bz-ffx-firefox


### PR DESCRIPTION
Add full import and sync capabilities to the cringe whiteboard tag:
- Component management with Product::Component format
- Issue type mapping (defect→Bug, task→Story, enhancement→Story)
- Status and resolution syncing using standard Mozilla mappings
- Field syncing: assignment, priority, severity
- Label syncing: whiteboard tags and keywords
- Relationship syncing: duplicates, dependencies, regressions, see_also
- Phabricator link integration
- Change tracking with Jira comments