### PR TITLE
fix: Correct HNT status_map to use Jira's actual "Live" status instead of "DONE"

### DIFF
--- a/config/config.prod.yaml
+++ b/config/config.prod.yaml
@@ -479,9 +479,9 @@
       NEW: Backlog
       ASSIGNED: In Progress
       REOPENED: In Progress
-      RESOLVED: DONE
-      VERIFIED: DONE
-      FIXED: DONE
+      RESOLVED: Live
+      VERIFIED: Live
+      FIXED: Live
       INVALID: Cancelled
       WONTFIX: Cancelled
       INACTIVE: Cancelled


### PR DESCRIPTION
fix: Correct HNT status_map to use Jira's actual "Live" status instead of "DONE"

HNT's Jira workflow has no status named "Done"/"DONE" — its terminal
state is called "Live". Since PR #1387, RESOLVED/VERIFIED/FIXED bugs
mapped to "DONE", which matched no transition and caused
maybe_update_issue_status to fail with "HTTP 400: 'transition'
identifier must be an integer", dead-lettering every affected bug.
