### PR TITLE
fix: Tighten outbound HTTP timeouts to 10s so slow events fail fast

### DIFF
--- a/jbi/bugzilla/client.py
+++ b/jbi/bugzilla/client.py
@@ -50,10 +50,13 @@ class BugzillaClient:
         # https://bmo.readthedocs.io/en/latest/api/core/v1/general.html?highlight=x-bugzilla-api-key#authentication
         headers = kwargs.setdefault("headers", {})
         headers.setdefault("x-bugzilla-api-key", self.api_key)
-        # Without a timeout, a hanging Bugzilla response blocks the request
-        # handler indefinitely, which can wedge the whole webhook delivery
-        # queue (Bugzilla retries the same event until it times out itself).
-        kwargs.setdefault("timeout", 30)
+        # Keep this well under the load balancer's ~30s request budget: a
+        # slow upstream call must fail fast enough for the webhook handler
+        # to still return a response (the failed event is parked in the
+        # dead letter queue and retried later). If the handler exceeds the
+        # budget instead, Bugzilla records a delivery failure and its
+        # whole in-order queue stalls behind the event.
+        kwargs.setdefault("timeout", 10)
         try:
             resp = self._client.request(verb, url, *args, **kwargs)
             resp.raise_for_status()

--- a/jbi/jira/service.py
+++ b/jbi/jira/service.py
@@ -879,10 +879,12 @@ def get_service():
         username=settings.jira_username,
         password=settings.jira_api_key,  # package calls this param 'password' but actually expects an api key
         cloud=True,  # we run against an instance of Jira cloud
-        # Default is 75s, which is longer than Kubernetes' probe tolerance;
-        # a hanging call can still starve request workers and fail liveness
-        # checks well before that.
-        timeout=30,
+        # Keep this well under the load balancer's ~30s request budget (the
+        # library default is 75s): a slow Jira call must fail fast enough
+        # for the webhook handler to still return a response, so the event
+        # is parked in the dead letter queue and retried later instead of
+        # stalling Bugzilla's in-order delivery queue.
+        timeout=10,
     )
 
     return JiraService(client=client)


### PR DESCRIPTION
## Problem

The 30s outbound timeout added in #1391 is equal to the GCLB backend's ~30s request budget. A single slow Bugzilla/Jira call therefore guarantees the webhook handler cannot respond in time: GCLB returns 502 to Bugzilla, BMO records a delivery failure, and its strict in-order queue stalls behind that one event, retrying every ~15 minutes. Observed in prod on 2026-09-04: a cluster of heavy events from a 19:55-20:00 bulk operation burned one full delivery cycle each while 4,700+ events piled up behind them.

## Why failing fast fixes it

JBI's dead-letter-queue design (`jbi/queue.py`) already handles processing failures gracefully: the exception is caught, the event is parked in the DLQ, the handler returns 200, and the hourly `jbi-retry` job retries it later. The *only* thing that wedges BMO's delivery queue is JBI failing to respond within the budget. With a 10s outbound cap, a slow upstream call fails fast enough for the handler to still answer in time — BMO keeps draining, and the slow event retries out-of-band.

## Changes
- `jbi/bugzilla/client.py`: outbound timeout 30s → 10s
- `jbi/jira/service.py`: Jira client timeout 30s → 10s

## Test plan
- [x] `uv run pytest tests/unit/jira tests/unit/bugzilla tests/unit/test_runner.py` — no new failures (2 pre-existing local-env failures identical with and without this change)
- [ ] After deploy: BMO webhook queue delivery cycles should stop dying on slow events; any genuinely slow events should appear in `/dl_queue/` and clear via the retry job