### PR TITLE
fix: Add explicit timeouts to outbound Bugzilla and Jira HTTP calls

### DIFF
--- a/jbi/bugzilla/client.py
+++ b/jbi/bugzilla/client.py
@@ -50,6 +50,10 @@ class BugzillaClient:
         # https://bmo.readthedocs.io/en/latest/api/core/v1/general.html?highlight=x-bugzilla-api-key#authentication
         headers = kwargs.setdefault("headers", {})
         headers.setdefault("x-bugzilla-api-key", self.api_key)
+        # Without a timeout, a hanging Bugzilla response blocks the request
+        # handler indefinitely, which can wedge the whole webhook delivery
+        # queue (Bugzilla retries the same event until it times out itself).
+        kwargs.setdefault("timeout", 30)
         try:
             resp = self._client.request(verb, url, *args, **kwargs)
             resp.raise_for_status()

--- a/jbi/jira/service.py
+++ b/jbi/jira/service.py
@@ -879,6 +879,10 @@ def get_service():
         username=settings.jira_username,
         password=settings.jira_api_key,  # package calls this param 'password' but actually expects an api key
         cloud=True,  # we run against an instance of Jira cloud
+        # Default is 75s, which is longer than Kubernetes' probe tolerance;
+        # a hanging call can still starve request workers and fail liveness
+        # checks well before that.
+        timeout=30,
     )
 
     return JiraService(client=client)


### PR DESCRIPTION
A hanging Bugzilla response could block a request handler indefinitely since BugzillaClient used a bare requests.Session() with no timeout, letting one slow/unresponsive call wedge the whole webhook delivery queue. The Jira client's underlying library default (75s) is also longer than Kubernetes' probe tolerance, so a slow call there could still starve workers and trip liveness-probe failures. Both are now bounded at 30s.