### PR TITLE
fix: Run webhook processing in a threadpool to keep the event loop free

### DIFF
--- a/jbi/runner.py
+++ b/jbi/runner.py
@@ -9,6 +9,7 @@ import re
 from typing import Optional, cast
 
 from dockerflow.logging import request_id_context
+from starlette.concurrency import run_in_threadpool
 from statsd.defaults.env import statsd
 
 from jbi import ActionResult, Operation, jira
@@ -202,7 +203,13 @@ async def execute_or_queue(
         return {"status": "skipped"}
 
     try:
-        return execute_action(request, actions)
+        # `execute_action` performs blocking I/O (Bugzilla/Jira HTTP calls,
+        # pandoc subprocess calls). This process runs a single asyncio event
+        # loop with no other workers, so calling it directly here would
+        # freeze the whole pod - including its own /__lbheartbeat__ health
+        # check - for the duration of a slow event, tripping the liveness
+        # probe. Run it on a thread instead so the event loop stays free.
+        return await run_in_threadpool(execute_action, request, actions)
     except IgnoreInvalidRequestError as exc:
         return {"status": "invalid", "error": str(exc)}
     except Exception as exc:


### PR DESCRIPTION
## Problem

The app runs a single uvicorn process ([asgi.py](../blob/main/asgi.py)) with one asyncio event loop, and `execute_action()` performs blocking I/O — synchronous Bugzilla/Jira HTTP calls via `requests`, and pandoc subprocess calls. The async `/bugzilla_webhook` handler called it directly, so a slow (not even hung) event froze the entire pod for its duration:

- `/__lbheartbeat__` could not respond → liveness probe failures (`context deadline exceeded`) → **109+ container restarts over 24h** in prod (confirmed via pod events).
- Concurrent BMO deliveries sat unanswered until Bugzilla's client timed out — the likely mechanism behind the 2026-09-03/04 incident where a stuck `bug.modify:depends_on` event head-of-line-blocked the entire `JBI-PROD-Any-Any` queue (3900+ events) for all projects.
- The 30s outbound timeouts added in #1391 bound the worst case but can't prevent a legitimately-slow 20-25s event from tripping the probe (5 failures × 6s period ≈ 30s tolerance).

## Fix

Run `execute_action` via `starlette.concurrency.run_in_threadpool` so the event loop stays free to answer health checks and accept concurrent deliveries while a webhook is processed on a worker thread.

## Behavioral note for reviewers

This introduces intra-pod concurrency where processing was previously serialized per pod. The `@lru_cache`d Bugzilla/Jira clients share `requests.Session` objects across threads — a standard pattern (urllib3 pools are thread-safe; auth is header-based, not cookie-based). Same-bug concurrency across the two BMO subscriptions and across the 2 pods was already possible before this change, so no new class of race is introduced. Contextvar propagation (dockerflow `request_id_context`) into the worker thread was verified with the pinned anyio/starlette versions.

A companion `webservices-infra` change bumping the container memory limit (128Mi → 256Mi) is recommended, since concurrent processing (incl. pandoc subprocesses, which count against the same cgroup) raises peak memory.

## Test plan
- [x] `uv run pytest tests/unit/test_runner.py tests/unit/test_router.py` — no new failures (7 pre-existing Windows-environment failures identical with and without this change)
- [x] Verified contextvars propagate through `run_in_threadpool` with anyio 4.11 / starlette 0.49
- [ ] After deploy: watch pod restart count (ArgoCD events) and `/__lbheartbeat__` 502 rate in nginx access logs — both should drop to ~zero